### PR TITLE
update modeler and testserver to eliminate constantinople vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "homepage": "https://github.com/Azure/autorest.csharp/blob/master/README.md",
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "^2.5.1",
-    "@microsoft.azure/autorest.modeler": "2.3.51",
+    "@microsoft.azure/autorest.testserver": "^2.5.16",
+    "@microsoft.azure/autorest.modeler": "2.3.47",
     "autorest": "^2.0.4255",
     "coffee-script": "^1.11.1",
     "dotnet-sdk-2.0.0": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/Azure/autorest.csharp/blob/master/README.md",
   "devDependencies": {
     "@microsoft.azure/autorest.testserver": "^2.5.16",
-    "@microsoft.azure/autorest.modeler": "2.3.47",
+    "@microsoft.azure/autorest.modeler": "2.3.55",
     "autorest": "^2.0.4255",
     "coffee-script": "^1.11.1",
     "dotnet-sdk-2.0.0": "^1.4.4",


### PR DESCRIPTION
Update to new testserver. The modeler has been updated to depend on the updated testserver so also update that version.

121 tests pass, 7 skipped.

Should resolve https://github.com/Azure/autorest/issues/2942