### PR TITLE
Add lanuch settings to debug the plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "name": "@autorest/csharp-v3",
   "description": "See readme.md for instructions",
   "scripts": {
-    "start": "dotnet ./bin/AutoRest.CSharp.V3.dll --server"
+    "start": "dotnet ./bin/AutoRest.CSharp.V3.dll --server",
+    "debug": "dotnet ./bin/AutoRest.CSharp.V3.dll --server --launch-debugger"
   }
 }

--- a/samples/xkcd/xkcd.yaml
+++ b/samples/xkcd/xkcd.yaml
@@ -1,0 +1,83 @@
+swagger: '2.0'
+schemes:
+  - http
+host: xkcd.com
+basePath: /
+info:
+  description: 'Webcomic of romance, sarcasm, math, and language.'
+  title: XKCD
+  version: 1.0.0
+  x-apisguru-categories:
+    - media
+  x-logo:
+    url: 'https: //api.apis.guru/v2/cache/logo/http_imgs.xkcd.com_static_terrible_small_logo.png'
+  x-origin:
+    - format: swagger
+      url: 'https: //raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/xkcd.com/1.0.0/swagger.yaml'
+      version: '2.0'
+  x-preferred: true
+  x-providerName: xkcd.com
+  x-tags:
+    - humor
+    - comics
+  x-unofficialSpec: true
+externalDocs:
+  url: 'https: //xkcd.com/json.html'
+securityDefinitions: {}
+produces:
+  - application/json
+consumes:
+  - application/json
+
+paths:
+  /info.0.json:
+    get:
+      operationId: xkcd_getComicForToday
+      description: |
+        Fetch current comic and metadata.
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/comic'
+  '/{comicId}/info.0.json':
+    get:
+      operationId: xkcd_getComic
+      description: |
+        Fetch comics and metadata  by comic id.
+      parameters:
+        - in: path
+          name: comicId
+          required: true
+          type: number
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/comic'
+definitions:
+  comic:
+    properties:
+      alt:
+        type: string
+      day:
+        type: string
+      img:
+        type: string
+      link:
+        type: string
+      month:
+        type: string
+      news:
+        type: string
+      num:
+        type: number
+      safe_title:
+        type: string
+      title:
+        type: string
+      transcript:
+        type: string
+      year:
+        type: string
+    type: object

--- a/src/AutoRest.CSharp.V3/PluginProcessor.cs
+++ b/src/AutoRest.CSharp.V3/PluginProcessor.cs
@@ -16,7 +16,7 @@ namespace AutoRest.CSharp.V3
         public static async Task<bool> Start(AutoRestInterface autoRest)
         {
             // AutoRest sends an empty Object as a 'true' value. When the configuration item is not present, it sends a Null value.
-            if ((await autoRest.GetValue<JsonElement?>($"{autoRest.PluginName}.debugger")).IsObject())
+            if ((await autoRest.GetValue<JsonElement?>($"{autoRest.PluginName}.debugger-attach")).IsObject())
             {
                 DebuggerAwaiter.Await();
             }

--- a/src/AutoRest.CSharp.V3/Program.cs
+++ b/src/AutoRest.CSharp.V3/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using AutoRest.CSharp.V3.JsonRpc;
 using AutoRest.CSharp.V3.JsonRpc.Messaging;
@@ -12,6 +13,11 @@ namespace AutoRest.CSharp.V3
 
         public static int Main(string[] args)
         {
+            if (args.Contains("--launch-debugger") && !Debugger.IsAttached)
+            {
+                Debugger.Launch();
+            }
+
             if (!HasServerArgument(args))
             {
                 Console.WriteLine("Not a valid invocation of this AutoRest extension. Invoke this extension through the AutoRest pipeline.");

--- a/src/AutoRest.CSharp.V3/Properties/launchSettings.json
+++ b/src/AutoRest.CSharp.V3/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "AutoRest.CSharp.V3": {
+      "commandName": "Executable",
+      "executablePath": "node",
+      "commandLineArgs": "%appdata%/npm/node_modules/autorest/entrypoints/app.js --debug --verbose --use:$(ProjectDir)../.. --input-file:$(ProjectDir)../../samples/xkcd/xkcd.yaml --csharp-v3.debugger",
+      "workingDirectory": "$(ProjectDir)../.."
+    }
+  }
+}


### PR DESCRIPTION
Add lanuch setting which will open autorest and you will get a prompt
to start debugging the .NET plugin as well. Do the launch via CTRL+F5,
instead of F5 if you want to use the same VS window for debugging otherwise
VS doesn't like to mix debugging node and .net in the same VS IDE.