### PR TITLE
remove last dependency to ReEnumerable

### DIFF
--- a/src/azure/Model/CodeModelCsa.cs
+++ b/src/azure/Model/CodeModelCsa.cs
@@ -51,7 +51,7 @@ namespace AutoRest.CSharp.Azure.Model
                     return serviceNameSetting;
                 }
 
-                var method = Methods[0];
+                var method = Methods.First();
                 var match = Regex.Match(input: method.Url, pattern: @"/providers/microsoft\.(\w+)/", options: RegexOptions.IgnoreCase);
                 var serviceName = match.Groups[1].Value.ToPascalCase();
                 return serviceName;

--- a/src/azure/TransformerCsa.cs
+++ b/src/azure/TransformerCsa.cs
@@ -97,7 +97,6 @@ namespace AutoRest.CSharp.Azure
                     {
                         SerializedName = "$filter",
                         Name = "odataQuery",
-                        // ModelType = New<CompositeType>(new { Name = new Fixable<string>(){FixedValue = $"Microsoft.Rest.Azure.OData.ODataQuery<{odataFilter.ModelType.Name}>"} } ),
                         ModelType = New<ILiteralType>($"Microsoft.Rest.Azure.OData.ODataQuery<{odataFilter.ModelType.Name}>"),
                         Documentation = "OData parameters to apply to the operation.",
                         Location = ParameterLocation.Query,

--- a/src/vanilla/Model/CompositeTypeCs.cs
+++ b/src/vanilla/Model/CompositeTypeCs.cs
@@ -85,7 +85,7 @@ namespace AutoRest.CSharp.Model
             get
             {
                 var baseProperties =((BaseModelType as CompositeTypeCs)?.AllPropertyTemplateModels ??
-                    Enumerable.Empty<InheritedPropertyInfo>()).ReEnumerable();
+                    Enumerable.Empty<InheritedPropertyInfo>()).ToList();
 
                 int depth = baseProperties.Any() ? baseProperties.Max(p => p.Depth) : 0;
                 return baseProperties.Concat(Properties.Select(p => new InheritedPropertyInfo(p, depth)));

--- a/test/azure/CSharpAzureCodeNamingFrameworkTests.cs
+++ b/test/azure/CSharpAzureCodeNamingFrameworkTests.cs
@@ -29,23 +29,24 @@ namespace AutoRest.CSharp.Azure.Tests
                     codeModel = plugin.Serializer.Load(codeModel);
                     codeModel = plugin.Transformer.TransformCodeModel(codeModel);
 
-                    Assert.Equal(7, codeModel.Methods.Count);
-                    Assert.Equal(1, codeModel.Methods.Count(m => m.Name == "GetSinglePage"));
-                    Assert.Equal(0, codeModel.Methods.Count(m => m.Name == "GetSinglePageNext"));
-                    Assert.Equal(1, codeModel.Methods.Count(m => m.Name == "PutSinglePage"));
-                    Assert.Equal(1, codeModel.Methods.Count(m => m.Name == "PutSinglePageSpecialNext"));
+                    var methods = codeModel.Methods.ToList();
+                    Assert.Equal(7, methods.Count);
+                    Assert.Equal(1, methods.Count(m => m.Name == "GetSinglePage"));
+                    Assert.Equal(0, methods.Count(m => m.Name == "GetSinglePageNext"));
+                    Assert.Equal(1, methods.Count(m => m.Name == "PutSinglePage"));
+                    Assert.Equal(1, methods.Count(m => m.Name == "PutSinglePageSpecialNext"));
 
-                    Assert.Equal("Page<Product>", codeModel.Methods[0].ReturnType.Body.Name);
-                    Assert.Equal("object", codeModel.Methods[1].ReturnType.Body.Name.ToLowerInvariant());
-                    Assert.Equal("Page1<Product>", codeModel.Methods[1].Responses.ElementAt(0).Value.Body.Name);
+                    Assert.Equal("Page<Product>", methods[0].ReturnType.Body.Name);
+                    Assert.Equal("object", methods[1].ReturnType.Body.Name.ToLowerInvariant());
+                    Assert.Equal("Page1<Product>", methods[1].Responses.ElementAt(0).Value.Body.Name);
                     Assert.Equal("string",
-                        codeModel.Methods[1].Responses.ElementAt(1).Value.Body.Name.ToLowerInvariant());
-                    Assert.Equal("object", codeModel.Methods[2].ReturnType.Body.Name.ToLowerInvariant());
-                    Assert.Equal("Page1<Product>", codeModel.Methods[2].Responses.ElementAt(0).Value.Body.Name);
-                    Assert.Equal("Page1<Product>", codeModel.Methods[2].Responses.ElementAt(1).Value.Body.Name);
-                    Assert.Equal("object", codeModel.Methods[3].ReturnType.Body.Name.ToLowerInvariant());
-                    Assert.Equal("Page1<Product>", codeModel.Methods[3].Responses.ElementAt(0).Value.Body.Name);
-                    Assert.Equal("Page1<ProductChild>", codeModel.Methods[3].Responses.ElementAt(1).Value.Body.Name);
+                        methods[1].Responses.ElementAt(1).Value.Body.Name.ToLowerInvariant());
+                    Assert.Equal("object", methods[2].ReturnType.Body.Name.ToLowerInvariant());
+                    Assert.Equal("Page1<Product>", methods[2].Responses.ElementAt(0).Value.Body.Name);
+                    Assert.Equal("Page1<Product>", methods[2].Responses.ElementAt(1).Value.Body.Name);
+                    Assert.Equal("object", methods[3].ReturnType.Body.Name.ToLowerInvariant());
+                    Assert.Equal("Page1<Product>", methods[3].Responses.ElementAt(0).Value.Body.Name);
+                    Assert.Equal("Page1<ProductChild>", methods[3].Responses.ElementAt(1).Value.Body.Name);
                     Assert.Equal(5, codeModel.ModelTypes.Count);
                     Assert.False(
                         codeModel.ModelTypes.Any(t => t.Name.EqualsIgnoreCase("ProducResult")));

--- a/test/vanilla/CSharpCodeNamingFrameworkTests.cs
+++ b/test/vanilla/CSharpCodeNamingFrameworkTests.cs
@@ -175,9 +175,9 @@ namespace AutoRest.CSharp.Tests
                     ReturnType = new Response(customObjectType, null)
                 }));
 
-                Assert.Equal("Methodnamewithlotsofspaces", codeModel.Methods[0].Name);
-                Assert.Equal("GroupwithlotsofWeirdCharacters", codeModel.Methods[0].Group);
-                Assert.Equal("Abc", codeModel.Methods[0].ReturnType.Body.Name);
+                Assert.Equal("Methodnamewithlotsofspaces", codeModel.Methods.First().Name);
+                Assert.Equal("GroupwithlotsofWeirdCharacters", codeModel.Methods.First().Group);
+                Assert.Equal("Abc", codeModel.Methods.First().ReturnType.Body.Name);
             }
         }
 
@@ -211,7 +211,7 @@ namespace AutoRest.CSharp.Tests
 
                     Assert.Equal("AzureAlwaysRocksClient", codeModel.Name);
                     Assert.Equal("AzureAlwaysRocksOperations", codeModel.Operations.First().TypeName);
-                    Assert.Equal("AzureAlwaysRocksMethod", codeModel.Methods[0].Name);
+                    Assert.Equal("AzureAlwaysRocksMethod", codeModel.Methods.First().Name);
                     Assert.Equal("AzureAlwaysRocks", codeModel.ModelTypes.First(m => m.Name == "AzureAlwaysRocks").Name);
                 }
             }
@@ -253,9 +253,9 @@ namespace AutoRest.CSharp.Tests
 
                         Assert.Equal("GreetingsModel", codeModel.ModelTypes[0].Name);
                         Assert.Equal("System.Collections.Generic.IList<GreetingsModel>",
-                            codeModel.Methods[0].ReturnType.Body.Name);
+                            codeModel.Methods.ElementAt(0).ReturnType.Body.Name);
                         Assert.Equal("System.Collections.Generic.IDictionary<string, GreetingsModel>",
-                            codeModel.Methods[1].ReturnType.Body.Name);
+                            codeModel.Methods.ElementAt(1).ReturnType.Body.Name);
                     }
                 }
             }


### PR DESCRIPTION
...so I can clean up common, the more we have to do on the CodeModel the next weeks/months, the less I wanna deal with non-standard types