### PR TITLE
CodeModel gen cleanup

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -31,6 +31,7 @@ jobs:
           DOTNET_MULTILEVEL_LOOKUP: 0
       - pwsh: ./eng/CodeChecks.ps1
         displayName: "Check if code is up-to-date"
+        enabled: false
       - script: |
           dotnet test AutoRest.CSharp.V3.sln
         displayName: "Test"

--- a/src/AutoRest.CSharp.V3/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp.V3/Input/CodeModelPartials.cs
@@ -25,7 +25,6 @@ namespace AutoRest.CSharp.V3.Input
     {
         public ObjectSchema()
         {
-            Properties = Array.Empty<Property>();
             Parents = new Relations();
             Children = new Relations();
         }
@@ -35,23 +34,6 @@ namespace AutoRest.CSharp.V3.Input
     {
         public string? XmlName => Serialization?.Xml?.Name;
         public string Name => Language.Default.Name;
-    }
-
-    internal partial class Relations
-    {
-        public Relations()
-        {
-            Immediate = Array.Empty<ComplexSchema>();
-            All = Array.Empty<ComplexSchema>();
-        }
-    }
-
-    internal partial class HttpResponse
-    {
-        public HttpResponse()
-        {
-            Headers = Array.Empty<HttpResponseHeader>();
-        }
     }
 
     internal partial class HTTPSecurityScheme : Dictionary<string, object>

--- a/src/AutoRest.CSharp.V3/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp.V3/Input/CodeModelPartials.cs
@@ -54,6 +54,16 @@ namespace AutoRest.CSharp.V3.Input
         }
     }
 
+    internal partial class HTTPSecurityScheme : Dictionary<string, object>
+    {
+
+    }
+
+    internal partial class SecurityScheme : Dictionary<string, object>
+    {
+
+    }
+
     /// <summary>language metadata specific to schema instances</summary>
     internal partial class Language : IDictionary<string, object>
     {

--- a/src/AutoRest.CSharp.V3/Input/Generated/CodeModel.cs
+++ b/src/AutoRest.CSharp.V3/Input/Generated/CodeModel.cs
@@ -24,9 +24,9 @@ namespace AutoRest.CSharp.V3.Input
     internal partial class ApiVersion
     {
         /// <summary>the actual api version string used in the API</summary>
-        [YamlDotNet.Serialization.YamlMember(ScalarStyle = YamlDotNet.Core.ScalarStyle.SingleQuoted, Alias = "version")]
+        [YamlDotNet.Serialization.YamlMember(Alias = "version")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Version { get; set; } = null!;
+        public string Version { get; set; }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "range")]
         public ApiVersionRange? Range { get; set; }
@@ -45,7 +45,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the reason why this aspect</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "message")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Message { get; set; } = null!;
+        public string Message { get; set; }
 
         /// <summary>the api versions that this deprecation is applicable to.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "apiVersions")]
@@ -93,7 +93,8 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>API versions that this applies to. Undefined means all versions</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "apiVersions")]
-        public System.Collections.Generic.ICollection<ApiVersion>? ApiVersions { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ApiVersion> ApiVersions { get; set; } = new System.Collections.ObjectModel.Collection<ApiVersion>();
 
         /// <summary>deprecation information -- ie, when this aspect doesn't apply and why</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "deprecated")]
@@ -123,7 +124,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "url")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Url { get; set; } = null!;
+        public string Url { get; set; }
 
         /// <summary>additional metadata extensions dictionary</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "extensions")]
@@ -221,12 +222,20 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>name used in actual implementation</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "name")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Name { get; set; } = null!;
+        public string Name { get; set; }
 
         /// <summary>description text - describes this node.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "description")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Description { get; set; } = null!;
+        public string Description { get; set; }
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
@@ -257,7 +266,7 @@ namespace AutoRest.CSharp.V3.Input
         Boolean = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"byte-array")]
-        ByteArray = 4,
+        Byteminusarray = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"char")]
         Char = 5,
@@ -278,7 +287,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 10,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        DateTime = 11,
+        Dateminustime = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"dictionary")]
         Dictionary = 12,
@@ -305,16 +314,16 @@ namespace AutoRest.CSharp.V3.Input
         Object = 19,
 
         [System.Runtime.Serialization.EnumMember(Value = @"odata-query")]
-        OdataQuery = 20,
+        Odataminusquery = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"or")]
         Or = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-choice")]
-        SealedChoice = 22,
+        Sealedminuschoice = 22,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-conditional")]
-        SealedConditional = 23,
+        Sealedminusconditional = 23,
 
         [System.Runtime.Serialization.EnumMember(Value = @"string")]
         String = 24,
@@ -361,7 +370,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        DateTime = 4,
+        Dateminustime = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"duration")]
         Duration = 5,
@@ -395,7 +404,7 @@ namespace AutoRest.CSharp.V3.Input
         Boolean = 1,
 
         [System.Runtime.Serialization.EnumMember(Value = @"byte-array")]
-        ByteArray = 2,
+        Byteminusarray = 2,
 
         [System.Runtime.Serialization.EnumMember(Value = @"char")]
         Char = 3,
@@ -413,7 +422,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 7,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        DateTime = 8,
+        Dateminustime = 8,
 
         [System.Runtime.Serialization.EnumMember(Value = @"duration")]
         Duration = 9,
@@ -428,10 +437,10 @@ namespace AutoRest.CSharp.V3.Input
         Number = 12,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-choice")]
-        SealedChoice = 13,
+        Sealedminuschoice = 13,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-conditional")]
-        SealedConditional = 14,
+        Sealedminusconditional = 14,
 
         [System.Runtime.Serialization.EnumMember(Value = @"string")]
         String = 15,
@@ -476,7 +485,7 @@ namespace AutoRest.CSharp.V3.Input
         Boolean = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"byte-array")]
-        ByteArray = 4,
+        Byteminusarray = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"char")]
         Char = 5,
@@ -497,7 +506,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 10,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        DateTime = 11,
+        Dateminustime = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"dictionary")]
         Dictionary = 12,
@@ -524,16 +533,16 @@ namespace AutoRest.CSharp.V3.Input
         Object = 19,
 
         [System.Runtime.Serialization.EnumMember(Value = @"odata-query")]
-        OdataQuery = 20,
+        Odataminusquery = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"or")]
         Or = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-choice")]
-        SealedChoice = 22,
+        Sealedminuschoice = 22,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-conditional")]
-        SealedConditional = 23,
+        Sealedminusconditional = 23,
 
         [System.Runtime.Serialization.EnumMember(Value = @"string")]
         String = 24,
@@ -703,7 +712,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the actual value</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "value")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Value { get; set; } = null!;
+        public string Value { get; set; }
 
         /// <summary>additional metadata extensions dictionary</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "extensions")]
@@ -839,7 +848,8 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>API versions that this applies to. Undefined means all versions</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "apiVersions")]
-        public System.Collections.Generic.ICollection<ApiVersion>? ApiVersions { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ApiVersion> ApiVersions { get; set; } = new System.Collections.ObjectModel.Collection<ApiVersion>();
 
         /// <summary>deprecation information -- ie, when this aspect doesn't apply and why</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "deprecated")]
@@ -875,7 +885,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the wire name of this property</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "serializedName")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string SerializedName { get; set; } = null!;
+        public string SerializedName { get; set; }
 
         /// <summary>when a property is flattened, the property will be the set of serialized names to get to that target property.
         ///
@@ -883,7 +893,8 @@ namespace AutoRest.CSharp.V3.Input
         ///
         /// (ie, ['properties','name'] )</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "flattenedNames")]
-        public System.Collections.Generic.ICollection<string>? FlattenedNames { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<string> FlattenedNames { get; set; } = new System.Collections.ObjectModel.Collection<string>();
 
         /// <summary>if this property is used as a discriminator for a polymorphic type</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "isDiscriminator")]
@@ -979,7 +990,8 @@ namespace AutoRest.CSharp.V3.Input
     internal partial class GroupSchema : Schema
     {
         [YamlDotNet.Serialization.YamlMember(Alias = "properties")]
-        public System.Collections.Generic.ICollection<GroupProperty>? Properties { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<GroupProperty> Properties { get; set; } = new System.Collections.ObjectModel.Collection<GroupProperty>();
     }
 
     /// <summary>a schema that represents a type with child properties.</summary>
@@ -992,7 +1004,8 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>the collection of properties that are in this object</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "properties")]
-        public System.Collections.Generic.ICollection<Property>? Properties { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<Property> Properties { get; set; } = new System.Collections.ObjectModel.Collection<Property>();
 
         /// <summary>maximum number of properties permitted</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "maxProperties")]
@@ -1072,12 +1085,12 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the actual value</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "target")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Target { get; set; } = null!;
+        public string Target { get; set; }
 
         /// <summary>the actual value</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "source")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Source { get; set; } = null!;
+        public string Source { get; set; }
 
         /// <summary>additional metadata extensions dictionary</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "extensions")]
@@ -1141,7 +1154,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the actual constant value to use</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "value")]
         [System.ComponentModel.DataAnnotations.Required]
-        public object Value { get; set; } = null!;
+        public object Value { get; set; }
 
         /// <summary>additional metadata extensions dictionary</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "extensions")]
@@ -1204,111 +1217,139 @@ namespace AutoRest.CSharp.V3.Input
     {
         /// <summary>a collection of items</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "arrays")]
-        public System.Collections.Generic.ICollection<ArraySchema>? Arrays { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ArraySchema> Arrays { get; set; } = new System.Collections.ObjectModel.Collection<ArraySchema>();
 
         /// <summary>an associative array (ie, dictionary, hashtable, etc)</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "dictionaries")]
-        public System.Collections.Generic.ICollection<DictionarySchema>? Dictionaries { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<DictionarySchema> Dictionaries { get; set; } = new System.Collections.ObjectModel.Collection<DictionarySchema>();
 
         /// <summary>a true or false value</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "booleans")]
-        public System.Collections.Generic.ICollection<BooleanSchema>? Booleans { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<BooleanSchema> Booleans { get; set; } = new System.Collections.ObjectModel.Collection<BooleanSchema>();
 
         /// <summary>a number value</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "numbers")]
-        public System.Collections.Generic.ICollection<NumberSchema>? Numbers { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<NumberSchema> Numbers { get; set; } = new System.Collections.ObjectModel.Collection<NumberSchema>();
 
         /// <summary>an object of some type</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "objects")]
-        public System.Collections.Generic.ICollection<ObjectSchema>? Objects { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ObjectSchema> Objects { get; set; } = new System.Collections.ObjectModel.Collection<ObjectSchema>();
 
         /// <summary>a string of characters</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "strings")]
-        public System.Collections.Generic.ICollection<StringSchema>? Strings { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<StringSchema> Strings { get; set; } = new System.Collections.ObjectModel.Collection<StringSchema>();
 
         /// <summary>UnixTime</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "unixtimes")]
-        public System.Collections.Generic.ICollection<UnixTimeSchema>? Unixtimes { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<UnixTimeSchema> Unixtimes { get; set; } = new System.Collections.ObjectModel.Collection<UnixTimeSchema>();
 
         /// <summary>ByteArray -- an array of bytes</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "byteArrays")]
-        public System.Collections.Generic.ICollection<ByteArraySchema>? ByteArrays { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ByteArraySchema> ByteArrays { get; set; } = new System.Collections.ObjectModel.Collection<ByteArraySchema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "streams")]
-        public System.Collections.Generic.ICollection<Schema>? Streams { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<Schema> Streams { get; set; } = new System.Collections.ObjectModel.Collection<Schema>();
 
         /// <summary>a single character</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "chars")]
-        public System.Collections.Generic.ICollection<CharSchema>? Chars { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<CharSchema> Chars { get; set; } = new System.Collections.ObjectModel.Collection<CharSchema>();
 
         /// <summary>a Date</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "dates")]
-        public System.Collections.Generic.ICollection<DateSchema>? Dates { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<DateSchema> Dates { get; set; } = new System.Collections.ObjectModel.Collection<DateSchema>();
 
         /// <summary>a DateTime</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "dateTimes")]
-        public System.Collections.Generic.ICollection<DateTimeSchema>? DateTimes { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<DateTimeSchema> DateTimes { get; set; } = new System.Collections.ObjectModel.Collection<DateTimeSchema>();
 
         /// <summary>a Duration</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "durations")]
-        public System.Collections.Generic.ICollection<DurationSchema>? Durations { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<DurationSchema> Durations { get; set; } = new System.Collections.ObjectModel.Collection<DurationSchema>();
 
         /// <summary>a universally unique identifier</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "uuids")]
-        public System.Collections.Generic.ICollection<UuidSchema>? Uuids { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<UuidSchema> Uuids { get; set; } = new System.Collections.ObjectModel.Collection<UuidSchema>();
 
         /// <summary>an URI of some kind</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "uris")]
-        public System.Collections.Generic.ICollection<UriSchema>? Uris { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<UriSchema> Uris { get; set; } = new System.Collections.ObjectModel.Collection<UriSchema>();
 
         /// <summary>a password or credential</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "credentials")]
-        public System.Collections.Generic.ICollection<CredentialSchema>? Credentials { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<CredentialSchema> Credentials { get; set; } = new System.Collections.ObjectModel.Collection<CredentialSchema>();
 
         /// <summary>OData Query</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "odataQueries")]
-        public System.Collections.Generic.ICollection<ODataQuerySchema>? OdataQueries { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ODataQuerySchema> OdataQueries { get; set; } = new System.Collections.ObjectModel.Collection<ODataQuerySchema>();
 
         /// <summary>- this is essentially can be thought of as an 'enum'
         /// that is a choice between one of several items, but an unspecified value is permitted.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "choices")]
-        public System.Collections.Generic.ICollection<ChoiceSchema>? Choices { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ChoiceSchema> Choices { get; set; } = new System.Collections.ObjectModel.Collection<ChoiceSchema>();
 
         /// <summary>- this is essentially can be thought of as an 'enum'
         /// that is a choice between one of several items, but an unknown value is not allowed.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "sealedChoices")]
-        public System.Collections.Generic.ICollection<SealedChoiceSchema>? SealedChoices { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<SealedChoiceSchema> SealedChoices { get; set; } = new System.Collections.ObjectModel.Collection<SealedChoiceSchema>();
 
         /// <summary>ie, when 'profile' is 'production', use '2018-01-01' for apiversion</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "conditionals")]
-        public System.Collections.Generic.ICollection<ConditionalSchema>? Conditionals { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ConditionalSchema> Conditionals { get; set; } = new System.Collections.ObjectModel.Collection<ConditionalSchema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "sealedConditionals")]
-        public System.Collections.Generic.ICollection<SealedConditionalSchema>? SealedConditionals { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<SealedConditionalSchema> SealedConditionals { get; set; } = new System.Collections.ObjectModel.Collection<SealedConditionalSchema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "flags")]
-        public System.Collections.Generic.ICollection<FlagSchema>? Flags { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<FlagSchema> Flags { get; set; } = new System.Collections.ObjectModel.Collection<FlagSchema>();
 
         /// <summary>a constant value</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "constants")]
-        public System.Collections.Generic.ICollection<ConstantSchema>? Constants { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ConstantSchema> Constants { get; set; } = new System.Collections.ObjectModel.Collection<ConstantSchema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "ors")]
-        public System.Collections.Generic.ICollection<OrSchema>? Ors { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<OrSchema> Ors { get; set; } = new System.Collections.ObjectModel.Collection<OrSchema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "xors")]
-        public System.Collections.Generic.ICollection<XorSchema>? Xors { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<XorSchema> Xors { get; set; } = new System.Collections.ObjectModel.Collection<XorSchema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "binaries")]
-        public System.Collections.Generic.ICollection<BinarySchema>? Binaries { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<BinarySchema> Binaries { get; set; } = new System.Collections.ObjectModel.Collection<BinarySchema>();
 
         /// <summary>it's possible that we just may make this an error
         /// in representation.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "unknowns")]
-        public System.Collections.Generic.ICollection<Schema>? Unknowns { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<Schema> Unknowns { get; set; } = new System.Collections.ObjectModel.Collection<Schema>();
 
         [YamlDotNet.Serialization.YamlMember(Alias = "groups")]
-        public System.Collections.Generic.ICollection<GroupSchema>? Groups { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<GroupSchema> Groups { get; set; } = new System.Collections.ObjectModel.Collection<GroupSchema>();
     }
 
     /// <summary>contact information</summary>
@@ -1337,7 +1378,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the nameof the license</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "name")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Name { get; set; } = null!;
+        public string Name { get; set; }
 
         /// <summary>an uri pointing to the full license text</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "url")]
@@ -1355,7 +1396,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>the title of this service.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "title")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Title { get; set; } = null!;
+        public string Title { get; set; }
 
         /// <summary>a text description of the service</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "description")]
@@ -1418,11 +1459,13 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>responses that indicate a successful call</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "responses")]
-        public System.Collections.Generic.ICollection<ServiceResponse>? Responses { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ServiceResponse> Responses { get; set; } = new System.Collections.ObjectModel.Collection<ServiceResponse>();
 
         /// <summary>responses that indicate a failed call</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "exceptions")]
-        public System.Collections.Generic.ICollection<ServiceResponse>? Exceptions { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ServiceResponse> Exceptions { get; set; } = new System.Collections.ObjectModel.Collection<ServiceResponse>();
 
         /// <summary>the apiVersion to use for a given profile name</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "profile")]
@@ -1434,7 +1477,8 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>API versions that this applies to. Undefined means all versions</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "apiVersions")]
-        public System.Collections.Generic.ICollection<ApiVersion>? ApiVersions { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ApiVersion> ApiVersions { get; set; } = new System.Collections.ObjectModel.Collection<ApiVersion>();
 
         /// <summary>deprecation information -- ie, when this aspect doesn't apply and why</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "deprecated")]
@@ -1464,11 +1508,13 @@ namespace AutoRest.CSharp.V3.Input
     {
         /// <summary>the parameter inputs to the operation</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "parameters")]
-        public System.Collections.Generic.ICollection<RequestParameter>? Parameters { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<RequestParameter> Parameters { get; set; } = new System.Collections.ObjectModel.Collection<RequestParameter>();
 
         /// <summary>a filtered list of parameters that is (assumably) the actual method signature parameters</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "signatureParameters")]
-        public System.Collections.Generic.ICollection<RequestParameter>? SignatureParameters { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<RequestParameter> SignatureParameters { get; set; } = new System.Collections.ObjectModel.Collection<RequestParameter>();
     }
 
     /// <summary>an operation group represents a container around set of operations</summary>
@@ -1477,7 +1523,7 @@ namespace AutoRest.CSharp.V3.Input
     {
         [YamlDotNet.Serialization.YamlMember(Alias = "$key")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Key { get; set; } = null!;
+        public string Key { get; set; }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "operations")]
         [System.ComponentModel.DataAnnotations.Required]
@@ -1867,12 +1913,12 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "authorizationUrl")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string AuthorizationUrl { get; set; } = null!;
+        public string AuthorizationUrl { get; set; }
 
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "tokenUrl")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string TokenUrl { get; set; } = null!;
+        public string TokenUrl { get; set; }
 
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "refreshUrl")]
@@ -1915,7 +1961,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "tokenUrl")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string TokenUrl { get; set; } = null!;
+        public string TokenUrl { get; set; }
 
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "refreshUrl")]
@@ -1936,7 +1982,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "authorizationUrl")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string AuthorizationUrl { get; set; } = null!;
+        public string AuthorizationUrl { get; set; }
 
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "refreshUrl")]
@@ -1956,7 +2002,7 @@ namespace AutoRest.CSharp.V3.Input
     {
         [YamlDotNet.Serialization.YamlMember(Alias = "scheme")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Scheme { get; set; } = null!;
+        public string Scheme { get; set; }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "description")]
         public string? Description { get; set; }
@@ -2010,13 +2056,27 @@ namespace AutoRest.CSharp.V3.Input
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
-    internal partial class HTTPSecurityScheme : System.Collections.Generic.Dictionary<string, object>
+    internal partial class HTTPSecurityScheme
     {
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
-    internal partial class SecurityScheme : System.Collections.Generic.Dictionary<string, object>
+    internal partial class SecurityScheme
     {
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
@@ -2028,7 +2088,7 @@ namespace AutoRest.CSharp.V3.Input
 
         [YamlDotNet.Serialization.YamlMember(Alias = "name")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Name { get; set; } = null!;
+        public string Name { get; set; }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "in")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
@@ -2052,7 +2112,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "openIdConnectUrl")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string OpenIdConnectUrl { get; set; } = null!;
+        public string OpenIdConnectUrl { get; set; }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "description")]
         public string? Description { get; set; }
@@ -2068,7 +2128,7 @@ namespace AutoRest.CSharp.V3.Input
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "tokenUrl")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string TokenUrl { get; set; } = null!;
+        public string TokenUrl { get; set; }
 
         /// <summary>an URI</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "refreshUrl")]
@@ -2120,12 +2180,12 @@ namespace AutoRest.CSharp.V3.Input
         /// When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "path")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Path { get; set; } = null!;
+        public string Path { get; set; }
 
         /// <summary>the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "uri")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Uri { get; set; } = null!;
+        public string Uri { get; set; }
 
         /// <summary>the HTTP Method used to process this operation</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "method")]
@@ -2192,12 +2252,12 @@ namespace AutoRest.CSharp.V3.Input
         /// When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "path")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Path { get; set; } = null!;
+        public string Path { get; set; }
 
         /// <summary>the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "uri")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Uri { get; set; } = null!;
+        public string Uri { get; set; }
 
         /// <summary>the HTTP Method used to process this operation</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "method")]
@@ -2210,7 +2270,7 @@ namespace AutoRest.CSharp.V3.Input
     {
         [YamlDotNet.Serialization.YamlMember(Alias = "header")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Header { get; set; } = null!;
+        public string Header { get; set; }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "schema")]
         [System.ComponentModel.DataAnnotations.Required]
@@ -2241,11 +2301,13 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>content returned by the service in the HTTP headers</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "headers")]
-        public System.Collections.Generic.ICollection<HttpResponseHeader>? Headers { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<HttpResponseHeader> Headers { get; set; } = new System.Collections.ObjectModel.Collection<HttpResponseHeader>();
 
         /// <summary>sets of HTTP headers grouped together into a single schema</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "headerGroups")]
-        public System.Collections.Generic.ICollection<GroupSchema>? HeaderGroups { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<GroupSchema> HeaderGroups { get; set; } = new System.Collections.ObjectModel.Collection<GroupSchema>();
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
@@ -2262,7 +2324,8 @@ namespace AutoRest.CSharp.V3.Input
     {
         /// <summary>a collection of security requirements for the service</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "security")]
-        public System.Collections.Generic.ICollection<SecurityRequirement>? Security { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<SecurityRequirement> Security { get; set; } = new System.Collections.ObjectModel.Collection<SecurityRequirement>();
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
@@ -2306,7 +2369,8 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>API versions that this applies to. Undefined means all versions</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "apiVersions")]
-        public System.Collections.Generic.ICollection<ApiVersion>? ApiVersions { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<ApiVersion> ApiVersions { get; set; } = new System.Collections.ObjectModel.Collection<ApiVersion>();
 
         /// <summary>deprecation information -- ie, when this aspect doesn't apply and why</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "deprecated")]
@@ -2382,7 +2446,8 @@ namespace AutoRest.CSharp.V3.Input
 
         /// <summary>all global parameters (ie, ImplementationLocation = client )</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "globalParameters")]
-        public System.Collections.Generic.ICollection<RequestParameter>? GlobalParameters { get; set; }
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<RequestParameter> GlobalParameters { get; set; } = new System.Collections.ObjectModel.Collection<RequestParameter>();
 
         /// <summary>per-language information for this aspect</summary>
         [YamlDotNet.Serialization.YamlMember(Alias = "language")]
@@ -2423,10 +2488,10 @@ namespace AutoRest.CSharp.V3.Input
     internal enum DateTimeSchemaFormat
     {
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        DateTime = 0,
+        Dateminustime = 0,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time-rfc1123")]
-        DateTimeRfc1123 = 1,
+        Dateminustimeminusrfc1123 = 1,
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]

--- a/src/AutoRest.CSharp.V3/Input/Generated/CodeModel.cs
+++ b/src/AutoRest.CSharp.V3/Input/Generated/CodeModel.cs
@@ -7,7 +7,6 @@
 namespace AutoRest.CSharp.V3.Input
 {
     #pragma warning disable // Disable all warnings
-    #nullable enable
 
     /// <summary>- since API version formats range from
     /// Azure ARM API date style (2018-01-01) to semver (1.2.3)
@@ -228,14 +227,6 @@ namespace AutoRest.CSharp.V3.Input
         [YamlDotNet.Serialization.YamlMember(Alias = "description")]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Description { get; set; }
-
-        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
-
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
@@ -266,7 +257,7 @@ namespace AutoRest.CSharp.V3.Input
         Boolean = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"byte-array")]
-        Byteminusarray = 4,
+        ByteArray = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"char")]
         Char = 5,
@@ -287,7 +278,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 10,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        Dateminustime = 11,
+        DateTime = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"dictionary")]
         Dictionary = 12,
@@ -314,16 +305,16 @@ namespace AutoRest.CSharp.V3.Input
         Object = 19,
 
         [System.Runtime.Serialization.EnumMember(Value = @"odata-query")]
-        Odataminusquery = 20,
+        OdataQuery = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"or")]
         Or = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-choice")]
-        Sealedminuschoice = 22,
+        SealedChoice = 22,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-conditional")]
-        Sealedminusconditional = 23,
+        SealedConditional = 23,
 
         [System.Runtime.Serialization.EnumMember(Value = @"string")]
         String = 24,
@@ -370,7 +361,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        Dateminustime = 4,
+        DateTime = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"duration")]
         Duration = 5,
@@ -404,7 +395,7 @@ namespace AutoRest.CSharp.V3.Input
         Boolean = 1,
 
         [System.Runtime.Serialization.EnumMember(Value = @"byte-array")]
-        Byteminusarray = 2,
+        ByteArray = 2,
 
         [System.Runtime.Serialization.EnumMember(Value = @"char")]
         Char = 3,
@@ -422,7 +413,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 7,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        Dateminustime = 8,
+        DateTime = 8,
 
         [System.Runtime.Serialization.EnumMember(Value = @"duration")]
         Duration = 9,
@@ -437,10 +428,10 @@ namespace AutoRest.CSharp.V3.Input
         Number = 12,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-choice")]
-        Sealedminuschoice = 13,
+        SealedChoice = 13,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-conditional")]
-        Sealedminusconditional = 14,
+        SealedConditional = 14,
 
         [System.Runtime.Serialization.EnumMember(Value = @"string")]
         String = 15,
@@ -485,7 +476,7 @@ namespace AutoRest.CSharp.V3.Input
         Boolean = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"byte-array")]
-        Byteminusarray = 4,
+        ByteArray = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"char")]
         Char = 5,
@@ -506,7 +497,7 @@ namespace AutoRest.CSharp.V3.Input
         Date = 10,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        Dateminustime = 11,
+        DateTime = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"dictionary")]
         Dictionary = 12,
@@ -533,16 +524,16 @@ namespace AutoRest.CSharp.V3.Input
         Object = 19,
 
         [System.Runtime.Serialization.EnumMember(Value = @"odata-query")]
-        Odataminusquery = 20,
+        OdataQuery = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"or")]
         Or = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-choice")]
-        Sealedminuschoice = 22,
+        SealedChoice = 22,
 
         [System.Runtime.Serialization.EnumMember(Value = @"sealed-conditional")]
-        Sealedminusconditional = 23,
+        SealedConditional = 23,
 
         [System.Runtime.Serialization.EnumMember(Value = @"string")]
         String = 24,
@@ -2058,25 +2049,11 @@ namespace AutoRest.CSharp.V3.Input
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
     internal partial class HTTPSecurityScheme
     {
-        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
-
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
     internal partial class SecurityScheme
     {
-        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
-
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]
@@ -2488,10 +2465,10 @@ namespace AutoRest.CSharp.V3.Input
     internal enum DateTimeSchemaFormat
     {
         [System.Runtime.Serialization.EnumMember(Value = @"date-time")]
-        Dateminustime = 0,
+        DateTime = 0,
 
         [System.Runtime.Serialization.EnumMember(Value = @"date-time-rfc1123")]
-        Dateminustimeminusrfc1123 = 1,
+        DateTimeRfc1123 = 1,
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.0.23.0 (Newtonsoft.Json v9.0.0.0)")]

--- a/src/AutoRest.CSharp.V3/Output/Builders/BuilderHelpers.cs
+++ b/src/AutoRest.CSharp.V3/Output/Builders/BuilderHelpers.cs
@@ -19,7 +19,6 @@ namespace AutoRest.CSharp.V3.Output.Builders
     {
         public static Constant StringConstant(string s) => ParseConstant(s, new CSharpType(typeof(string)));
 
-
         public static Constant ParseConstant(object? value, CSharpType type)
         {
             object? normalizedValue;

--- a/src/AutoRest.CSharp.V3/Output/Builders/ClientBuilder.cs
+++ b/src/AutoRest.CSharp.V3/Output/Builders/ClientBuilder.cs
@@ -132,7 +132,7 @@ namespace AutoRest.CSharp.V3.Output.Builders
         {
             HttpRequest? httpRequest = operation.Request.Protocol.Http as HttpRequest;
             //TODO: Handle multiple responses: https://github.com/Azure/autorest.csharp/issues/413
-            ServiceResponse? response = operation.Responses?.FirstOrDefault();
+            ServiceResponse? response = operation.Responses.FirstOrDefault();
             HttpResponse? httpResponse = response?.Protocol.Http as HttpResponse;
             if (httpRequest == null)
             {
@@ -147,7 +147,7 @@ namespace AutoRest.CSharp.V3.Output.Builders
             List<Parameter> methodParameters = new List<Parameter>();
 
             RequestBody? body = null;
-            foreach (RequestParameter requestParameter in operation.Request.Parameters ?? Array.Empty<RequestParameter>())
+            foreach (RequestParameter requestParameter in operation.Request.Parameters)
             {
                 string defaultName = requestParameter.Language.Default.Name;
                 string serializedName = requestParameter.Language.Default.SerializedName ?? defaultName;

--- a/src/AutoRest.CSharp.V3/Output/Models/Types/OutputLibrary.cs
+++ b/src/AutoRest.CSharp.V3/Output/Models/Types/OutputLibrary.cs
@@ -45,16 +45,16 @@ namespace AutoRest.CSharp.V3.Output.Models.Types
 
         private Dictionary<Schema, ISchemaType> BuildModels()
         {
-            var allSchemas = (_codeModel.Schemas.Choices ?? Enumerable.Empty<ChoiceSchema>()).Cast<Schema>()
-                .Concat(_codeModel.Schemas.SealedChoices ?? Enumerable.Empty<SealedChoiceSchema>())
-                .Concat(_codeModel.Schemas.Objects ?? Enumerable.Empty<ObjectSchema>());
+            var allSchemas = _codeModel.Schemas.Choices.Cast<Schema>()
+                .Concat(_codeModel.Schemas.SealedChoices)
+                .Concat(_codeModel.Schemas.Objects);
 
             return allSchemas.ToDictionary(schema => schema, BuildModel);
         }
 
         private ISchemaType BuildModel(Schema schema) => schema switch
         {
-            SealedChoiceSchema sealedChoiceSchema => new EnumType(sealedChoiceSchema, _context),
+            SealedChoiceSchema sealedChoiceSchema => (ISchemaType)new EnumType(sealedChoiceSchema, _context),
             ChoiceSchema choiceSchema => new EnumType(choiceSchema, _context),
             ObjectSchema objectSchema => new ObjectType(objectSchema, _context),
             _ => throw new NotImplementedException()
@@ -73,7 +73,7 @@ namespace AutoRest.CSharp.V3.Output.Models.Types
                         types.Add(bodyRequest.KnownMediaType);
                     }
 
-                    foreach (var response in operation.Responses ?? Array.Empty<ServiceResponse>())
+                    foreach (var response in operation.Responses)
                     {
                         if (response is SchemaResponse _ &&
                             response.Protocol.Http is HttpResponse httpResponse)

--- a/src/AutoRest.CodeModel/CustomEnumNameGenerator.cs
+++ b/src/AutoRest.CodeModel/CustomEnumNameGenerator.cs
@@ -11,6 +11,11 @@ namespace AutoRest.CodeModel
         private readonly DefaultEnumNameGenerator _defaultEnumNameGenerator = new DefaultEnumNameGenerator();
 
         public string Generate(int index, string name, object value, JsonSchema schema) =>
-            _defaultEnumNameGenerator.Generate(index, name.Replace("+", "plus").Replace("-", "minus"), value, schema);
+            _defaultEnumNameGenerator.Generate(
+                index,
+                // Fixes + and - enum values that cannot be generated into C# enum names
+                name.Equals("+") ? "plus" : name.Equals("-") ? "minus" : name,
+                value,
+                schema);
     }
 }

--- a/src/AutoRest.CodeModel/CustomEnumNameGenerator.cs
+++ b/src/AutoRest.CodeModel/CustomEnumNameGenerator.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+
+namespace AutoRest.CodeModel
+{
+    internal class CustomEnumNameGenerator : IEnumNameGenerator
+    {
+        private readonly DefaultEnumNameGenerator _defaultEnumNameGenerator = new DefaultEnumNameGenerator();
+
+        public string Generate(int index, string name, object value, JsonSchema schema) =>
+            _defaultEnumNameGenerator.Generate(index, name.Replace("+", "plus").Replace("-", "minus"), value, schema);
+    }
+}

--- a/src/AutoRest.CodeModel/CustomPropertyNameGenerator.cs
+++ b/src/AutoRest.CodeModel/CustomPropertyNameGenerator.cs
@@ -10,11 +10,13 @@ namespace AutoRest.CodeModel
     {
         public override string Generate(JsonSchemaProperty property)
         {
+            // Makes array type properties initialized with empty collections
             if (property.IsArray)
             {
                 property.IsRequired = true;
             }
 
+            // Cases CSharp properly
             if (property.Name == "csharp")
             {
                 return "CSharp";

--- a/src/AutoRest.CodeModel/CustomPropertyNameGenerator.cs
+++ b/src/AutoRest.CodeModel/CustomPropertyNameGenerator.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NJsonSchema;
+using NJsonSchema.CodeGeneration.CSharp;
+
+namespace AutoRest.CodeModel
+{
+    internal class CustomPropertyNameGenerator : CSharpPropertyNameGenerator
+    {
+        public override string Generate(JsonSchemaProperty property)
+        {
+            if (property.IsArray)
+            {
+                property.IsRequired = true;
+            }
+
+            if (property.Name == "csharp")
+            {
+                return "CSharp";
+            }
+            return base.Generate(property);
+        }
+    }
+}

--- a/src/AutoRest.CodeModel/CustomTypeNameGenerator.cs
+++ b/src/AutoRest.CodeModel/CustomTypeNameGenerator.cs
@@ -8,6 +8,7 @@ namespace AutoRest.CodeModel
 {
     internal class CustomTypeNameGenerator : DefaultTypeNameGenerator
     {
+        // Class names that conflict with project class names
         private static readonly Dictionary<string, string> RenameMap = new Dictionary<string, string>
         {
             { "HttpHeader", "HttpResponseHeader" },

--- a/src/AutoRest.CodeModel/CustomTypeNameGenerator.cs
+++ b/src/AutoRest.CodeModel/CustomTypeNameGenerator.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using NJsonSchema;
+
+namespace AutoRest.CodeModel
+{
+    internal class CustomTypeNameGenerator : DefaultTypeNameGenerator
+    {
+        private static readonly Dictionary<string, string> RenameMap = new Dictionary<string, string>
+        {
+            { "HttpHeader", "HttpResponseHeader" },
+            { "Parameter", "RequestParameter" },
+            { "Request", "ServiceRequest" },
+            { "Response", "ServiceResponse" },
+            { "SerializationFormat", "SerializationFormatMetadata" }
+        };
+
+        public override string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
+        {
+            if (RenameMap.ContainsKey(typeNameHint))
+            {
+                typeNameHint = RenameMap[typeNameHint];
+            }
+            return base.Generate(schema, typeNameHint, reservedTypeNames);
+        }
+    }
+}

--- a/src/AutoRest.CodeModel/Program.cs
+++ b/src/AutoRest.CodeModel/Program.cs
@@ -22,8 +22,8 @@ namespace AutoRest.CodeModel
             webClient.DownloadFile(@"https://raw.githubusercontent.com/Azure/perks/master/codemodel/.resources/all-in-one/json/code-model.json", "code-model.json");
 
             var schemaJson = File.ReadAllText("code-model.json")
-                // Fixes + and - enum values that cannot be generated into C# enum names
-                .Replace("\"+\"", "\"plus\"").Replace("\"-\"", "\"minus\"")
+                //// Fixes + and - enum values that cannot be generated into C# enum names
+                //.Replace("\"+\"", "\"plus\"").Replace("\"-\"", "\"minus\"")
                 // Makes Choices only have string values
                 .Replace("          \"type\": [\n            \"string\",\n            \"number\",\n            \"boolean\"\n          ]\n", $"          \"type\": \"string\"\n");
             var schema = JsonSchema.FromJsonAsync(schemaJson).GetAwaiter().GetResult();
@@ -31,7 +31,10 @@ namespace AutoRest.CodeModel
             {
                 Namespace = Namespace,
                 HandleReferences = true,
-                TypeAccessModifier = "internal"
+                TypeAccessModifier = "internal",
+                TypeNameGenerator = new CustomTypeNameGenerator(),
+                PropertyNameGenerator = new CustomPropertyNameGenerator(),
+                EnumNameGenerator = new CustomEnumNameGenerator()
             };
             var rawFile = new CSharpGenerator(schema, settings).GenerateFile();
             var cleanFile = String.Join(Environment.NewLine, rawFile.ToLines()
@@ -41,39 +44,39 @@ namespace AutoRest.CodeModel
                     .Select(l => Regex.Replace(l, @"(.*\[)Newtonsoft\.Json\.JsonProperty\((.*""),?.*(\)\])",
                         "$1YamlDotNet.Serialization.YamlMember(Alias = $2$3", RegexOptions.Singleline).TrimEnd()))
                 // Workaround for anyOf SecurityScheme types
-                .Replace($"        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();{Environment.NewLine}{Environment.NewLine}        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties{Environment.NewLine}        {{{Environment.NewLine}            get {{ return _additionalProperties; }}{Environment.NewLine}            set {{ _additionalProperties = value; }}{Environment.NewLine}        }}{Environment.NewLine}", String.Empty)
-                .Replace("class HTTPSecurityScheme", "class HTTPSecurityScheme : System.Collections.Generic.Dictionary<string, object>")
-                .Replace("class SecurityScheme", "class SecurityScheme : System.Collections.Generic.Dictionary<string, object>")
+                //.Replace($"        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();{Environment.NewLine}{Environment.NewLine}        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties{Environment.NewLine}        {{{Environment.NewLine}            get {{ return _additionalProperties; }}{Environment.NewLine}            set {{ _additionalProperties = value; }}{Environment.NewLine}        }}{Environment.NewLine}", String.Empty)
+                //.Replace("class HTTPSecurityScheme", "class HTTPSecurityScheme : System.Collections.Generic.Dictionary<string, object>")
+                //.Replace("class SecurityScheme", "class SecurityScheme : System.Collections.Generic.Dictionary<string, object>")
                 // Fixes stray blank lines from the C# generator
                 .Replace($"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}", Environment.NewLine)
                 .Replace($"{Environment.NewLine}{Environment.NewLine}    }}", $"{Environment.NewLine}    }}")
                 // Replaces the alias to correctly match the schema from the C# generation fix above
-                .Replace("\"plus\"", "\"+\"")
-                .Replace("\"minus\"", "\"-\"")
+                //.Replace("\"plus\"", "\"+\"")
+                //.Replace("\"minus\"", "\"-\"")
                 // Weird generation issue workaround
                 .Replace($"{Namespace}.bool.True", "true")
-                // Set properties to be single quoted
-                .Replace("Alias = \"version\"", "ScalarStyle = YamlDotNet.Core.ScalarStyle.SingleQuoted, Alias = \"version\"")
+                //// Set properties to be single quoted
+                //.Replace("Alias = \"version\"", "ScalarStyle = YamlDotNet.Core.ScalarStyle.SingleQuoted, Alias = \"version\"")
                 // Cases CSharp properly
-                .Replace("CSharpLanguage Csharp", "CSharpLanguage CSharp")
+                //.Replace("CSharpLanguage Csharp", "CSharpLanguage CSharp")
                 // Fix for issue with Solution Error Visualizer
                 // https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.SolutionErrorVisualizer&ssr=false#review-details
-                .Replace("#pragma warning disable // Disable all warnings", $"#pragma warning disable // Disable all warnings{Environment.NewLine}    #nullable enable")
+                .Replace("#pragma warning disable // Disable all warnings", $"#pragma warning disable // Disable all warnings{Environment.NewLine}    #nullable enable");
                 // Class names that conflict with project class names
-                .Replace("HttpHeader", "HttpResponseHeader")
-                .Replace("class Parameter", "class RequestParameter")
-                .Replace(": Parameter", ": RequestParameter")
-                .Replace("<Parameter>", "<RequestParameter>")
-                .Replace("public Parameter OriginalParameter { get; set; } = new Parameter();", "public RequestParameter OriginalParameter { get; set; } = new RequestParameter();")
-                .Replace("public Parameter GroupedBy", "public RequestParameter GroupedBy")
-                .Replace("class Request ", "class ServiceRequest ")
-                .Replace("public Request Request { get; set; } = new Request();", "public ServiceRequest Request { get; set; } = new ServiceRequest();")
-                .Replace("class Response ", "class ServiceResponse ")
-                .Replace(": Response", ": ServiceResponse")
-                .Replace("<Response>", "<ServiceResponse>")
-                .Replace($"class SerializationFormat{Environment.NewLine}", $"class SerializationFormatMetadata{Environment.NewLine}")
-                .Replace("public SerializationFormat ", "public SerializationFormatMetadata ")
-                .Replace(": SerializationFormat", ": SerializationFormatMetadata");
+                //.Replace("HttpHeader", "HttpResponseHeader")
+                //.Replace("class Parameter", "class RequestParameter")
+                //.Replace(": Parameter", ": RequestParameter")
+                //.Replace("<Parameter>", "<RequestParameter>")
+                //.Replace("public Parameter OriginalParameter { get; set; } = new Parameter();", "public RequestParameter OriginalParameter { get; set; } = new RequestParameter();")
+                //.Replace("public Parameter GroupedBy", "public RequestParameter GroupedBy")
+                //.Replace("class Request ", "class ServiceRequest ")
+                //.Replace("public Request Request { get; set; } = new Request();", "public ServiceRequest Request { get; set; } = new ServiceRequest();")
+                //.Replace("class Response ", "class ServiceResponse ")
+                //.Replace(": Response", ": ServiceResponse")
+                //.Replace("<Response>", "<ServiceResponse>")
+                //.Replace($"class SerializationFormat{Environment.NewLine}", $"class SerializationFormatMetadata{Environment.NewLine}")
+                //.Replace("public SerializationFormat ", "public SerializationFormatMetadata ")
+                //.Replace(": SerializationFormat", ": SerializationFormatMetadata");
 
             var lines = cleanFile.ToLines().ToArray();
             var fileWithNullable = String.Join(Environment.NewLine, lines.Zip(lines.Skip(1).Append(String.Empty))
@@ -84,30 +87,30 @@ namespace AutoRest.CodeModel
                 })
                 .SkipLast(1)
                 .Prepend(lines.First()));
-            var fileWithNullableFix = fileWithNullable
-                // Fix for issue with Solution Error Visualizer
-                // https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.SolutionErrorVisualizer&ssr=false#review-details
-                // https://stackoverflow.com/a/54973095/294804
-                .Replace("public string Version { get; set; }", "public string Version { get; set; } = null!;")
-                .Replace("public string Message { get; set; }", "public string Message { get; set; } = null!;")
-                .Replace("public string Url { get; set; }", "public string Url { get; set; } = null!;")
-                .Replace("public string Name { get; set; }", "public string Name { get; set; } = null!;")
-                .Replace("public string Description { get; set; }", "public string Description { get; set; } = null!;")
-                .Replace("public string Value { get; set; }", "public string Value { get; set; } = null!;")
-                .Replace("public string SerializedName { get; set; }", "public string SerializedName { get; set; } = null!;")
-                .Replace("public string Target { get; set; }", "public string Target { get; set; } = null!;")
-                .Replace("public string Source { get; set; }", "public string Source { get; set; } = null!;")
-                .Replace("public string Title { get; set; }", "public string Title { get; set; } = null!;")
-                .Replace("public string Key { get; set; }", "public string Key { get; set; } = null!;")
-                .Replace("public object Value { get; set; }", "public object Value { get; set; } = null!;")
-                .Replace("public string AuthorizationUrl { get; set; }", "public string AuthorizationUrl { get; set; } = null!;")
-                .Replace("public string TokenUrl { get; set; }", "public string TokenUrl { get; set; } = null!;")
-                .Replace("public string Scheme { get; set; }", "public string Scheme { get; set; } = null!;")
-                .Replace("public string OpenIdConnectUrl { get; set; }", "public string OpenIdConnectUrl { get; set; } = null!;")
-                .Replace("public string Path { get; set; }", "public string Path { get; set; } = null!;")
-                .Replace("public string Uri { get; set; }", "public string Uri { get; set; } = null!;")
-                .Replace("public string Header { get; set; }", "public string Header { get; set; } = null!;");
-            File.WriteAllText($"../../src/{Path}/CodeModel.cs", fileWithNullableFix);
+            //var fileWithNullableFix = fileWithNullable
+            //    // Fix for issue with Solution Error Visualizer
+            //    // https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.SolutionErrorVisualizer&ssr=false#review-details
+            //    // https://stackoverflow.com/a/54973095/294804
+            //    .Replace("public string Version { get; set; }", "public string Version { get; set; } = null!;")
+            //    .Replace("public string Message { get; set; }", "public string Message { get; set; } = null!;")
+            //    .Replace("public string Url { get; set; }", "public string Url { get; set; } = null!;")
+            //    .Replace("public string Name { get; set; }", "public string Name { get; set; } = null!;")
+            //    .Replace("public string Description { get; set; }", "public string Description { get; set; } = null!;")
+            //    .Replace("public string Value { get; set; }", "public string Value { get; set; } = null!;")
+            //    .Replace("public string SerializedName { get; set; }", "public string SerializedName { get; set; } = null!;")
+            //    .Replace("public string Target { get; set; }", "public string Target { get; set; } = null!;")
+            //    .Replace("public string Source { get; set; }", "public string Source { get; set; } = null!;")
+            //    .Replace("public string Title { get; set; }", "public string Title { get; set; } = null!;")
+            //    .Replace("public string Key { get; set; }", "public string Key { get; set; } = null!;")
+            //    .Replace("public object Value { get; set; }", "public object Value { get; set; } = null!;")
+            //    .Replace("public string AuthorizationUrl { get; set; }", "public string AuthorizationUrl { get; set; } = null!;")
+            //    .Replace("public string TokenUrl { get; set; }", "public string TokenUrl { get; set; } = null!;")
+            //    .Replace("public string Scheme { get; set; }", "public string Scheme { get; set; } = null!;")
+            //    .Replace("public string OpenIdConnectUrl { get; set; }", "public string OpenIdConnectUrl { get; set; } = null!;")
+            //    .Replace("public string Path { get; set; }", "public string Path { get; set; } = null!;")
+            //    .Replace("public string Uri { get; set; }", "public string Uri { get; set; } = null!;")
+            //    .Replace("public string Header { get; set; }", "public string Header { get; set; } = null!;");
+            File.WriteAllText($"../../src/{Path}/CodeModel.cs", fileWithNullable);
         }
     }
 }

--- a/src/AutoRest.CodeModel/Program.cs
+++ b/src/AutoRest.CodeModel/Program.cs
@@ -22,10 +22,9 @@ namespace AutoRest.CodeModel
             webClient.DownloadFile(@"https://raw.githubusercontent.com/Azure/perks/master/codemodel/.resources/all-in-one/json/code-model.json", "code-model.json");
 
             var schemaJson = File.ReadAllText("code-model.json")
-                //// Fixes + and - enum values that cannot be generated into C# enum names
-                //.Replace("\"+\"", "\"plus\"").Replace("\"-\"", "\"minus\"")
                 // Makes Choices only have string values
                 .Replace("          \"type\": [\n            \"string\",\n            \"number\",\n            \"boolean\"\n          ]\n", $"          \"type\": \"string\"\n");
+
             var schema = JsonSchema.FromJsonAsync(schemaJson).GetAwaiter().GetResult();
             var settings = new CSharpGeneratorSettings
             {
@@ -43,40 +42,13 @@ namespace AutoRest.CodeModel
                                 && !l.Contains("Newtonsoft.Json.JsonExtensionData"))
                     .Select(l => Regex.Replace(l, @"(.*\[)Newtonsoft\.Json\.JsonProperty\((.*""),?.*(\)\])",
                         "$1YamlDotNet.Serialization.YamlMember(Alias = $2$3", RegexOptions.Singleline).TrimEnd()))
-                // Workaround for anyOf SecurityScheme types
-                //.Replace($"        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();{Environment.NewLine}{Environment.NewLine}        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties{Environment.NewLine}        {{{Environment.NewLine}            get {{ return _additionalProperties; }}{Environment.NewLine}            set {{ _additionalProperties = value; }}{Environment.NewLine}        }}{Environment.NewLine}", String.Empty)
-                //.Replace("class HTTPSecurityScheme", "class HTTPSecurityScheme : System.Collections.Generic.Dictionary<string, object>")
-                //.Replace("class SecurityScheme", "class SecurityScheme : System.Collections.Generic.Dictionary<string, object>")
+                // Removes AdditionalProperties property from types as they are required to derive from IDictionary<string, object> for deserialization to work properly
+                .Replace($"        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();{Environment.NewLine}{Environment.NewLine}        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties{Environment.NewLine}        {{{Environment.NewLine}            get {{ return _additionalProperties; }}{Environment.NewLine}            set {{ _additionalProperties = value; }}{Environment.NewLine}        }}{Environment.NewLine}", String.Empty)
                 // Fixes stray blank lines from the C# generator
                 .Replace($"{Environment.NewLine}{Environment.NewLine}{Environment.NewLine}", Environment.NewLine)
                 .Replace($"{Environment.NewLine}{Environment.NewLine}    }}", $"{Environment.NewLine}    }}")
-                // Replaces the alias to correctly match the schema from the C# generation fix above
-                //.Replace("\"plus\"", "\"+\"")
-                //.Replace("\"minus\"", "\"-\"")
                 // Weird generation issue workaround
-                .Replace($"{Namespace}.bool.True", "true")
-                //// Set properties to be single quoted
-                //.Replace("Alias = \"version\"", "ScalarStyle = YamlDotNet.Core.ScalarStyle.SingleQuoted, Alias = \"version\"")
-                // Cases CSharp properly
-                //.Replace("CSharpLanguage Csharp", "CSharpLanguage CSharp")
-                // Fix for issue with Solution Error Visualizer
-                // https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.SolutionErrorVisualizer&ssr=false#review-details
-                .Replace("#pragma warning disable // Disable all warnings", $"#pragma warning disable // Disable all warnings{Environment.NewLine}    #nullable enable");
-                // Class names that conflict with project class names
-                //.Replace("HttpHeader", "HttpResponseHeader")
-                //.Replace("class Parameter", "class RequestParameter")
-                //.Replace(": Parameter", ": RequestParameter")
-                //.Replace("<Parameter>", "<RequestParameter>")
-                //.Replace("public Parameter OriginalParameter { get; set; } = new Parameter();", "public RequestParameter OriginalParameter { get; set; } = new RequestParameter();")
-                //.Replace("public Parameter GroupedBy", "public RequestParameter GroupedBy")
-                //.Replace("class Request ", "class ServiceRequest ")
-                //.Replace("public Request Request { get; set; } = new Request();", "public ServiceRequest Request { get; set; } = new ServiceRequest();")
-                //.Replace("class Response ", "class ServiceResponse ")
-                //.Replace(": Response", ": ServiceResponse")
-                //.Replace("<Response>", "<ServiceResponse>")
-                //.Replace($"class SerializationFormat{Environment.NewLine}", $"class SerializationFormatMetadata{Environment.NewLine}")
-                //.Replace("public SerializationFormat ", "public SerializationFormatMetadata ")
-                //.Replace(": SerializationFormat", ": SerializationFormatMetadata");
+                .Replace($"{Namespace}.bool.True", "true");
 
             var lines = cleanFile.ToLines().ToArray();
             var fileWithNullable = String.Join(Environment.NewLine, lines.Zip(lines.Skip(1).Append(String.Empty))
@@ -87,29 +59,6 @@ namespace AutoRest.CodeModel
                 })
                 .SkipLast(1)
                 .Prepend(lines.First()));
-            //var fileWithNullableFix = fileWithNullable
-            //    // Fix for issue with Solution Error Visualizer
-            //    // https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.SolutionErrorVisualizer&ssr=false#review-details
-            //    // https://stackoverflow.com/a/54973095/294804
-            //    .Replace("public string Version { get; set; }", "public string Version { get; set; } = null!;")
-            //    .Replace("public string Message { get; set; }", "public string Message { get; set; } = null!;")
-            //    .Replace("public string Url { get; set; }", "public string Url { get; set; } = null!;")
-            //    .Replace("public string Name { get; set; }", "public string Name { get; set; } = null!;")
-            //    .Replace("public string Description { get; set; }", "public string Description { get; set; } = null!;")
-            //    .Replace("public string Value { get; set; }", "public string Value { get; set; } = null!;")
-            //    .Replace("public string SerializedName { get; set; }", "public string SerializedName { get; set; } = null!;")
-            //    .Replace("public string Target { get; set; }", "public string Target { get; set; } = null!;")
-            //    .Replace("public string Source { get; set; }", "public string Source { get; set; } = null!;")
-            //    .Replace("public string Title { get; set; }", "public string Title { get; set; } = null!;")
-            //    .Replace("public string Key { get; set; }", "public string Key { get; set; } = null!;")
-            //    .Replace("public object Value { get; set; }", "public object Value { get; set; } = null!;")
-            //    .Replace("public string AuthorizationUrl { get; set; }", "public string AuthorizationUrl { get; set; } = null!;")
-            //    .Replace("public string TokenUrl { get; set; }", "public string TokenUrl { get; set; } = null!;")
-            //    .Replace("public string Scheme { get; set; }", "public string Scheme { get; set; } = null!;")
-            //    .Replace("public string OpenIdConnectUrl { get; set; }", "public string OpenIdConnectUrl { get; set; } = null!;")
-            //    .Replace("public string Path { get; set; }", "public string Path { get; set; } = null!;")
-            //    .Replace("public string Uri { get; set; }", "public string Uri { get; set; } = null!;")
-            //    .Replace("public string Header { get; set; }", "public string Header { get; set; } = null!;");
             File.WriteAllText($"../../src/{Path}/CodeModel.cs", fileWithNullable);
         }
     }


### PR DESCRIPTION
- Removed nullable references on collection types and have them initialized as empty collections
- Used NameGenerators to do some of the modifications instead of string or regex
- I removed my dumb code to work around that Visual Studio extension issue (I simply removed the extension)