### PR TITLE
fix weird overwrite of partially constant properties

### DIFF
--- a/src/vanilla/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/vanilla/Templates/Rest/Common/ModelTemplate.cshtml
@@ -69,14 +69,6 @@ if (!string.IsNullOrEmpty(Model.BaseConstructorCall))
 }
         @:{
 
-foreach (var property in Model.ComposedProperties.Where(p => p.ModelType is CompositeType ct
-    && !p.IsConstant
-    && p.IsRequired
-    && ct.ContainsConstantProperties))
-{
-            @:this.@(property.Name) = new @(property.ModelTypeName)();
-}
-
 foreach (var property in Model.InstanceProperties)
 {
             @:this.@(property.Name) = @(CodeNamer.Instance.CamelCase(property.Name));

--- a/test/vanilla/Expected/AcceptanceTests/Validation/Models/Product.cs
+++ b/test/vanilla/Expected/AcceptanceTests/Validation/Models/Product.cs
@@ -42,7 +42,6 @@ namespace Fixtures.AcceptanceTestsValidation.Models
         /// values include: 'constant_string_as_enum'</param>
         public Product(ChildProduct child, IList<string> displayNames = default(IList<string>), int? capacity = default(int?), string image = default(string), EnumConst? constStringAsEnum = default(EnumConst?))
         {
-            Child = new ChildProduct();
             DisplayNames = displayNames;
             Capacity = capacity;
             Image = image;


### PR DESCRIPTION
The removed part is pretty much guaranteed to not make sense: It emits initialization for properties that are `IsRequired` (ignore all other filters). But required stuff is also provided via constructor (as required arg), so why do anything else than take what was passed to the constructor?