### PR TITLE
Allow for optional multipart form content parameters

### DIFF
--- a/src/vanilla/Templates/Rest/Client/MethodBodyTemplateRestCall.cshtml
+++ b/src/vanilla/Templates/Rest/Client/MethodBodyTemplateRestCall.cshtml
@@ -248,7 +248,7 @@ else if (Model.LogicalParameters.Any(p => p.Location == ParameterLocation.FormDa
     @:_multiPartContent.Add(@(localParam), "@(parameter.SerializedName)");
 @:}
     }
-@:_httpRequest.Content = _multiPartContent;
+@:_httpRequest.Content = System.Linq.Enumerable.Any(_multiPartContent) ? _multiPartContent : null;
     }
     else
     {

--- a/test/vanilla/Expected/BodyFormData/Formdata.cs
+++ b/test/vanilla/Expected/BodyFormData/Formdata.cs
@@ -156,7 +156,7 @@ namespace Fixtures.BodyFormData
                 StringContent _fileName = new StringContent(fileName, System.Text.Encoding.UTF8);
                 _multiPartContent.Add(_fileName, "fileName");
             }
-            _httpRequest.Content = _multiPartContent;
+            _httpRequest.Content = System.Linq.Enumerable.Any(_multiPartContent) ? _multiPartContent : null;
             // Send Request
             if (_shouldTrace)
             {


### PR DESCRIPTION
Similar to the issue described in https://github.com/Azure/autorest/issues/1629, there currently is an issue with optional stream parameters as part of multipart form contents.

The scenario is the following:

- The API defines a POST or PUT operation that takes (possibly along with other parameters) an optional parameter using multipart form data content
  - in my project, it was an ASP.NET Core 2.1 controller method that had several parameters bound to Route & Query string, plus an IFormFile parameter bound to the request body. The IFormFile parameter is optional
- The generated client checks if the stream passed into the call is != null before adding it to the MultipartFormDataContent (which is correct)
- But this also implies, that the generated MultipartFormDataContent contains no actual content, but is still set as the http requests content
- This in turn will lead to an error in the ASP.NET Core model binder, because it will try to fill the IFormFile parameter instead of setting it to null (which it does if the request body is empty)

The fix is to only set the request content to the MultipartFormDataContent instance, if the MultipartFormDataContent instance actually contains any content.