### PR TITLE
Priortizing customization layer to initialize ContractsResolver

### DIFF
--- a/autorest.csharp.sln
+++ b/autorest.csharp.sln
@@ -44,4 +44,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1E74389E-D907-4512-8B7B-D8DC75613358}
+	EndGlobalSection
 EndGlobal

--- a/src/vanilla/Templates/Rest/Client/ServiceClientTemplate.cshtml
+++ b/src/vanilla/Templates/Rest/Client/ServiceClientTemplate.cshtml
@@ -86,14 +86,23 @@ namespace @Settings.Namespace
             @:SerializationSettings.Converters.Add(new Microsoft.Rest.Serialization.PolymorphicSerializeJsonConverter<@(polymorphicType.Name)>("@(polymorphicType.PolymorphicDiscriminator)"));
             @:DeserializationSettings.Converters.Add(new  Microsoft.Rest.Serialization.PolymorphicDeserializeJsonConverter<@(polymorphicType.Name)>("@(polymorphicType.PolymorphicDiscriminator)"));
             }
-
+            @EmptyLine
             CustomInitialize();
+            @EmptyLine
+            if(SerializationSettings.ContractResolver == null)
+            {
+                SerializationSettings.ContractResolver = new Microsoft.Rest.Serialization.ReadOnlyJsonContractResolver();
+            }
+
+            if (DeserializationSettings.ContractResolver == null)
+            {
+                DeserializationSettings.ContractResolver = new Microsoft.Rest.Serialization.ReadOnlyJsonContractResolver();
+            }
             
             @if (Model.NeedsTransformationConverter)
             {
             @:DeserializationSettings.Converters.Add(new Microsoft.Rest.Serialization.TransformationJsonConverter());
-            }
-    
+            }    
         }    
     
         @foreach (MethodCs method in Model.Methods.Where( m => m.Group.IsNullOrEmpty()))

--- a/test/autorest.csharp.test.csproj
+++ b/test/autorest.csharp.test.csproj
@@ -47,5 +47,9 @@
     <ProjectReference Include="$(SolutionDir)src/autorest.csharp.csproj" />
   </ItemGroup>
  
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+ 
   <ProjectExtensions><VisualStudio><UserProperties Resource_4Swagger_4swagger-x-ms-discriminator-value_1json__JSONSchema="..\..\..\..\..\schema\swagger-extensions.json" /></VisualStudio></ProjectExtensions>
 </Project>


### PR DESCRIPTION
Allowing customization layer to initialized ContractResolvers before a default ContractResolver is initialized.