### PR TITLE
Update paging to use new m4 data

### DIFF
--- a/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ClientWriter.cs
@@ -281,7 +281,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
             }
         }
 
-        private void WritePagingOperation(CodeWriter writer, Paging pagingMethod, bool async)
+        private void WritePagingOperation(CodeWriter writer, PagingInfo pagingMethod, bool async)
         {
             var pageType = pagingMethod.ItemType;
             CSharpType responseType = async ? new CSharpType(typeof(AsyncPageable<>), pageType) : new CSharpType(typeof(Pageable<>), pageType);

--- a/src/AutoRest.CSharp.V3/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp.V3/Input/CodeModelPartials.cs
@@ -46,6 +46,24 @@ namespace AutoRest.CSharp.V3.Input
 
     }
 
+    internal partial class Paging
+    {
+        [YamlMember(Alias = "group")]
+        public string? Group { get; set; }
+
+        [YamlMember(Alias = "itemName")]
+        public string? ItemName { get; set; }
+
+        [YamlMember(Alias = "member")]
+        public string? Member { get; set; }
+
+        [YamlMember(Alias = "nextLinkName")]
+        public string? NextLinkName { get; set; }
+
+        [YamlMember(Alias = "nextLinkOperation")]
+        public Operation? NextLinkOperation { get; set; }
+    }
+
     /// <summary>language metadata specific to schema instances</summary>
     internal partial class Language : IDictionary<string, object>
     {
@@ -65,6 +83,9 @@ namespace AutoRest.CSharp.V3.Input
 
         [YamlMember(Alias = "serializedName")]
         public string? SerializedName { get; set; }
+
+        [YamlMember(Alias = "paging")]
+        public Paging? Paging { get; set; }
 
         [YamlIgnore]
         public IDictionary<string, object> AdditionalProperties = new Dictionary<string, object>();

--- a/src/AutoRest.CSharp.V3/Output/Builders/ClientBuilder.cs
+++ b/src/AutoRest.CSharp.V3/Output/Builders/ClientBuilder.cs
@@ -50,69 +50,64 @@ namespace AutoRest.CSharp.V3.Output.Builders
             }
 
             string clientName = operationGroup.CSharpName();
-            Dictionary<string, OperationMethod> processedMethods = new Dictionary<string, OperationMethod>(StringComparer.InvariantCultureIgnoreCase);
+            Dictionary<string, OperationMethod> operationMethods = new Dictionary<string, OperationMethod>(StringComparer.InvariantCultureIgnoreCase);
             foreach (Operation operation in operationGroup.Operations)
             {
                 Method? method = BuildMethod(operation, clientName, clientParameters);
                 if (method != null)
                 {
-                    processedMethods.Add(operation.Language.Default.Name, new OperationMethod(operation, method));
+                    operationMethods.Add(operation.Language.Default.Name, new OperationMethod(operation, method));
                 }
             }
 
             List<Method> nextPageMethods = new List<Method>();
-            List<Paging> pagingMethods = new List<Paging>();
+            List<PagingInfo> pagingMethods = new List<PagingInfo>();
             List<LongRunningOperation> longRunningOperationMethods = new List<LongRunningOperation>();
-            foreach ((string processedName, OperationMethod processed) in processedMethods)
+            foreach ((string operationName, (Operation operation, Method method)) in operationMethods)
             {
-                IDictionary<object, object>? pageable = processed.Operation.Extensions.GetValue<IDictionary<object, object>>("x-ms-pageable");
-                if (pageable != null)
+                Paging? paging = operation.Language.Default.Paging;
+                if (paging != null)
                 {
-                    //TODO: Assuming operationName is in this operation group: https://github.com/Azure/autorest.modelerfour/issues/85
-                    string? extensionOperationName = pageable.GetValue<string>("operationName");
-                    string? operationName = extensionOperationName?.Split('_').Last();
-
-                    OperationMethod? next = null;
-                    if (operationName != null)
+                    Method? next = null;
+                    if (paging.NextLinkOperation != null)
                     {
-                        if (!processedMethods.TryGetValue(operationName, out OperationMethod? nextOperationMethod))
+                        //TODO: This assumes the operation is within this operationGroup
+                        string nextOperationName = paging.NextLinkOperation.Language.Default.Name;
+                        if (!operationMethods.TryGetValue(nextOperationName, out OperationMethod? nextOperationMethod))
                         {
-                            throw new Exception(
-                                $"The x-ms-pageable operationName \"{extensionOperationName}\" for operation {operationGroup.Key}_{processedName} was not found.");
+                            throw new Exception($"The x-ms-pageable operationName \"{paging.Group}_{paging.Member}\" for operation {operationGroup.Key}_{operation.Language.Default.Name} was not found.");
                         }
 
-                        next = nextOperationMethod;
+                        next = nextOperationMethod.Method;
                     }
                     // If there is no operationName or we didn't find an existing operation, we use the original method to construct the nextPageMethod.
-                    Method nextPageMethod = next?.Method ?? BuildNextPageMethod(processed.Method);
+                    Method nextPageMethod = next ?? BuildNextPageMethod(method);
                     // Only add the method if it didn't previously exist
                     if (next == null)
                     {
                         nextPageMethods.Add(nextPageMethod);
                     }
 
-                    if (!(processed.Method.Response.ResponseBody is ObjectResponseBody objectResponseBody))
+                    if (!(method.Response.ResponseBody is ObjectResponseBody objectResponseBody))
                     {
-                        throw new InvalidOperationException($"Method {processed.Method.Name} has to have a return value");
+                        throw new InvalidOperationException($"Method {method.Name} has to have a return value");
                     }
 
-                    var type = objectResponseBody.Type;
-                    var implementation = type.Implementation;
+                    ITypeProvider implementation = objectResponseBody.Type.Implementation;
                     if (!(implementation is ObjectType objectType))
                     {
-                        throw new InvalidOperationException($"The return type of {processed.Method.Name} has to be and object schema to be used in paging");
+                        throw new InvalidOperationException($"The return type of {method.Name} has to be and object schema to be used in paging");
                     }
 
-                    Paging pagingMethod = GetClientMethodPaging(processed.Method, nextPageMethod, pageable, objectType);
-                    pagingMethods.Add(pagingMethod);
+                    PagingInfo pagingInfo = GetPagingInfo(method, nextPageMethod, paging, objectType);
+                    pagingMethods.Add(pagingInfo);
                 }
                 // For some reason, booleans in dictionaries are deserialized as string instead of bool.
-                bool longRunningOperation = Convert.ToBoolean(processed.Operation.Extensions.GetValue<string>("x-ms-long-running-operation") ?? "false");
-                if (longRunningOperation && pageable == null)
+                bool longRunningOperation = Convert.ToBoolean(operation.Extensions.GetValue<string>("x-ms-long-running-operation") ?? "false");
+                if (longRunningOperation && paging == null)
                 {
-                    Method method = processed.Method;
-                    Response originalResponse = processed.Method.Response;
-                    processedMethods[processedName].Method = new Method(
+                    Response originalResponse = method.Response;
+                    operationMethods[operationName].Method = new Method(
                         method.Name,
                         method.Description,
                         method.Request,
@@ -121,14 +116,14 @@ namespace AutoRest.CSharp.V3.Output.Builders
                         method.Diagnostics
                     );
 
-                    IDictionary<object, object> options = processed.Operation.Extensions.GetValue<IDictionary<object, object>>("x-ms-long-running-operation-options")
+                    IDictionary<object, object> options = operation.Extensions.GetValue<IDictionary<object, object>>("x-ms-long-running-operation-options")
                                                           ?? ImmutableDictionary<object, object>.Empty;
                     LongRunningOperation longRunningOperationMethod = BuildLongRunningOperation(method, originalResponse, options);
                     longRunningOperationMethods.Add(longRunningOperationMethod);
                 }
             }
 
-            Method[] methods = processedMethods.Select(om => om.Value.Method).Concat(nextPageMethods).ToArray();
+            Method[] methods = operationMethods.Select(om => om.Value.Method).Concat(nextPageMethods).ToArray();
             return new Client(
                 BuilderHelpers.CreateTypeAttributes(clientName, _context.DefaultNamespace, Accessibility.Internal),
                 operationGroup.Language.Default.Description,
@@ -144,6 +139,12 @@ namespace AutoRest.CSharp.V3.Output.Builders
             {
                 Operation = operation;
                 Method = method;
+            }
+
+            public void Deconstruct(out Operation operation, out Method method)
+            {
+                operation = Operation;
+                method = Method;
             }
 
             public Operation Operation { get; }
@@ -312,12 +313,12 @@ namespace AutoRest.CSharp.V3.Output.Builders
                 method.Diagnostics);
         }
 
-        private Paging GetClientMethodPaging(Method method, Method nextPageMethod, IDictionary<object, object> pageable, ObjectType type)
+        private PagingInfo GetPagingInfo(Method method, Method nextPageMethod, Paging paging, ObjectType type)
         {
-            var nextLinkName = pageable.GetValue<string>("nextLinkName");
-            var itemName = pageable.GetValue<string>("itemName") ?? "value";
+            string? nextLinkName = paging.NextLinkName;
+            string itemName = paging.ItemName ?? "value";
 
-            var itemProperty = type.GetPropertyBySerializedName(itemName);
+            ObjectTypeProperty itemProperty = type.GetPropertyBySerializedName(itemName);
 
             ObjectTypeProperty? nextLinkProperty = null;
             if (nextLinkName != null)
@@ -327,15 +328,13 @@ namespace AutoRest.CSharp.V3.Output.Builders
 
             if (itemProperty.SchemaProperty.Schema is ArraySchema arraySchema)
             {
-                var itemType = _typeFactory.CreateType(arraySchema.ElementType, false);
+                CSharpType itemType = _typeFactory.CreateType(arraySchema.ElementType, false);
 
-                var name = $"{method.Name}Pageable";
-                return new Paging(method, nextPageMethod, name, nextLinkProperty?.DeclarationOptions.Name, itemProperty.DeclarationOptions.Name, itemType);
+                string name = $"{method.Name}Pageable";
+                return new PagingInfo(method, nextPageMethod, name, nextLinkProperty?.DeclarationOptions.Name, itemProperty.DeclarationOptions.Name, itemType);
             }
-            else
-            {
-                throw new InvalidOperationException($"{itemName} property has to be an array schema, actual {itemProperty.SchemaProperty}");
-            }
+
+            throw new InvalidOperationException($"{itemName} property has to be an array schema, actual {itemProperty.SchemaProperty}");
         }
 
         private static LongRunningOperation BuildLongRunningOperation(Method method, Response originalResponse, IDictionary<object, object> options)

--- a/src/AutoRest.CSharp.V3/Output/Models/Client.cs
+++ b/src/AutoRest.CSharp.V3/Output/Models/Client.cs
@@ -10,7 +10,7 @@ namespace AutoRest.CSharp.V3.Output.Models
 {
     internal class Client: ITypeProvider
     {
-        public Client(TypeDeclarationOptions declaredType, string description, Parameter[] parameters, Method[] methods, Paging[] pagingMethods, LongRunningOperation[] longRunningOperationMethods)
+        public Client(TypeDeclarationOptions declaredType, string description, Parameter[] parameters, Method[] methods, PagingInfo[] pagingMethods, LongRunningOperation[] longRunningOperationMethods)
         {
             DeclaredType = declaredType;
             Parameters = parameters;
@@ -22,7 +22,7 @@ namespace AutoRest.CSharp.V3.Output.Models
 
         public string Description { get; }
         public Method[] Methods { get; }
-        public Paging[] PagingMethods { get; }
+        public PagingInfo[] PagingMethods { get; }
         public LongRunningOperation[] LongRunningOperationMethods { get; }
         public TypeDeclarationOptions DeclaredType { get; }
         public Parameter[] Parameters { get; }

--- a/src/AutoRest.CSharp.V3/Output/Models/Requests/PagingInfo.cs
+++ b/src/AutoRest.CSharp.V3/Output/Models/Requests/PagingInfo.cs
@@ -6,9 +6,9 @@ using AutoRest.CSharp.V3.Generation.Types;
 
 namespace AutoRest.CSharp.V3.Output.Models.Requests
 {
-    internal class Paging
+    internal class PagingInfo
     {
-        public Paging(Method method, Method nextPageMethod, string name, string? nextLinkName, string itemName, CSharpType itemType)
+        public PagingInfo(Method method, Method nextPageMethod, string name, string? nextLinkName, string itemName, CSharpType itemType)
         {
             Method = method;
             NextPageMethod = nextPageMethod;

--- a/test/TestServerProjects/paging/Generated/Operations/PagingOperations.cs
+++ b/test/TestServerProjects/paging/Generated/Operations/PagingOperations.cs
@@ -2308,6 +2308,162 @@ namespace paging
                 throw;
             }
         }
+        internal HttpMessage CreateNextFragmentNextPageRequest(string nextLink)
+        {
+            var message = pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethodAdditional.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(nextLink, false);
+            request.Uri = uri;
+            return message;
+        }
+        /// <summary> A paging operation that doesn&apos;t return a full URL, just a fragment. </summary>
+        /// <param name="nextLink"> The URL to the next page of results. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        public async ValueTask<Response<OdataProductResult>> NextFragmentNextPageAsync(string nextLink, CancellationToken cancellationToken = default)
+        {
+            if (nextLink == null)
+            {
+                throw new ArgumentNullException(nameof(nextLink));
+            }
+
+            using var scope = clientDiagnostics.CreateScope("PagingOperations.NextFragment");
+            scope.Start();
+            try
+            {
+                using var message = CreateNextFragmentNextPageRequest(nextLink);
+                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                switch (message.Response.Status)
+                {
+                    case 200:
+                        {
+                            using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                            var value = OdataProductResult.DeserializeOdataProductResult(document.RootElement);
+                            return Response.FromValue(value, message.Response);
+                        }
+                    default:
+                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                }
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+        /// <summary> A paging operation that doesn&apos;t return a full URL, just a fragment. </summary>
+        /// <param name="nextLink"> The URL to the next page of results. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        public Response<OdataProductResult> NextFragmentNextPage(string nextLink, CancellationToken cancellationToken = default)
+        {
+            if (nextLink == null)
+            {
+                throw new ArgumentNullException(nameof(nextLink));
+            }
+
+            using var scope = clientDiagnostics.CreateScope("PagingOperations.NextFragment");
+            scope.Start();
+            try
+            {
+                using var message = CreateNextFragmentNextPageRequest(nextLink);
+                pipeline.Send(message, cancellationToken);
+                switch (message.Response.Status)
+                {
+                    case 200:
+                        {
+                            using var document = JsonDocument.Parse(message.Response.ContentStream);
+                            var value = OdataProductResult.DeserializeOdataProductResult(document.RootElement);
+                            return Response.FromValue(value, message.Response);
+                        }
+                    default:
+                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                }
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+        internal HttpMessage CreateNextFragmentWithGroupingNextPageRequest(string nextLink)
+        {
+            var message = pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethodAdditional.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(nextLink, false);
+            request.Uri = uri;
+            return message;
+        }
+        /// <summary> A paging operation that doesn&apos;t return a full URL, just a fragment. </summary>
+        /// <param name="nextLink"> The URL to the next page of results. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        public async ValueTask<Response<OdataProductResult>> NextFragmentWithGroupingNextPageAsync(string nextLink, CancellationToken cancellationToken = default)
+        {
+            if (nextLink == null)
+            {
+                throw new ArgumentNullException(nameof(nextLink));
+            }
+
+            using var scope = clientDiagnostics.CreateScope("PagingOperations.NextFragmentWithGrouping");
+            scope.Start();
+            try
+            {
+                using var message = CreateNextFragmentWithGroupingNextPageRequest(nextLink);
+                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                switch (message.Response.Status)
+                {
+                    case 200:
+                        {
+                            using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                            var value = OdataProductResult.DeserializeOdataProductResult(document.RootElement);
+                            return Response.FromValue(value, message.Response);
+                        }
+                    default:
+                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                }
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+        /// <summary> A paging operation that doesn&apos;t return a full URL, just a fragment. </summary>
+        /// <param name="nextLink"> The URL to the next page of results. </param>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        public Response<OdataProductResult> NextFragmentWithGroupingNextPage(string nextLink, CancellationToken cancellationToken = default)
+        {
+            if (nextLink == null)
+            {
+                throw new ArgumentNullException(nameof(nextLink));
+            }
+
+            using var scope = clientDiagnostics.CreateScope("PagingOperations.NextFragmentWithGrouping");
+            scope.Start();
+            try
+            {
+                using var message = CreateNextFragmentWithGroupingNextPageRequest(nextLink);
+                pipeline.Send(message, cancellationToken);
+                switch (message.Response.Status)
+                {
+                    case 200:
+                        {
+                            using var document = JsonDocument.Parse(message.Response.ContentStream);
+                            var value = OdataProductResult.DeserializeOdataProductResult(document.RootElement);
+                            return Response.FromValue(value, message.Response);
+                        }
+                    default:
+                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                }
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
         /// <summary> A paging operation that must return result of the default &apos;value&apos; node. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public AsyncPageable<Product> GetNoItemNamePagesPageableAsync(CancellationToken cancellationToken = default)
@@ -2853,7 +3009,7 @@ namespace paging
             }
             async Task<Page<Product>> NextPageFunc(string nextLink, int? pageSizeHint)
             {
-                var response = await NextFragmentAsync(apiVersion, tenant, nextLink, cancellationToken).ConfigureAwait(false);
+                var response = await NextFragmentNextPageAsync(nextLink, cancellationToken).ConfigureAwait(false);
                 return Page.FromValues(response.Value.Values, response.Value.OdataNextLink, response.GetRawResponse());
             }
             return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc);
@@ -2885,7 +3041,7 @@ namespace paging
             }
             Page<Product> NextPageFunc(string nextLink, int? pageSizeHint)
             {
-                var response = NextFragment(apiVersion, tenant, nextLink, cancellationToken);
+                var response = NextFragmentNextPage(nextLink, cancellationToken);
                 return Page.FromValues(response.Value.Values, response.Value.OdataNextLink, response.GetRawResponse());
             }
             return PageableHelpers.CreateEnumerable(FirstPageFunc, NextPageFunc);
@@ -2917,7 +3073,7 @@ namespace paging
             }
             async Task<Page<Product>> NextPageFunc(string nextLink, int? pageSizeHint)
             {
-                var response = await NextFragmentWithGroupingAsync(apiVersion, tenant, nextLink, cancellationToken).ConfigureAwait(false);
+                var response = await NextFragmentWithGroupingNextPageAsync(nextLink, cancellationToken).ConfigureAwait(false);
                 return Page.FromValues(response.Value.Values, response.Value.OdataNextLink, response.GetRawResponse());
             }
             return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc);
@@ -2949,7 +3105,7 @@ namespace paging
             }
             Page<Product> NextPageFunc(string nextLink, int? pageSizeHint)
             {
-                var response = NextFragmentWithGrouping(apiVersion, tenant, nextLink, cancellationToken);
+                var response = NextFragmentWithGroupingNextPage(nextLink, cancellationToken);
                 return Page.FromValues(response.Value.Values, response.Value.OdataNextLink, response.GetRawResponse());
             }
             return PageableHelpers.CreateEnumerable(FirstPageFunc, NextPageFunc);


### PR DESCRIPTION
Replaced the paging implementation that used the x-ms-pageable extension information. Now, it uses the paging node in language.default.