### PR TITLE
Made ExceptionTemplate use a partial class so exceptions can be extended

### DIFF
--- a/src/vanilla/Templates/Rest/Common/ExceptionTemplate.cshtml
+++ b/src/vanilla/Templates/Rest/Common/ExceptionTemplate.cshtml
@@ -8,7 +8,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
     /// <summary>
     @WrapComment("/// ", "Exception thrown for an invalid response with " + Model.Name + " information.")
     /// </summary>
-    public class @Model.ExceptionTypeDefinitionName : Microsoft.Rest.RestException
+    public partial class @Model.ExceptionTypeDefinitionName : Microsoft.Rest.RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.


### PR DESCRIPTION
The model classes inside of a generated exception are already partial which is helpful for extending the error model, but the exception itself isn't partial. I've update ExceptionTemplate.cshtml to be a partial class so that exceptions can be extended.

For example, in my use case, I'd like to extend the exception's ToString() to print out a user friendly version of the error.

I tried looking through the tests to see how I could write a test for this, but couldn't find an existing analogous test. If a test is required for this change, can someone point me in the direction of how such a test would be written? For example, do we want an example that adds a partial exception and want to confirm that it compiles as expected, or is there some test that can check whether the class definition itself is marked as partial.