### PR TITLE
Null check: empty line bug

### DIFF
--- a/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -366,7 +367,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                 }
             }
 
-            if (parameters.Count > 0)
+            if (parameters.Any())
             {
                 writer.Line();
             }

--- a/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -352,11 +353,11 @@ namespace AutoRest.CSharp.V3.Generation.Writers
             }
         };
 
-        private void WriteParameterNullChecks(CodeWriter writer, IEnumerable<Parameter> parameters)
+        private void WriteParameterNullChecks(CodeWriter writer, IReadOnlyCollection<Parameter> parameters)
         {
             foreach (Parameter parameter in parameters)
             {
-                var cs = _typeFactory.CreateType(parameter.Type);
+                CSharpType cs = _typeFactory.CreateType(parameter.Type);
                 if (parameter.IsRequired && (cs.IsNullable || !cs.IsValueType))
                 {
                     using (writer.If($"{parameter.Name} == null"))
@@ -365,7 +366,11 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                     }
                 }
             }
-            writer.Line();
+
+            if (parameters.Count > 0)
+            {
+                writer.Line();
+            }
         }
 
         private void WriteConstant(CodeWriter writer, Constant constant)

--- a/test/TestServerProjects/body-array/Generated/Operations/ArrayOperations.cs
+++ b/test/TestServerProjects/body-array/Generated/Operations/ArrayOperations.cs
@@ -45,7 +45,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<int>>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetNull");
             scope.Start();
             try
@@ -78,7 +77,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<int>> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetNull");
             scope.Start();
             try
@@ -122,7 +120,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<int>>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetInvalid");
             scope.Start();
             try
@@ -155,7 +152,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<int>> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetInvalid");
             scope.Start();
             try
@@ -199,7 +195,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<int>>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetEmpty");
             scope.Start();
             try
@@ -232,7 +227,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<int>> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetEmpty");
             scope.Start();
             try
@@ -356,7 +350,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<bool>>> GetBooleanTfftAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBooleanTfft");
             scope.Start();
             try
@@ -389,7 +382,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<bool>> GetBooleanTfft(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBooleanTfft");
             scope.Start();
             try
@@ -513,7 +505,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<bool>>> GetBooleanInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBooleanInvalidNull");
             scope.Start();
             try
@@ -546,7 +537,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<bool>> GetBooleanInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBooleanInvalidNull");
             scope.Start();
             try
@@ -590,7 +580,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<bool>>> GetBooleanInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBooleanInvalidString");
             scope.Start();
             try
@@ -623,7 +612,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<bool>> GetBooleanInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBooleanInvalidString");
             scope.Start();
             try
@@ -667,7 +655,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<int>>> GetIntegerValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetIntegerValid");
             scope.Start();
             try
@@ -700,7 +687,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<int>> GetIntegerValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetIntegerValid");
             scope.Start();
             try
@@ -824,7 +810,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<int>>> GetIntInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetIntInvalidNull");
             scope.Start();
             try
@@ -857,7 +842,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<int>> GetIntInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetIntInvalidNull");
             scope.Start();
             try
@@ -901,7 +885,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<int>>> GetIntInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetIntInvalidString");
             scope.Start();
             try
@@ -934,7 +917,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<int>> GetIntInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetIntInvalidString");
             scope.Start();
             try
@@ -978,7 +960,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<long>>> GetLongValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetLongValid");
             scope.Start();
             try
@@ -1011,7 +992,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<long>> GetLongValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetLongValid");
             scope.Start();
             try
@@ -1135,7 +1115,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<long>>> GetLongInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetLongInvalidNull");
             scope.Start();
             try
@@ -1168,7 +1147,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<long>> GetLongInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetLongInvalidNull");
             scope.Start();
             try
@@ -1212,7 +1190,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<long>>> GetLongInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetLongInvalidString");
             scope.Start();
             try
@@ -1245,7 +1222,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<long>> GetLongInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetLongInvalidString");
             scope.Start();
             try
@@ -1289,7 +1265,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<float>>> GetFloatValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetFloatValid");
             scope.Start();
             try
@@ -1322,7 +1297,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<float>> GetFloatValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetFloatValid");
             scope.Start();
             try
@@ -1446,7 +1420,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<float>>> GetFloatInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetFloatInvalidNull");
             scope.Start();
             try
@@ -1479,7 +1452,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<float>> GetFloatInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetFloatInvalidNull");
             scope.Start();
             try
@@ -1523,7 +1495,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<float>>> GetFloatInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetFloatInvalidString");
             scope.Start();
             try
@@ -1556,7 +1527,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<float>> GetFloatInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetFloatInvalidString");
             scope.Start();
             try
@@ -1600,7 +1570,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<double>>> GetDoubleValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDoubleValid");
             scope.Start();
             try
@@ -1633,7 +1602,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<double>> GetDoubleValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDoubleValid");
             scope.Start();
             try
@@ -1757,7 +1725,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<double>>> GetDoubleInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDoubleInvalidNull");
             scope.Start();
             try
@@ -1790,7 +1757,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<double>> GetDoubleInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDoubleInvalidNull");
             scope.Start();
             try
@@ -1834,7 +1800,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<double>>> GetDoubleInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDoubleInvalidString");
             scope.Start();
             try
@@ -1867,7 +1832,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<double>> GetDoubleInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDoubleInvalidString");
             scope.Start();
             try
@@ -1911,7 +1875,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<string>>> GetStringValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringValid");
             scope.Start();
             try
@@ -1944,7 +1907,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<string>> GetStringValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringValid");
             scope.Start();
             try
@@ -2068,7 +2030,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<FooEnum>>> GetEnumValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetEnumValid");
             scope.Start();
             try
@@ -2101,7 +2062,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<FooEnum>> GetEnumValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetEnumValid");
             scope.Start();
             try
@@ -2225,7 +2185,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Enum0>>> GetStringEnumValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringEnumValid");
             scope.Start();
             try
@@ -2258,7 +2217,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Enum0>> GetStringEnumValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringEnumValid");
             scope.Start();
             try
@@ -2382,7 +2340,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<string>>> GetStringWithNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringWithNull");
             scope.Start();
             try
@@ -2415,7 +2372,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<string>> GetStringWithNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringWithNull");
             scope.Start();
             try
@@ -2459,7 +2415,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<string>>> GetStringWithInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringWithInvalid");
             scope.Start();
             try
@@ -2492,7 +2447,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<string>> GetStringWithInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetStringWithInvalid");
             scope.Start();
             try
@@ -2536,7 +2490,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Guid>>> GetUuidValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetUuidValid");
             scope.Start();
             try
@@ -2569,7 +2522,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Guid>> GetUuidValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetUuidValid");
             scope.Start();
             try
@@ -2693,7 +2645,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Guid>>> GetUuidInvalidCharsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetUuidInvalidChars");
             scope.Start();
             try
@@ -2726,7 +2677,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Guid>> GetUuidInvalidChars(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetUuidInvalidChars");
             scope.Start();
             try
@@ -2770,7 +2720,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateValid");
             scope.Start();
             try
@@ -2803,7 +2752,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateValid");
             scope.Start();
             try
@@ -2927,7 +2875,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateInvalidNull");
             scope.Start();
             try
@@ -2960,7 +2907,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateInvalidNull");
             scope.Start();
             try
@@ -3004,7 +2950,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateInvalidCharsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateInvalidChars");
             scope.Start();
             try
@@ -3037,7 +2982,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateInvalidChars(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateInvalidChars");
             scope.Start();
             try
@@ -3081,7 +3025,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateTimeValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeValid");
             scope.Start();
             try
@@ -3114,7 +3057,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateTimeValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeValid");
             scope.Start();
             try
@@ -3238,7 +3180,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateTimeInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeInvalidNull");
             scope.Start();
             try
@@ -3271,7 +3212,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateTimeInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeInvalidNull");
             scope.Start();
             try
@@ -3315,7 +3255,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateTimeInvalidCharsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeInvalidChars");
             scope.Start();
             try
@@ -3348,7 +3287,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateTimeInvalidChars(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeInvalidChars");
             scope.Start();
             try
@@ -3392,7 +3330,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<DateTimeOffset>>> GetDateTimeRfc1123ValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeRfc1123Valid");
             scope.Start();
             try
@@ -3425,7 +3362,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<DateTimeOffset>> GetDateTimeRfc1123Valid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDateTimeRfc1123Valid");
             scope.Start();
             try
@@ -3549,7 +3485,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<TimeSpan>>> GetDurationValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDurationValid");
             scope.Start();
             try
@@ -3582,7 +3517,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<TimeSpan>> GetDurationValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDurationValid");
             scope.Start();
             try
@@ -3706,7 +3640,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<byte[]>>> GetByteValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetByteValid");
             scope.Start();
             try
@@ -3739,7 +3672,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<byte[]>> GetByteValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetByteValid");
             scope.Start();
             try
@@ -3863,7 +3795,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<byte[]>>> GetByteInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetByteInvalidNull");
             scope.Start();
             try
@@ -3896,7 +3827,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<byte[]>> GetByteInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetByteInvalidNull");
             scope.Start();
             try
@@ -3940,7 +3870,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<byte[]>>> GetBase64UrlAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBase64Url");
             scope.Start();
             try
@@ -3973,7 +3902,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<byte[]>> GetBase64Url(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetBase64Url");
             scope.Start();
             try
@@ -4017,7 +3945,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Product>>> GetComplexNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexNull");
             scope.Start();
             try
@@ -4050,7 +3977,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Product>> GetComplexNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexNull");
             scope.Start();
             try
@@ -4094,7 +4020,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Product>>> GetComplexEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexEmpty");
             scope.Start();
             try
@@ -4127,7 +4052,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Product>> GetComplexEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexEmpty");
             scope.Start();
             try
@@ -4171,7 +4095,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Product>>> GetComplexItemNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexItemNull");
             scope.Start();
             try
@@ -4204,7 +4127,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Product>> GetComplexItemNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexItemNull");
             scope.Start();
             try
@@ -4248,7 +4170,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Product>>> GetComplexItemEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexItemEmpty");
             scope.Start();
             try
@@ -4281,7 +4202,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Product>> GetComplexItemEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexItemEmpty");
             scope.Start();
             try
@@ -4325,7 +4245,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Product>>> GetComplexValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexValid");
             scope.Start();
             try
@@ -4358,7 +4277,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Product>> GetComplexValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetComplexValid");
             scope.Start();
             try
@@ -4482,7 +4400,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<ICollection<string>>>> GetArrayNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayNull");
             scope.Start();
             try
@@ -4520,7 +4437,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<ICollection<string>>> GetArrayNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayNull");
             scope.Start();
             try
@@ -4569,7 +4485,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<ICollection<string>>>> GetArrayEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayEmpty");
             scope.Start();
             try
@@ -4607,7 +4522,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<ICollection<string>>> GetArrayEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayEmpty");
             scope.Start();
             try
@@ -4656,7 +4570,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<ICollection<string>>>> GetArrayItemNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayItemNull");
             scope.Start();
             try
@@ -4694,7 +4607,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<ICollection<string>>> GetArrayItemNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayItemNull");
             scope.Start();
             try
@@ -4743,7 +4655,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<ICollection<string>>>> GetArrayItemEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayItemEmpty");
             scope.Start();
             try
@@ -4781,7 +4692,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<ICollection<string>>> GetArrayItemEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayItemEmpty");
             scope.Start();
             try
@@ -4830,7 +4740,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<ICollection<string>>>> GetArrayValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayValid");
             scope.Start();
             try
@@ -4868,7 +4777,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<ICollection<string>>> GetArrayValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetArrayValid");
             scope.Start();
             try
@@ -5002,7 +4910,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<IDictionary<string, string>>>> GetDictionaryNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryNull");
             scope.Start();
             try
@@ -5040,7 +4947,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<IDictionary<string, string>>> GetDictionaryNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryNull");
             scope.Start();
             try
@@ -5089,7 +4995,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<IDictionary<string, string>>>> GetDictionaryEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryEmpty");
             scope.Start();
             try
@@ -5127,7 +5032,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<IDictionary<string, string>>> GetDictionaryEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryEmpty");
             scope.Start();
             try
@@ -5176,7 +5080,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<IDictionary<string, string>>>> GetDictionaryItemNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryItemNull");
             scope.Start();
             try
@@ -5214,7 +5117,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<IDictionary<string, string>>> GetDictionaryItemNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryItemNull");
             scope.Start();
             try
@@ -5263,7 +5165,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<IDictionary<string, string>>>> GetDictionaryItemEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryItemEmpty");
             scope.Start();
             try
@@ -5301,7 +5202,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<IDictionary<string, string>>> GetDictionaryItemEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryItemEmpty");
             scope.Start();
             try
@@ -5350,7 +5250,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<IDictionary<string, string>>>> GetDictionaryValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryValid");
             scope.Start();
             try
@@ -5388,7 +5287,6 @@ namespace body_array
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<IDictionary<string, string>>> GetDictionaryValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetDictionaryValid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-boolean/Generated/Operations/BoolOperations.cs
+++ b/test/TestServerProjects/body-boolean/Generated/Operations/BoolOperations.cs
@@ -43,7 +43,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<bool>> GetTrueAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetTrue");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<bool> GetTrue(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetTrue");
             scope.Start();
             try
@@ -116,7 +114,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutTrueAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.PutTrue");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutTrue(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.PutTrue");
             scope.Start();
             try
@@ -177,7 +173,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<bool>> GetFalseAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetFalse");
             scope.Start();
             try
@@ -206,7 +201,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<bool> GetFalse(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetFalse");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutFalseAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.PutFalse");
             scope.Start();
             try
@@ -275,7 +268,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutFalse(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.PutFalse");
             scope.Start();
             try
@@ -311,7 +303,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<bool>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetNull");
             scope.Start();
             try
@@ -340,7 +331,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<bool> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetNull");
             scope.Start();
             try
@@ -380,7 +370,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<bool>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetInvalid");
             scope.Start();
             try
@@ -409,7 +398,6 @@ namespace body_boolean
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<bool> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BoolOperations.GetInvalid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-byte/Generated/Operations/ByteOperations.cs
+++ b/test/TestServerProjects/body-byte/Generated/Operations/ByteOperations.cs
@@ -43,7 +43,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetNull");
             scope.Start();
             try
@@ -112,7 +110,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetEmpty");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetEmpty");
             scope.Start();
             try
@@ -181,7 +177,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetNonAsciiAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetNonAscii");
             scope.Start();
             try
@@ -210,7 +205,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetNonAscii(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetNonAscii");
             scope.Start();
             try
@@ -325,7 +319,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetInvalid");
             scope.Start();
             try
@@ -354,7 +347,6 @@ namespace body_byte
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ByteOperations.GetInvalid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/ArrayOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/ArrayOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ArrayWrapper>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ArrayWrapper> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetValid");
             scope.Start();
             try
@@ -188,7 +186,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ArrayWrapper>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetEmpty");
             scope.Start();
             try
@@ -217,7 +214,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ArrayWrapper> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetEmpty");
             scope.Start();
             try
@@ -332,7 +328,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ArrayWrapper>> GetNotProvidedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetNotProvided");
             scope.Start();
             try
@@ -361,7 +356,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ArrayWrapper> GetNotProvided(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ArrayOperations.GetNotProvided");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/BasicOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/BasicOperations.cs
@@ -50,7 +50,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Basic>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetValid");
             scope.Start();
             try
@@ -79,7 +78,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Basic> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetValid");
             scope.Start();
             try
@@ -195,7 +193,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Basic>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetInvalid");
             scope.Start();
             try
@@ -224,7 +221,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Basic> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetInvalid");
             scope.Start();
             try
@@ -264,7 +260,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Basic>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetEmpty");
             scope.Start();
             try
@@ -293,7 +288,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Basic> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetEmpty");
             scope.Start();
             try
@@ -333,7 +327,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Basic>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetNull");
             scope.Start();
             try
@@ -362,7 +355,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Basic> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetNull");
             scope.Start();
             try
@@ -402,7 +394,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Basic>> GetNotProvidedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetNotProvided");
             scope.Start();
             try
@@ -431,7 +422,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Basic> GetNotProvided(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("BasicOperations.GetNotProvided");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/DictionaryOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/DictionaryOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DictionaryWrapper>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DictionaryWrapper> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetValid");
             scope.Start();
             try
@@ -188,7 +186,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DictionaryWrapper>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetEmpty");
             scope.Start();
             try
@@ -217,7 +214,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DictionaryWrapper> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetEmpty");
             scope.Start();
             try
@@ -332,7 +328,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DictionaryWrapper>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNull");
             scope.Start();
             try
@@ -361,7 +356,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DictionaryWrapper> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNull");
             scope.Start();
             try
@@ -401,7 +395,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DictionaryWrapper>> GetNotProvidedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNotProvided");
             scope.Start();
             try
@@ -430,7 +423,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DictionaryWrapper> GetNotProvided(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNotProvided");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/FlattencomplexOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/FlattencomplexOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<MyBaseType>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FlattencomplexOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<MyBaseType> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FlattencomplexOperations.GetValid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/InheritanceOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/InheritanceOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Siamese>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("InheritanceOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Siamese> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("InheritanceOperations.GetValid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/PolymorphicrecursiveOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/PolymorphicrecursiveOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Fish>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphicrecursiveOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Fish> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphicrecursiveOperations.GetValid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/PolymorphismOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/PolymorphismOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Fish>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Fish> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetValid");
             scope.Start();
             try
@@ -256,7 +254,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DotFish>> GetDotSyntaxAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetDotSyntax");
             scope.Start();
             try
@@ -285,7 +282,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DotFish> GetDotSyntax(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetDotSyntax");
             scope.Start();
             try
@@ -325,7 +321,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DotFishMarket>> GetComposedWithDiscriminatorAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetComposedWithDiscriminator");
             scope.Start();
             try
@@ -354,7 +349,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DotFishMarket> GetComposedWithDiscriminator(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetComposedWithDiscriminator");
             scope.Start();
             try
@@ -394,7 +388,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DotFishMarket>> GetComposedWithoutDiscriminatorAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetComposedWithoutDiscriminator");
             scope.Start();
             try
@@ -423,7 +416,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DotFishMarket> GetComposedWithoutDiscriminator(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetComposedWithoutDiscriminator");
             scope.Start();
             try
@@ -463,7 +455,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Salmon>> GetComplicatedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetComplicated");
             scope.Start();
             try
@@ -492,7 +483,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Salmon> GetComplicated(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PolymorphismOperations.GetComplicated");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/PrimitiveOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/PrimitiveOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IntWrapper>> GetIntAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetInt");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IntWrapper> GetInt(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetInt");
             scope.Start();
             try
@@ -188,7 +186,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<LongWrapper>> GetLongAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetLong");
             scope.Start();
             try
@@ -217,7 +214,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<LongWrapper> GetLong(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetLong");
             scope.Start();
             try
@@ -332,7 +328,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<FloatWrapper>> GetFloatAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetFloat");
             scope.Start();
             try
@@ -361,7 +356,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<FloatWrapper> GetFloat(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetFloat");
             scope.Start();
             try
@@ -476,7 +470,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DoubleWrapper>> GetDoubleAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDouble");
             scope.Start();
             try
@@ -505,7 +498,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DoubleWrapper> GetDouble(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDouble");
             scope.Start();
             try
@@ -620,7 +612,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<BooleanWrapper>> GetBoolAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetBool");
             scope.Start();
             try
@@ -649,7 +640,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<BooleanWrapper> GetBool(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetBool");
             scope.Start();
             try
@@ -764,7 +754,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<StringWrapper>> GetStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetString");
             scope.Start();
             try
@@ -793,7 +782,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<StringWrapper> GetString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetString");
             scope.Start();
             try
@@ -908,7 +896,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateWrapper>> GetDateAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDate");
             scope.Start();
             try
@@ -937,7 +924,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateWrapper> GetDate(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDate");
             scope.Start();
             try
@@ -1052,7 +1038,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DatetimeWrapper>> GetDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDateTime");
             scope.Start();
             try
@@ -1081,7 +1066,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DatetimeWrapper> GetDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDateTime");
             scope.Start();
             try
@@ -1196,7 +1180,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Datetimerfc1123Wrapper>> GetDateTimeRfc1123Async(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDateTimeRfc1123");
             scope.Start();
             try
@@ -1225,7 +1208,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Datetimerfc1123Wrapper> GetDateTimeRfc1123(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDateTimeRfc1123");
             scope.Start();
             try
@@ -1340,7 +1322,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DurationWrapper>> GetDurationAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDuration");
             scope.Start();
             try
@@ -1369,7 +1350,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DurationWrapper> GetDuration(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetDuration");
             scope.Start();
             try
@@ -1484,7 +1464,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ByteWrapper>> GetByteAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetByte");
             scope.Start();
             try
@@ -1513,7 +1492,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ByteWrapper> GetByte(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PrimitiveOperations.GetByte");
             scope.Start();
             try

--- a/test/TestServerProjects/body-complex/Generated/Operations/ReadonlypropertyOperations.cs
+++ b/test/TestServerProjects/body-complex/Generated/Operations/ReadonlypropertyOperations.cs
@@ -44,7 +44,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ReadonlyObj>> GetValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ReadonlypropertyOperations.GetValid");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_complex
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ReadonlyObj> GetValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("ReadonlypropertyOperations.GetValid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-date/Generated/Operations/DateOperations.cs
+++ b/test/TestServerProjects/body-date/Generated/Operations/DateOperations.cs
@@ -43,7 +43,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetNull");
             scope.Start();
             try
@@ -112,7 +110,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetInvalidDateAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetInvalidDate");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetInvalidDate(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetInvalidDate");
             scope.Start();
             try
@@ -181,7 +177,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetOverflowDateAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetOverflowDate");
             scope.Start();
             try
@@ -210,7 +205,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetOverflowDate(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetOverflowDate");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUnderflowDateAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetUnderflowDate");
             scope.Start();
             try
@@ -279,7 +272,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUnderflowDate(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetUnderflowDate");
             scope.Start();
             try
@@ -386,7 +378,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetMaxDateAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetMaxDate");
             scope.Start();
             try
@@ -415,7 +406,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetMaxDate(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetMaxDate");
             scope.Start();
             try
@@ -522,7 +512,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetMinDateAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetMinDate");
             scope.Start();
             try
@@ -551,7 +540,6 @@ namespace body_date
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetMinDate(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DateOperations.GetMinDate");
             scope.Start();
             try

--- a/test/TestServerProjects/body-datetime-rfc1123/Generated/Operations/Datetimerfc1123Operations.cs
+++ b/test/TestServerProjects/body-datetime-rfc1123/Generated/Operations/Datetimerfc1123Operations.cs
@@ -43,7 +43,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetNull");
             scope.Start();
             try
@@ -112,7 +110,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetInvalid");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetInvalid");
             scope.Start();
             try
@@ -181,7 +177,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetOverflowAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetOverflow");
             scope.Start();
             try
@@ -210,7 +205,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetOverflow(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetOverflow");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUnderflowAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUnderflow");
             scope.Start();
             try
@@ -279,7 +272,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUnderflow(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUnderflow");
             scope.Start();
             try
@@ -386,7 +378,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcLowercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUtcLowercaseMaxDateTime");
             scope.Start();
             try
@@ -415,7 +406,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcLowercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUtcLowercaseMaxDateTime");
             scope.Start();
             try
@@ -455,7 +445,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcUppercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUtcUppercaseMaxDateTime");
             scope.Start();
             try
@@ -484,7 +473,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcUppercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUtcUppercaseMaxDateTime");
             scope.Start();
             try
@@ -591,7 +579,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcMinDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUtcMinDateTime");
             scope.Start();
             try
@@ -620,7 +607,6 @@ namespace body_datetime_rfc1123
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcMinDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("Datetimerfc1123Operations.GetUtcMinDateTime");
             scope.Start();
             try

--- a/test/TestServerProjects/body-datetime/Generated/Operations/DatetimeOperations.cs
+++ b/test/TestServerProjects/body-datetime/Generated/Operations/DatetimeOperations.cs
@@ -43,7 +43,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetNull");
             scope.Start();
             try
@@ -112,7 +110,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetInvalid");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetInvalid");
             scope.Start();
             try
@@ -181,7 +177,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetOverflowAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetOverflow");
             scope.Start();
             try
@@ -210,7 +205,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetOverflow(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetOverflow");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUnderflowAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUnderflow");
             scope.Start();
             try
@@ -279,7 +272,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUnderflow(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUnderflow");
             scope.Start();
             try
@@ -453,7 +445,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcLowercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcLowercaseMaxDateTime");
             scope.Start();
             try
@@ -482,7 +473,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcLowercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcLowercaseMaxDateTime");
             scope.Start();
             try
@@ -522,7 +512,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcUppercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcUppercaseMaxDateTime");
             scope.Start();
             try
@@ -551,7 +540,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcUppercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcUppercaseMaxDateTime");
             scope.Start();
             try
@@ -591,7 +579,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcUppercaseMaxDateTime7DigitsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcUppercaseMaxDateTime7Digits");
             scope.Start();
             try
@@ -620,7 +607,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcUppercaseMaxDateTime7Digits(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcUppercaseMaxDateTime7Digits");
             scope.Start();
             try
@@ -727,7 +713,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetLocalPositiveOffsetLowercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalPositiveOffsetLowercaseMaxDateTime");
             scope.Start();
             try
@@ -756,7 +741,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetLocalPositiveOffsetLowercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalPositiveOffsetLowercaseMaxDateTime");
             scope.Start();
             try
@@ -796,7 +780,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetLocalPositiveOffsetUppercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalPositiveOffsetUppercaseMaxDateTime");
             scope.Start();
             try
@@ -825,7 +808,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetLocalPositiveOffsetUppercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalPositiveOffsetUppercaseMaxDateTime");
             scope.Start();
             try
@@ -932,7 +914,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetLocalNegativeOffsetUppercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalNegativeOffsetUppercaseMaxDateTime");
             scope.Start();
             try
@@ -961,7 +942,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetLocalNegativeOffsetUppercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalNegativeOffsetUppercaseMaxDateTime");
             scope.Start();
             try
@@ -1001,7 +981,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetLocalNegativeOffsetLowercaseMaxDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalNegativeOffsetLowercaseMaxDateTime");
             scope.Start();
             try
@@ -1030,7 +1009,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetLocalNegativeOffsetLowercaseMaxDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalNegativeOffsetLowercaseMaxDateTime");
             scope.Start();
             try
@@ -1137,7 +1115,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUtcMinDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcMinDateTime");
             scope.Start();
             try
@@ -1166,7 +1143,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUtcMinDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetUtcMinDateTime");
             scope.Start();
             try
@@ -1273,7 +1249,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetLocalPositiveOffsetMinDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalPositiveOffsetMinDateTime");
             scope.Start();
             try
@@ -1302,7 +1277,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetLocalPositiveOffsetMinDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalPositiveOffsetMinDateTime");
             scope.Start();
             try
@@ -1409,7 +1383,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetLocalNegativeOffsetMinDateTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalNegativeOffsetMinDateTime");
             scope.Start();
             try
@@ -1438,7 +1411,6 @@ namespace body_datetime
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetLocalNegativeOffsetMinDateTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DatetimeOperations.GetLocalNegativeOffsetMinDateTime");
             scope.Start();
             try

--- a/test/TestServerProjects/body-dictionary/Generated/Operations/DictionaryOperations.cs
+++ b/test/TestServerProjects/body-dictionary/Generated/Operations/DictionaryOperations.cs
@@ -45,7 +45,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, int>>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNull");
             scope.Start();
             try
@@ -78,7 +77,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, int>> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNull");
             scope.Start();
             try
@@ -122,7 +120,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, int>>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetEmpty");
             scope.Start();
             try
@@ -155,7 +152,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, int>> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetEmpty");
             scope.Start();
             try
@@ -280,7 +276,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetNullValueAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNullValue");
             scope.Start();
             try
@@ -313,7 +308,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetNullValue(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNullValue");
             scope.Start();
             try
@@ -357,7 +351,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetNullKeyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNullKey");
             scope.Start();
             try
@@ -390,7 +383,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetNullKey(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetNullKey");
             scope.Start();
             try
@@ -434,7 +426,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetEmptyStringKeyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetEmptyStringKey");
             scope.Start();
             try
@@ -467,7 +458,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetEmptyStringKey(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetEmptyStringKey");
             scope.Start();
             try
@@ -511,7 +501,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetInvalid");
             scope.Start();
             try
@@ -544,7 +533,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetInvalid");
             scope.Start();
             try
@@ -588,7 +576,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, bool>>> GetBooleanTfftAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBooleanTfft");
             scope.Start();
             try
@@ -621,7 +608,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, bool>> GetBooleanTfft(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBooleanTfft");
             scope.Start();
             try
@@ -746,7 +732,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, bool>>> GetBooleanInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBooleanInvalidNull");
             scope.Start();
             try
@@ -779,7 +764,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, bool>> GetBooleanInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBooleanInvalidNull");
             scope.Start();
             try
@@ -823,7 +807,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, bool>>> GetBooleanInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBooleanInvalidString");
             scope.Start();
             try
@@ -856,7 +839,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, bool>> GetBooleanInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBooleanInvalidString");
             scope.Start();
             try
@@ -900,7 +882,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, int>>> GetIntegerValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetIntegerValid");
             scope.Start();
             try
@@ -933,7 +914,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, int>> GetIntegerValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetIntegerValid");
             scope.Start();
             try
@@ -1058,7 +1038,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, int>>> GetIntInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetIntInvalidNull");
             scope.Start();
             try
@@ -1091,7 +1070,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, int>> GetIntInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetIntInvalidNull");
             scope.Start();
             try
@@ -1135,7 +1113,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, int>>> GetIntInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetIntInvalidString");
             scope.Start();
             try
@@ -1168,7 +1145,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, int>> GetIntInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetIntInvalidString");
             scope.Start();
             try
@@ -1212,7 +1188,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, long>>> GetLongValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetLongValid");
             scope.Start();
             try
@@ -1245,7 +1220,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, long>> GetLongValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetLongValid");
             scope.Start();
             try
@@ -1370,7 +1344,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, long>>> GetLongInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetLongInvalidNull");
             scope.Start();
             try
@@ -1403,7 +1376,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, long>> GetLongInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetLongInvalidNull");
             scope.Start();
             try
@@ -1447,7 +1419,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, long>>> GetLongInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetLongInvalidString");
             scope.Start();
             try
@@ -1480,7 +1451,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, long>> GetLongInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetLongInvalidString");
             scope.Start();
             try
@@ -1524,7 +1494,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, float>>> GetFloatValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetFloatValid");
             scope.Start();
             try
@@ -1557,7 +1526,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, float>> GetFloatValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetFloatValid");
             scope.Start();
             try
@@ -1682,7 +1650,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, float>>> GetFloatInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetFloatInvalidNull");
             scope.Start();
             try
@@ -1715,7 +1682,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, float>> GetFloatInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetFloatInvalidNull");
             scope.Start();
             try
@@ -1759,7 +1725,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, float>>> GetFloatInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetFloatInvalidString");
             scope.Start();
             try
@@ -1792,7 +1757,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, float>> GetFloatInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetFloatInvalidString");
             scope.Start();
             try
@@ -1836,7 +1800,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, double>>> GetDoubleValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDoubleValid");
             scope.Start();
             try
@@ -1869,7 +1832,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, double>> GetDoubleValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDoubleValid");
             scope.Start();
             try
@@ -1994,7 +1956,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, double>>> GetDoubleInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDoubleInvalidNull");
             scope.Start();
             try
@@ -2027,7 +1988,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, double>> GetDoubleInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDoubleInvalidNull");
             scope.Start();
             try
@@ -2071,7 +2031,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, double>>> GetDoubleInvalidStringAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDoubleInvalidString");
             scope.Start();
             try
@@ -2104,7 +2063,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, double>> GetDoubleInvalidString(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDoubleInvalidString");
             scope.Start();
             try
@@ -2148,7 +2106,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetStringValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetStringValid");
             scope.Start();
             try
@@ -2181,7 +2138,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetStringValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetStringValid");
             scope.Start();
             try
@@ -2306,7 +2262,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetStringWithNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetStringWithNull");
             scope.Start();
             try
@@ -2339,7 +2294,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetStringWithNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetStringWithNull");
             scope.Start();
             try
@@ -2383,7 +2337,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, string>>> GetStringWithInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetStringWithInvalid");
             scope.Start();
             try
@@ -2416,7 +2369,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, string>> GetStringWithInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetStringWithInvalid");
             scope.Start();
             try
@@ -2460,7 +2412,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateValid");
             scope.Start();
             try
@@ -2493,7 +2444,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateValid");
             scope.Start();
             try
@@ -2618,7 +2568,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateInvalidNull");
             scope.Start();
             try
@@ -2651,7 +2600,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateInvalidNull");
             scope.Start();
             try
@@ -2695,7 +2643,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateInvalidCharsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateInvalidChars");
             scope.Start();
             try
@@ -2728,7 +2675,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateInvalidChars(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateInvalidChars");
             scope.Start();
             try
@@ -2772,7 +2718,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateTimeValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeValid");
             scope.Start();
             try
@@ -2805,7 +2750,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateTimeValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeValid");
             scope.Start();
             try
@@ -2930,7 +2874,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateTimeInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeInvalidNull");
             scope.Start();
             try
@@ -2963,7 +2906,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateTimeInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeInvalidNull");
             scope.Start();
             try
@@ -3007,7 +2949,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateTimeInvalidCharsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeInvalidChars");
             scope.Start();
             try
@@ -3040,7 +2981,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateTimeInvalidChars(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeInvalidChars");
             scope.Start();
             try
@@ -3084,7 +3024,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, DateTimeOffset>>> GetDateTimeRfc1123ValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeRfc1123Valid");
             scope.Start();
             try
@@ -3117,7 +3056,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, DateTimeOffset>> GetDateTimeRfc1123Valid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDateTimeRfc1123Valid");
             scope.Start();
             try
@@ -3242,7 +3180,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, TimeSpan>>> GetDurationValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDurationValid");
             scope.Start();
             try
@@ -3275,7 +3212,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, TimeSpan>> GetDurationValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDurationValid");
             scope.Start();
             try
@@ -3400,7 +3336,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, byte[]>>> GetByteValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetByteValid");
             scope.Start();
             try
@@ -3433,7 +3368,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, byte[]>> GetByteValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetByteValid");
             scope.Start();
             try
@@ -3558,7 +3492,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, byte[]>>> GetByteInvalidNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetByteInvalidNull");
             scope.Start();
             try
@@ -3591,7 +3524,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, byte[]>> GetByteInvalidNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetByteInvalidNull");
             scope.Start();
             try
@@ -3635,7 +3567,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, byte[]>>> GetBase64UrlAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBase64Url");
             scope.Start();
             try
@@ -3668,7 +3599,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, byte[]>> GetBase64Url(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetBase64Url");
             scope.Start();
             try
@@ -3712,7 +3642,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, Widget>>> GetComplexNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexNull");
             scope.Start();
             try
@@ -3745,7 +3674,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, Widget>> GetComplexNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexNull");
             scope.Start();
             try
@@ -3789,7 +3717,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, Widget>>> GetComplexEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexEmpty");
             scope.Start();
             try
@@ -3822,7 +3749,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, Widget>> GetComplexEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexEmpty");
             scope.Start();
             try
@@ -3866,7 +3792,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, Widget>>> GetComplexItemNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexItemNull");
             scope.Start();
             try
@@ -3899,7 +3824,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, Widget>> GetComplexItemNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexItemNull");
             scope.Start();
             try
@@ -3943,7 +3867,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, Widget>>> GetComplexItemEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexItemEmpty");
             scope.Start();
             try
@@ -3976,7 +3899,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, Widget>> GetComplexItemEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexItemEmpty");
             scope.Start();
             try
@@ -4020,7 +3942,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, Widget>>> GetComplexValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexValid");
             scope.Start();
             try
@@ -4053,7 +3974,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, Widget>> GetComplexValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetComplexValid");
             scope.Start();
             try
@@ -4178,7 +4098,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, ICollection<string>>>> GetArrayNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayNull");
             scope.Start();
             try
@@ -4216,7 +4135,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, ICollection<string>>> GetArrayNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayNull");
             scope.Start();
             try
@@ -4265,7 +4183,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, ICollection<string>>>> GetArrayEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayEmpty");
             scope.Start();
             try
@@ -4303,7 +4220,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, ICollection<string>>> GetArrayEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayEmpty");
             scope.Start();
             try
@@ -4352,7 +4268,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, ICollection<string>>>> GetArrayItemNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayItemNull");
             scope.Start();
             try
@@ -4390,7 +4305,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, ICollection<string>>> GetArrayItemNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayItemNull");
             scope.Start();
             try
@@ -4439,7 +4353,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, ICollection<string>>>> GetArrayItemEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayItemEmpty");
             scope.Start();
             try
@@ -4477,7 +4390,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, ICollection<string>>> GetArrayItemEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayItemEmpty");
             scope.Start();
             try
@@ -4526,7 +4438,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, ICollection<string>>>> GetArrayValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayValid");
             scope.Start();
             try
@@ -4564,7 +4475,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, ICollection<string>>> GetArrayValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetArrayValid");
             scope.Start();
             try
@@ -4699,7 +4609,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, object>>> GetDictionaryNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryNull");
             scope.Start();
             try
@@ -4732,7 +4641,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, object>> GetDictionaryNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryNull");
             scope.Start();
             try
@@ -4776,7 +4684,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, object>>> GetDictionaryEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryEmpty");
             scope.Start();
             try
@@ -4809,7 +4716,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, object>> GetDictionaryEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryEmpty");
             scope.Start();
             try
@@ -4853,7 +4759,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, object>>> GetDictionaryItemNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryItemNull");
             scope.Start();
             try
@@ -4886,7 +4791,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, object>> GetDictionaryItemNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryItemNull");
             scope.Start();
             try
@@ -4930,7 +4834,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, object>>> GetDictionaryItemEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryItemEmpty");
             scope.Start();
             try
@@ -4963,7 +4866,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, object>> GetDictionaryItemEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryItemEmpty");
             scope.Start();
             try
@@ -5007,7 +4909,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IDictionary<string, object>>> GetDictionaryValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryValid");
             scope.Start();
             try
@@ -5040,7 +4941,6 @@ namespace body_dictionary
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IDictionary<string, object>> GetDictionaryValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DictionaryOperations.GetDictionaryValid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-duration/Generated/Operations/DurationOperations.cs
+++ b/test/TestServerProjects/body-duration/Generated/Operations/DurationOperations.cs
@@ -43,7 +43,6 @@ namespace body_duration
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TimeSpan>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DurationOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_duration
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TimeSpan> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DurationOperations.GetNull");
             scope.Start();
             try
@@ -179,7 +177,6 @@ namespace body_duration
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TimeSpan>> GetPositiveDurationAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DurationOperations.GetPositiveDuration");
             scope.Start();
             try
@@ -208,7 +205,6 @@ namespace body_duration
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TimeSpan> GetPositiveDuration(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DurationOperations.GetPositiveDuration");
             scope.Start();
             try
@@ -248,7 +244,6 @@ namespace body_duration
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TimeSpan>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DurationOperations.GetInvalid");
             scope.Start();
             try
@@ -277,7 +272,6 @@ namespace body_duration
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TimeSpan> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("DurationOperations.GetInvalid");
             scope.Start();
             try

--- a/test/TestServerProjects/body-file/Generated/Operations/FilesOperations.cs
+++ b/test/TestServerProjects/body-file/Generated/Operations/FilesOperations.cs
@@ -43,7 +43,6 @@ namespace body_file
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Stream>> GetFileAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FilesOperations.GetFile");
             scope.Start();
             try
@@ -71,7 +70,6 @@ namespace body_file
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Stream> GetFile(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FilesOperations.GetFile");
             scope.Start();
             try
@@ -110,7 +108,6 @@ namespace body_file
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Stream>> GetFileLargeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FilesOperations.GetFileLarge");
             scope.Start();
             try
@@ -138,7 +135,6 @@ namespace body_file
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Stream> GetFileLarge(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FilesOperations.GetFileLarge");
             scope.Start();
             try
@@ -177,7 +173,6 @@ namespace body_file
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Stream>> GetEmptyFileAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FilesOperations.GetEmptyFile");
             scope.Start();
             try
@@ -205,7 +200,6 @@ namespace body_file
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Stream> GetEmptyFile(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("FilesOperations.GetEmptyFile");
             scope.Start();
             try

--- a/test/TestServerProjects/body-integer/Generated/Operations/IntOperations.cs
+++ b/test/TestServerProjects/body-integer/Generated/Operations/IntOperations.cs
@@ -43,7 +43,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<int>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<int> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetNull");
             scope.Start();
             try
@@ -112,7 +110,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<int>> GetInvalidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetInvalid");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<int> GetInvalid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetInvalid");
             scope.Start();
             try
@@ -181,7 +177,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<int>> GetOverflowInt32Async(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetOverflowInt32");
             scope.Start();
             try
@@ -210,7 +205,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<int> GetOverflowInt32(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetOverflowInt32");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<int>> GetUnderflowInt32Async(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetUnderflowInt32");
             scope.Start();
             try
@@ -279,7 +272,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<int> GetUnderflowInt32(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetUnderflowInt32");
             scope.Start();
             try
@@ -319,7 +311,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<long>> GetOverflowInt64Async(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetOverflowInt64");
             scope.Start();
             try
@@ -348,7 +339,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<long> GetOverflowInt64(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetOverflowInt64");
             scope.Start();
             try
@@ -388,7 +378,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<long>> GetUnderflowInt64Async(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetUnderflowInt64");
             scope.Start();
             try
@@ -417,7 +406,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<long> GetUnderflowInt64(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetUnderflowInt64");
             scope.Start();
             try
@@ -725,7 +713,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetUnixTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetUnixTime");
             scope.Start();
             try
@@ -754,7 +741,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetUnixTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetUnixTime");
             scope.Start();
             try
@@ -861,7 +847,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetInvalidUnixTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetInvalidUnixTime");
             scope.Start();
             try
@@ -890,7 +875,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetInvalidUnixTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetInvalidUnixTime");
             scope.Start();
             try
@@ -930,7 +914,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DateTimeOffset>> GetNullUnixTimeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetNullUnixTime");
             scope.Start();
             try
@@ -959,7 +942,6 @@ namespace body_integer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DateTimeOffset> GetNullUnixTime(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("IntOperations.GetNullUnixTime");
             scope.Start();
             try

--- a/test/TestServerProjects/body-number/Generated/Operations/NumberOperations.cs
+++ b/test/TestServerProjects/body-number/Generated/Operations/NumberOperations.cs
@@ -43,7 +43,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<float>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<float> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetNull");
             scope.Start();
             try
@@ -112,7 +110,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<float>> GetInvalidFloatAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetInvalidFloat");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<float> GetInvalidFloat(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetInvalidFloat");
             scope.Start();
             try
@@ -181,7 +177,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<double>> GetInvalidDoubleAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetInvalidDouble");
             scope.Start();
             try
@@ -210,7 +205,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<double> GetInvalidDouble(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetInvalidDouble");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<decimal>> GetInvalidDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetInvalidDecimal");
             scope.Start();
             try
@@ -279,7 +272,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<decimal> GetInvalidDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetInvalidDecimal");
             scope.Start();
             try
@@ -386,7 +378,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<float>> GetBigFloatAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigFloat");
             scope.Start();
             try
@@ -415,7 +406,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<float> GetBigFloat(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigFloat");
             scope.Start();
             try
@@ -522,7 +512,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<double>> GetBigDoubleAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDouble");
             scope.Start();
             try
@@ -551,7 +540,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<double> GetBigDouble(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDouble");
             scope.Start();
             try
@@ -595,7 +583,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutBigDoublePositiveDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDoublePositiveDecimal");
             scope.Start();
             try
@@ -620,7 +607,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutBigDoublePositiveDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDoublePositiveDecimal");
             scope.Start();
             try
@@ -656,7 +642,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<double>> GetBigDoublePositiveDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDoublePositiveDecimal");
             scope.Start();
             try
@@ -685,7 +670,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<double> GetBigDoublePositiveDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDoublePositiveDecimal");
             scope.Start();
             try
@@ -729,7 +713,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutBigDoubleNegativeDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDoubleNegativeDecimal");
             scope.Start();
             try
@@ -754,7 +737,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutBigDoubleNegativeDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDoubleNegativeDecimal");
             scope.Start();
             try
@@ -790,7 +772,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<double>> GetBigDoubleNegativeDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDoubleNegativeDecimal");
             scope.Start();
             try
@@ -819,7 +800,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<double> GetBigDoubleNegativeDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDoubleNegativeDecimal");
             scope.Start();
             try
@@ -926,7 +906,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<decimal>> GetBigDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDecimal");
             scope.Start();
             try
@@ -955,7 +934,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<decimal> GetBigDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDecimal");
             scope.Start();
             try
@@ -999,7 +977,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutBigDecimalPositiveDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDecimalPositiveDecimal");
             scope.Start();
             try
@@ -1024,7 +1001,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutBigDecimalPositiveDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDecimalPositiveDecimal");
             scope.Start();
             try
@@ -1060,7 +1036,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<decimal>> GetBigDecimalPositiveDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDecimalPositiveDecimal");
             scope.Start();
             try
@@ -1089,7 +1064,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<decimal> GetBigDecimalPositiveDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDecimalPositiveDecimal");
             scope.Start();
             try
@@ -1133,7 +1107,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutBigDecimalNegativeDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDecimalNegativeDecimal");
             scope.Start();
             try
@@ -1158,7 +1131,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutBigDecimalNegativeDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.PutBigDecimalNegativeDecimal");
             scope.Start();
             try
@@ -1194,7 +1166,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<decimal>> GetBigDecimalNegativeDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDecimalNegativeDecimal");
             scope.Start();
             try
@@ -1223,7 +1194,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<decimal> GetBigDecimalNegativeDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetBigDecimalNegativeDecimal");
             scope.Start();
             try
@@ -1330,7 +1300,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<double>> GetSmallFloatAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetSmallFloat");
             scope.Start();
             try
@@ -1359,7 +1328,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<double> GetSmallFloat(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetSmallFloat");
             scope.Start();
             try
@@ -1466,7 +1434,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<double>> GetSmallDoubleAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetSmallDouble");
             scope.Start();
             try
@@ -1495,7 +1462,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<double> GetSmallDouble(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetSmallDouble");
             scope.Start();
             try
@@ -1602,7 +1568,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<decimal>> GetSmallDecimalAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetSmallDecimal");
             scope.Start();
             try
@@ -1631,7 +1596,6 @@ namespace body_number
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<decimal> GetSmallDecimal(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("NumberOperations.GetSmallDecimal");
             scope.Start();
             try

--- a/test/TestServerProjects/body-string/Generated/Operations/EnumOperations.cs
+++ b/test/TestServerProjects/body-string/Generated/Operations/EnumOperations.cs
@@ -44,7 +44,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Colors>> GetNotExpandableAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("EnumOperations.GetNotExpandable");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Colors> GetNotExpandable(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("EnumOperations.GetNotExpandable");
             scope.Start();
             try
@@ -180,7 +178,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Colors>> GetReferencedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("EnumOperations.GetReferenced");
             scope.Start();
             try
@@ -209,7 +206,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Colors> GetReferenced(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("EnumOperations.GetReferenced");
             scope.Start();
             try
@@ -316,7 +312,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<RefColorConstant>> GetReferencedConstantAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("EnumOperations.GetReferencedConstant");
             scope.Start();
             try
@@ -345,7 +340,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<RefColorConstant> GetReferencedConstant(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("EnumOperations.GetReferencedConstant");
             scope.Start();
             try

--- a/test/TestServerProjects/body-string/Generated/Operations/StringOperations.cs
+++ b/test/TestServerProjects/body-string/Generated/Operations/StringOperations.cs
@@ -43,7 +43,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<string>> GetNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetNull");
             scope.Start();
             try
@@ -72,7 +71,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<string> GetNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetNull");
             scope.Start();
             try
@@ -116,7 +114,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutNullAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutNull");
             scope.Start();
             try
@@ -141,7 +138,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutNull(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutNull");
             scope.Start();
             try
@@ -177,7 +173,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<string>> GetEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetEmpty");
             scope.Start();
             try
@@ -206,7 +201,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<string> GetEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetEmpty");
             scope.Start();
             try
@@ -250,7 +244,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutEmpty");
             scope.Start();
             try
@@ -275,7 +268,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutEmpty");
             scope.Start();
             try
@@ -311,7 +303,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<string>> GetMbcsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetMbcs");
             scope.Start();
             try
@@ -340,7 +331,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<string> GetMbcs(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetMbcs");
             scope.Start();
             try
@@ -384,7 +374,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutMbcsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutMbcs");
             scope.Start();
             try
@@ -409,7 +398,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutMbcs(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutMbcs");
             scope.Start();
             try
@@ -445,7 +433,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<string>> GetWhitespaceAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetWhitespace");
             scope.Start();
             try
@@ -474,7 +461,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<string> GetWhitespace(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetWhitespace");
             scope.Start();
             try
@@ -518,7 +504,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> PutWhitespaceAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutWhitespace");
             scope.Start();
             try
@@ -543,7 +528,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response PutWhitespace(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.PutWhitespace");
             scope.Start();
             try
@@ -579,7 +563,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<string>> GetNotProvidedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetNotProvided");
             scope.Start();
             try
@@ -608,7 +591,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<string> GetNotProvided(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetNotProvided");
             scope.Start();
             try
@@ -648,7 +630,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetBase64EncodedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetBase64Encoded");
             scope.Start();
             try
@@ -677,7 +658,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetBase64Encoded(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetBase64Encoded");
             scope.Start();
             try
@@ -717,7 +697,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetBase64UrlEncodedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetBase64UrlEncoded");
             scope.Start();
             try
@@ -746,7 +725,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetBase64UrlEncoded(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetBase64UrlEncoded");
             scope.Start();
             try
@@ -861,7 +839,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<byte[]>> GetNullBase64UrlEncodedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetNullBase64UrlEncoded");
             scope.Start();
             try
@@ -890,7 +867,6 @@ namespace body_string
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<byte[]> GetNullBase64UrlEncoded(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("StringOperations.GetNullBase64UrlEncoded");
             scope.Start();
             try

--- a/test/TestServerProjects/header/Generated/Operations/HeaderOperations.cs
+++ b/test/TestServerProjects/header/Generated/Operations/HeaderOperations.cs
@@ -115,7 +115,6 @@ namespace header
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<ResponseExistingKeyHeaders>> ResponseExistingKeyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("HeaderOperations.ResponseExistingKey");
             scope.Start();
             try
@@ -141,7 +140,6 @@ namespace header
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<ResponseExistingKeyHeaders> ResponseExistingKey(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("HeaderOperations.ResponseExistingKey");
             scope.Start();
             try
@@ -250,7 +248,6 @@ namespace header
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<ResponseProtectedKeyHeaders>> ResponseProtectedKeyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("HeaderOperations.ResponseProtectedKey");
             scope.Start();
             try
@@ -276,7 +273,6 @@ namespace header
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<ResponseProtectedKeyHeaders> ResponseProtectedKey(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("HeaderOperations.ResponseProtectedKey");
             scope.Start();
             try
@@ -2118,7 +2114,6 @@ namespace header
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> CustomRequestIdAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("HeaderOperations.CustomRequestId");
             scope.Start();
             try
@@ -2143,7 +2138,6 @@ namespace header
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response CustomRequestId(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("HeaderOperations.CustomRequestId");
             scope.Start();
             try

--- a/test/TestServerProjects/paging/Generated/Operations/PagingOperations.cs
+++ b/test/TestServerProjects/paging/Generated/Operations/PagingOperations.cs
@@ -44,7 +44,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResultValue>> GetNoItemNamePagesAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetNoItemNamePages");
             scope.Start();
             try
@@ -73,7 +72,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResultValue> GetNoItemNamePages(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetNoItemNamePages");
             scope.Start();
             try
@@ -113,7 +111,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetNullNextLinkNamePagesAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetNullNextLinkNamePages");
             scope.Start();
             try
@@ -142,7 +139,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetNullNextLinkNamePages(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetNullNextLinkNamePages");
             scope.Start();
             try
@@ -182,7 +178,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetSinglePagesAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetSinglePages");
             scope.Start();
             try
@@ -211,7 +206,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetSinglePages(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetSinglePages");
             scope.Start();
             try
@@ -515,7 +509,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetMultiplePagesRetryFirstAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesRetryFirst");
             scope.Start();
             try
@@ -544,7 +537,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetMultiplePagesRetryFirst(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesRetryFirst");
             scope.Start();
             try
@@ -584,7 +576,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetMultiplePagesRetrySecondAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesRetrySecond");
             scope.Start();
             try
@@ -613,7 +604,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetMultiplePagesRetrySecond(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesRetrySecond");
             scope.Start();
             try
@@ -653,7 +643,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetSinglePagesFailureAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetSinglePagesFailure");
             scope.Start();
             try
@@ -682,7 +671,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetSinglePagesFailure(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetSinglePagesFailure");
             scope.Start();
             try
@@ -722,7 +710,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetMultiplePagesFailureAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesFailure");
             scope.Start();
             try
@@ -751,7 +738,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetMultiplePagesFailure(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesFailure");
             scope.Start();
             try
@@ -791,7 +777,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ProductResult>> GetMultiplePagesFailureUriAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesFailureUri");
             scope.Start();
             try
@@ -820,7 +805,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ProductResult> GetMultiplePagesFailureUri(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PagingOperations.GetMultiplePagesFailureUri");
             scope.Start();
             try
@@ -2332,7 +2316,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetNoItemNamePagesPageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetNoItemNamePagesAsync(cancellationToken).ConfigureAwait(false);
@@ -2349,7 +2332,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetNoItemNamePagesPageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetNoItemNamePages(cancellationToken);
@@ -2366,7 +2348,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetNullNextLinkNamePagesPageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetNullNextLinkNamePagesAsync(cancellationToken).ConfigureAwait(false);
@@ -2383,7 +2364,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetNullNextLinkNamePagesPageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetNullNextLinkNamePages(cancellationToken);
@@ -2400,7 +2380,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetSinglePagesPageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetSinglePagesAsync(cancellationToken).ConfigureAwait(false);
@@ -2417,7 +2396,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetSinglePagesPageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetSinglePages(cancellationToken);
@@ -2556,7 +2534,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetMultiplePagesRetryFirstPageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetMultiplePagesRetryFirstAsync(cancellationToken).ConfigureAwait(false);
@@ -2573,7 +2550,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetMultiplePagesRetryFirstPageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetMultiplePagesRetryFirst(cancellationToken);
@@ -2590,7 +2566,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetMultiplePagesRetrySecondPageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetMultiplePagesRetrySecondAsync(cancellationToken).ConfigureAwait(false);
@@ -2607,7 +2582,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetMultiplePagesRetrySecondPageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetMultiplePagesRetrySecond(cancellationToken);
@@ -2624,7 +2598,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetSinglePagesFailurePageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetSinglePagesFailureAsync(cancellationToken).ConfigureAwait(false);
@@ -2641,7 +2614,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetSinglePagesFailurePageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetSinglePagesFailure(cancellationToken);
@@ -2658,7 +2630,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetMultiplePagesFailurePageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetMultiplePagesFailureAsync(cancellationToken).ConfigureAwait(false);
@@ -2675,7 +2646,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetMultiplePagesFailurePageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetMultiplePagesFailure(cancellationToken);
@@ -2692,7 +2662,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetMultiplePagesFailureUriPageableAsync(CancellationToken cancellationToken = default)
         {
-
             async Task<Page<Product>> FirstPageFunc(int? pageSizeHint)
             {
                 var response = await GetMultiplePagesFailureUriAsync(cancellationToken).ConfigureAwait(false);
@@ -2709,7 +2678,6 @@ namespace paging
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Pageable<Product> GetMultiplePagesFailureUriPageable(CancellationToken cancellationToken = default)
         {
-
             Page<Product> FirstPageFunc(int? pageSizeHint)
             {
                 var response = GetMultiplePagesFailureUri(cancellationToken);

--- a/test/TestServerProjects/url/Generated/Operations/PathsOperations.cs
+++ b/test/TestServerProjects/url/Generated/Operations/PathsOperations.cs
@@ -45,7 +45,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetBooleanTrueAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetBooleanTrue");
             scope.Start();
             try
@@ -70,7 +69,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetBooleanTrue(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetBooleanTrue");
             scope.Start();
             try
@@ -107,7 +105,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetBooleanFalseAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetBooleanFalse");
             scope.Start();
             try
@@ -132,7 +129,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetBooleanFalse(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetBooleanFalse");
             scope.Start();
             try
@@ -169,7 +165,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetIntOneMillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetIntOneMillion");
             scope.Start();
             try
@@ -194,7 +189,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetIntOneMillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetIntOneMillion");
             scope.Start();
             try
@@ -231,7 +225,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetIntNegativeOneMillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetIntNegativeOneMillion");
             scope.Start();
             try
@@ -256,7 +249,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetIntNegativeOneMillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetIntNegativeOneMillion");
             scope.Start();
             try
@@ -293,7 +285,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetTenBillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetTenBillion");
             scope.Start();
             try
@@ -318,7 +309,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetTenBillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetTenBillion");
             scope.Start();
             try
@@ -355,7 +345,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetNegativeTenBillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetNegativeTenBillion");
             scope.Start();
             try
@@ -380,7 +369,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetNegativeTenBillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.GetNegativeTenBillion");
             scope.Start();
             try
@@ -417,7 +405,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> FloatScientificPositiveAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.FloatScientificPositive");
             scope.Start();
             try
@@ -442,7 +429,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response FloatScientificPositive(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.FloatScientificPositive");
             scope.Start();
             try
@@ -479,7 +465,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> FloatScientificNegativeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.FloatScientificNegative");
             scope.Start();
             try
@@ -504,7 +489,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response FloatScientificNegative(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.FloatScientificNegative");
             scope.Start();
             try
@@ -541,7 +525,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DoubleDecimalPositiveAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DoubleDecimalPositive");
             scope.Start();
             try
@@ -566,7 +549,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DoubleDecimalPositive(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DoubleDecimalPositive");
             scope.Start();
             try
@@ -603,7 +585,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DoubleDecimalNegativeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DoubleDecimalNegative");
             scope.Start();
             try
@@ -628,7 +609,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DoubleDecimalNegative(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DoubleDecimalNegative");
             scope.Start();
             try
@@ -665,7 +645,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringUnicodeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringUnicode");
             scope.Start();
             try
@@ -690,7 +669,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringUnicode(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringUnicode");
             scope.Start();
             try
@@ -727,7 +705,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringUrlEncodedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringUrlEncoded");
             scope.Start();
             try
@@ -752,7 +729,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringUrlEncoded(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringUrlEncoded");
             scope.Start();
             try
@@ -789,7 +765,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringUrlNonEncodedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringUrlNonEncoded");
             scope.Start();
             try
@@ -814,7 +789,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringUrlNonEncoded(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringUrlNonEncoded");
             scope.Start();
             try
@@ -851,7 +825,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringEmpty");
             scope.Start();
             try
@@ -876,7 +849,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.StringEmpty");
             scope.Start();
             try
@@ -1185,7 +1157,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> ByteEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.ByteEmpty");
             scope.Start();
             try
@@ -1210,7 +1181,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response ByteEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.ByteEmpty");
             scope.Start();
             try
@@ -1319,7 +1289,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DateValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DateValid");
             scope.Start();
             try
@@ -1344,7 +1313,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DateValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DateValid");
             scope.Start();
             try
@@ -1445,7 +1413,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DateTimeValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DateTimeValid");
             scope.Start();
             try
@@ -1470,7 +1437,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DateTimeValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("PathsOperations.DateTimeValid");
             scope.Start();
             try

--- a/test/TestServerProjects/url/Generated/Operations/QueriesOperations.cs
+++ b/test/TestServerProjects/url/Generated/Operations/QueriesOperations.cs
@@ -45,7 +45,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetBooleanTrueAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetBooleanTrue");
             scope.Start();
             try
@@ -70,7 +69,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetBooleanTrue(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetBooleanTrue");
             scope.Start();
             try
@@ -107,7 +105,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetBooleanFalseAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetBooleanFalse");
             scope.Start();
             try
@@ -132,7 +129,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetBooleanFalse(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetBooleanFalse");
             scope.Start();
             try
@@ -236,7 +232,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetIntOneMillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetIntOneMillion");
             scope.Start();
             try
@@ -261,7 +256,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetIntOneMillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetIntOneMillion");
             scope.Start();
             try
@@ -298,7 +292,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetIntNegativeOneMillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetIntNegativeOneMillion");
             scope.Start();
             try
@@ -323,7 +316,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetIntNegativeOneMillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetIntNegativeOneMillion");
             scope.Start();
             try
@@ -427,7 +419,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetTenBillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetTenBillion");
             scope.Start();
             try
@@ -452,7 +443,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetTenBillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetTenBillion");
             scope.Start();
             try
@@ -489,7 +479,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetNegativeTenBillionAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetNegativeTenBillion");
             scope.Start();
             try
@@ -514,7 +503,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetNegativeTenBillion(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.GetNegativeTenBillion");
             scope.Start();
             try
@@ -618,7 +606,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> FloatScientificPositiveAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.FloatScientificPositive");
             scope.Start();
             try
@@ -643,7 +630,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response FloatScientificPositive(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.FloatScientificPositive");
             scope.Start();
             try
@@ -680,7 +666,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> FloatScientificNegativeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.FloatScientificNegative");
             scope.Start();
             try
@@ -705,7 +690,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response FloatScientificNegative(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.FloatScientificNegative");
             scope.Start();
             try
@@ -809,7 +793,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DoubleDecimalPositiveAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DoubleDecimalPositive");
             scope.Start();
             try
@@ -834,7 +817,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DoubleDecimalPositive(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DoubleDecimalPositive");
             scope.Start();
             try
@@ -871,7 +853,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DoubleDecimalNegativeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DoubleDecimalNegative");
             scope.Start();
             try
@@ -896,7 +877,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DoubleDecimalNegative(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DoubleDecimalNegative");
             scope.Start();
             try
@@ -1000,7 +980,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringUnicodeAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.StringUnicode");
             scope.Start();
             try
@@ -1025,7 +1004,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringUnicode(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.StringUnicode");
             scope.Start();
             try
@@ -1062,7 +1040,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringUrlEncodedAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.StringUrlEncoded");
             scope.Start();
             try
@@ -1087,7 +1064,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringUrlEncoded(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.StringUrlEncoded");
             scope.Start();
             try
@@ -1124,7 +1100,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> StringEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.StringEmpty");
             scope.Start();
             try
@@ -1149,7 +1124,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response StringEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.StringEmpty");
             scope.Start();
             try
@@ -1454,7 +1428,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> ByteEmptyAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.ByteEmpty");
             scope.Start();
             try
@@ -1479,7 +1452,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response ByteEmpty(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.ByteEmpty");
             scope.Start();
             try
@@ -1583,7 +1555,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DateValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DateValid");
             scope.Start();
             try
@@ -1608,7 +1579,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DateValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DateValid");
             scope.Start();
             try
@@ -1712,7 +1682,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DateTimeValidAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DateTimeValid");
             scope.Start();
             try
@@ -1737,7 +1706,6 @@ namespace url
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DateTimeValid(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("QueriesOperations.DateTimeValid");
             scope.Start();
             try

--- a/test/TestServerProjects/validation/Generated/Operations/AllOperations.cs
+++ b/test/TestServerProjects/validation/Generated/Operations/AllOperations.cs
@@ -238,7 +238,6 @@ namespace validation
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> GetWithConstantInPathAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("AllOperations.GetWithConstantInPath");
             scope.Start();
             try
@@ -263,7 +262,6 @@ namespace validation
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response GetWithConstantInPath(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("AllOperations.GetWithConstantInPath");
             scope.Start();
             try

--- a/test/TestServerProjects/xml-service/Generated/Operations/XmlOperations.cs
+++ b/test/TestServerProjects/xml-service/Generated/Operations/XmlOperations.cs
@@ -46,7 +46,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<RootWithRefAndNoMeta>> GetComplexTypeRefNoMetaAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetComplexTypeRefNoMeta");
             scope.Start();
             try
@@ -80,7 +79,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<RootWithRefAndNoMeta> GetComplexTypeRefNoMeta(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetComplexTypeRefNoMeta");
             scope.Start();
             try
@@ -200,7 +198,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<RootWithRefAndMeta>> GetComplexTypeRefWithMetaAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetComplexTypeRefWithMeta");
             scope.Start();
             try
@@ -234,7 +231,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<RootWithRefAndMeta> GetComplexTypeRefWithMeta(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetComplexTypeRefWithMeta");
             scope.Start();
             try
@@ -354,7 +350,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Slideshow>> GetSimpleAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetSimple");
             scope.Start();
             try
@@ -388,7 +383,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Slideshow> GetSimple(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetSimple");
             scope.Start();
             try
@@ -508,7 +502,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<AppleBarrel>> GetWrappedListsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetWrappedLists");
             scope.Start();
             try
@@ -542,7 +535,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<AppleBarrel> GetWrappedLists(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetWrappedLists");
             scope.Start();
             try
@@ -662,7 +654,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<GetHeadersHeaders>> GetHeadersAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetHeaders");
             scope.Start();
             try
@@ -688,7 +679,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<GetHeadersHeaders> GetHeaders(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetHeaders");
             scope.Start();
             try
@@ -725,7 +715,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Slideshow>> GetEmptyListAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyList");
             scope.Start();
             try
@@ -759,7 +748,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Slideshow> GetEmptyList(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyList");
             scope.Start();
             try
@@ -879,7 +867,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<AppleBarrel>> GetEmptyWrappedListsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyWrappedLists");
             scope.Start();
             try
@@ -913,7 +900,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<AppleBarrel> GetEmptyWrappedLists(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyWrappedLists");
             scope.Start();
             try
@@ -1033,7 +1019,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Banana>>> GetRootListAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetRootList");
             scope.Start();
             try
@@ -1073,7 +1058,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Banana>> GetRootList(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetRootList");
             scope.Start();
             try
@@ -1204,7 +1188,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Banana>>> GetRootListSingleItemAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetRootListSingleItem");
             scope.Start();
             try
@@ -1244,7 +1227,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Banana>> GetRootListSingleItem(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetRootListSingleItem");
             scope.Start();
             try
@@ -1375,7 +1357,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<Banana>>> GetEmptyRootListAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyRootList");
             scope.Start();
             try
@@ -1415,7 +1396,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<Banana>> GetEmptyRootList(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyRootList");
             scope.Start();
             try
@@ -1546,7 +1526,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Banana>> GetEmptyChildElementAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyChildElement");
             scope.Start();
             try
@@ -1580,7 +1559,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Banana> GetEmptyChildElement(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetEmptyChildElement");
             scope.Start();
             try
@@ -1701,7 +1679,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ListContainersResponse>> ListContainersAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.ListContainers");
             scope.Start();
             try
@@ -1735,7 +1712,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ListContainersResponse> ListContainers(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.ListContainers");
             scope.Start();
             try
@@ -1782,7 +1758,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<StorageServiceProperties>> GetServicePropertiesAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetServiceProperties");
             scope.Start();
             try
@@ -1816,7 +1791,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<StorageServiceProperties> GetServiceProperties(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetServiceProperties");
             scope.Start();
             try
@@ -1940,7 +1914,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ICollection<SignedIdentifier>>> GetAclsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetAcls");
             scope.Start();
             try
@@ -1980,7 +1953,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ICollection<SignedIdentifier>> GetAcls(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.GetAcls");
             scope.Start();
             try
@@ -2115,7 +2087,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ListBlobsResponse>> ListBlobsAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.ListBlobs");
             scope.Start();
             try
@@ -2149,7 +2120,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ListBlobsResponse> ListBlobs(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.ListBlobs");
             scope.Start();
             try
@@ -2269,7 +2239,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<JSONOutput>> JsonOutputAsync(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.JsonOutput");
             scope.Start();
             try
@@ -2298,7 +2267,6 @@ namespace xml_service
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<JSONOutput> JsonOutput(CancellationToken cancellationToken = default)
         {
-
             using var scope = clientDiagnostics.CreateScope("XmlOperations.JsonOutput");
             scope.Start();
             try


### PR DESCRIPTION
Fixed inserting an empty line at the start of the operation methods if no null checks existed. (It was annoying the crap out of me)