### PR TITLE
Chsuich/partial exceptions

### DIFF
--- a/src/vanilla/Templates/Rest/Common/ExceptionTemplate.cshtml
+++ b/src/vanilla/Templates/Rest/Common/ExceptionTemplate.cshtml
@@ -8,7 +8,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
     /// <summary>
     @WrapComment("/// ", "Exception thrown for an invalid response with " + Model.Name + " information.")
     /// </summary>
-    public class @Model.ExceptionTypeDefinitionName : Microsoft.Rest.RestException
+    public partial class @Model.ExceptionTypeDefinitionName : Microsoft.Rest.RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDuration/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDuration/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDurationAllSync.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDurationNoSync.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureCompositeModelClient.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureParameterGrouping/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureReport/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureReport/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureResource/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureResource/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/AzureSpecials/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/AzureSpecials/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/CustomBaseUri/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/CustomBaseUri/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/ErrorException.cs
+++ b/test/azure/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureBodyDuration/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureBodyDuration/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureBodyDuration.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureBodyDurationAllSync.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureBodyDurationNoSync.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureCompositeModelClient.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureParameterGrouping/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureParameterGrouping/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureParameterGrouping.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureReport/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureReport/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureReport.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureResource/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureResource/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureResource.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/AzureSpecials/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/AzureSpecials/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsAzureSpecials.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/CustomBaseUri/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/CustomBaseUri/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsCustomBaseUri.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/azurefluent/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/ErrorException.cs
+++ b/test/azurefluent/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.Azure.Fluent.AcceptanceTestsSubscriptionIdApiVersion.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/AcceptanceTests.cs
+++ b/test/vanilla/AcceptanceTests.cs
@@ -2291,6 +2291,14 @@ namespace AutoRest.CSharp.Tests
             Assert.Null(petstoreWithEssentialSyncMethods.GetMethod("AddPetWithHttpMessages"));
         }
 
+        [Fact]
+        // Really, this test is more useful at compile time since this field is introduced by a partial and compilation
+        // will fail if the partials can't be merged.
+        public void SupportsPartialExceptionTest()
+        {
+            Assert.NotNull(ErrorException.StringFromPartial);
+        }
+
         public void EnsureTestCoverage()
         {
             using (var client =

--- a/test/vanilla/Expected/AcceptanceTests/BodyArray/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyArray/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyArray.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyBoolean/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyBoolean/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyBoolean.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyByte/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyByte/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyByte.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyComplex/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyComplex/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyDate/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDate/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyDate.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTime/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTime/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyDateTime.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDateTimeRfc1123/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyDictionary/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDictionary/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyDictionary.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyDuration/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyDuration/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyDuration.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyFile/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFile/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyFile.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyFormData/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyFormData/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyFormData.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyInteger/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyInteger/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyInteger.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyNumber/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyNumber/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyNumber.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/BodyString/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/BodyString/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsBodyString.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/CompositeBoolIntClient/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/CompositeBoolIntClient/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUri/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsCustomBaseUri.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/CustomBaseUriMoreOptions/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsCustomBaseUriMoreOptions.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/Header/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Header/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/Http/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Http/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/Http/Models/MyException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Http/Models/MyException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// <summary>
     /// Exception thrown for an invalid response with A information.
     /// </summary>
-    public class MyException : RestException
+    public partial class MyException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/ModelFlattening/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/ModelFlattening/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/Report/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Report/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsReport.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/RequiredOptional/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/RequiredOptional/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/Url/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Url/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsUrl.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/UrlMultiCollectionFormat/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsUrlMultiCollectionFormat.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/AcceptanceTests/Validation/Models/ErrorException.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.AcceptanceTestsValidation.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/DateTimeOffset/Models/ErrorException.cs
+++ b/test/vanilla/Expected/DateTimeOffset/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.DateTimeOffset.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/Mirror.Polymorphic/Models/Error2Exception.cs
+++ b/test/vanilla/Expected/Mirror.Polymorphic/Models/Error2Exception.cs
@@ -15,7 +15,7 @@ namespace Fixtures.MirrorPolymorphic.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error2 information.
     /// </summary>
-    public class Error2Exception : RestException
+    public partial class Error2Exception : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/Mirror.Primitives/Models/ErrorException.cs
+++ b/test/vanilla/Expected/Mirror.Primitives/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.MirrorPrimitives.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/Mirror.RecursiveTypes/Models/ErrorException.cs
+++ b/test/vanilla/Expected/Mirror.RecursiveTypes/Models/ErrorException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.MirrorRecursiveTypes.Models
     /// <summary>
     /// Exception thrown for an invalid response with Error information.
     /// </summary>
-    public class ErrorException : RestException
+    public partial class ErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/Expected/Mirror.Sequences/Models/ErrorModelException.cs
+++ b/test/vanilla/Expected/Mirror.Sequences/Models/ErrorModelException.cs
@@ -15,7 +15,7 @@ namespace Fixtures.MirrorSequences.Models
     /// <summary>
     /// Exception thrown for an invalid response with ErrorModel information.
     /// </summary>
-    public class ErrorModelException : RestException
+    public partial class ErrorModelException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.

--- a/test/vanilla/ExpectedCustomized/AcceptanceTests/Http/Models/ErrorException.cs
+++ b/test/vanilla/ExpectedCustomized/AcceptanceTests/Http/Models/ErrorException.cs
@@ -1,0 +1,12 @@
+namespace Fixtures.AcceptanceTestsHttp.Models
+{
+    using Microsoft.Rest;
+
+    /// <summary>
+    /// Exception thrown for an invalid response with Error information.
+    /// </summary>
+    public partial class ErrorException : RestException
+    {
+        public const string StringFromPartial = "StringFromPartial";
+    }
+}


### PR DESCRIPTION
The model classes inside of a generated exception are already partial which is helpful for extending the error model, but the exception itself isn't partial. I've update ExceptionTemplate.cshtml to be a partial class so that exceptions can be extended.

For example, in my use case, I'd like to extend the exception's ToString() to print out a user friendly version of the error.

So, I have:
- Update the template to be partial
- Regenerated the tests so that all the generated exceptions are now partial
- Added a partial implementation of the test/vanilla/AcceptanceTests/Http/Models/ErrorException.cs which simply adds a const string
- Added a test to AcceptanceTests.cs which references the const string so that compilation of the acceptance test will fail if the partials can't be compiled