### PR TITLE
LRO update and fixes

### DIFF
--- a/src/assets/Generator.Shared/ArmOperationHelpers.cs
+++ b/src/assets/Generator.Shared/ArmOperationHelpers.cs
@@ -99,14 +99,7 @@ namespace Azure.Core
                 _requestMethod = requestMethod;
                 _originalUri = originalUri;
                 _finalStateVia = finalStateVia;
-                //_headerFrom = GetHeaderFrom();
                 InitializeScenarioInfo();
-                //InitializeScenarioInfo(originalUri, finalStateVia);
-                //if ((requestMethod != RequestMethod.Put && (_headerFrom == HeaderFrom.None || !_hasLocation)) || finalStateVia == OperationFinalStateVia.AzureAsyncOperation)
-                //{
-                //    // Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447
-                //    throw clientDiagnostics.CreateRequestFailedException(originalResponse);
-                //}
 
                 _pipeline = pipeline;
                 _clientDiagnostics = clientDiagnostics;
@@ -340,51 +333,6 @@ namespace Azure.Core
                 _pollUri = _originalUri;
                 _headerFrom = HeaderFrom.None;
             }
-
-            //private void InitializeScenarioInfo(string originalUri, OperationFinalStateVia finalStateVia)
-            //{
-            //    _hasLocation = _rawResponse.Headers.TryGetValue("Location", out string? location);
-            //    string? GetFinalUri()
-            //    {
-            //        if (_requestMethod == RequestMethod.Put || finalStateVia == OperationFinalStateVia.OriginalUri)
-            //        {
-            //            return originalUri;
-            //        }
-
-            //        if (finalStateVia == OperationFinalStateVia.Location)
-            //        {
-            //            return location;
-            //        }
-
-            //        return null;
-            //    }
-
-            //    if (_rawResponse.Headers.TryGetValue("Operation-Location", out string? operationLocation))
-            //    {
-            //        _headerFrom = HeaderFrom.OperationLocation;
-            //        _pollUri = operationLocation;
-            //        _finalUri = GetFinalUri();
-            //        return;
-            //    }
-
-            //    if (_rawResponse.Headers.TryGetValue("Azure-AsyncOperation", out string? azureAsyncOperation))
-            //    {
-            //        _headerFrom = HeaderFrom.AzureAsyncOperation;
-            //        _pollUri = azureAsyncOperation;
-            //        _finalUri = GetFinalUri();
-            //        return;
-            //    }
-
-            //    if (_hasLocation)
-            //    {
-            //        _headerFrom = HeaderFrom.Location;
-            //        _pollUri = location!;
-            //        return;
-            //    }
-
-            //    _headerFrom = HeaderFrom.None;
-            //    _pollUri = originalUri;
-            //}
 
             private void UpdatePollUri()
             {

--- a/src/assets/Generator.Shared/ArmOperationHelpers.cs
+++ b/src/assets/Generator.Shared/ArmOperationHelpers.cs
@@ -78,10 +78,12 @@ namespace Azure.Core
             private readonly Func<Response, CancellationToken, T> _createFinalResponse;
             private readonly Func<Response, CancellationToken, ValueTask<T>> _createFinalResponseAsync;
             private readonly RequestMethod _requestMethod;
+            private readonly string _originalUri;
+            private readonly OperationFinalStateVia _finalStateVia;
             private HeaderFrom _headerFrom;
             private string _pollUri = default!;
-            private string? _finalUri;
-            private bool _hasLocation;
+            private bool _originalHasLocation;
+            private string? _lastKnownLocation;
 
             private Response _rawResponse;
             private T _value = default!;
@@ -95,12 +97,16 @@ namespace Azure.Core
             {
                 _rawResponse = originalResponse;
                 _requestMethod = requestMethod;
-                InitializeScenarioInfo(originalUri, finalStateVia);
-                if ((requestMethod != RequestMethod.Put && (_headerFrom == HeaderFrom.None || !_hasLocation)) || finalStateVia == OperationFinalStateVia.AzureAsyncOperation)
-                {
-                    // Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447
-                    throw clientDiagnostics.CreateRequestFailedException(originalResponse);
-                }
+                _originalUri = originalUri;
+                _finalStateVia = finalStateVia;
+                //_headerFrom = GetHeaderFrom();
+                InitializeScenarioInfo();
+                //InitializeScenarioInfo(originalUri, finalStateVia);
+                //if ((requestMethod != RequestMethod.Put && (_headerFrom == HeaderFrom.None || !_hasLocation)) || finalStateVia == OperationFinalStateVia.AzureAsyncOperation)
+                //{
+                //    // Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447
+                //    throw clientDiagnostics.CreateRequestFailedException(originalResponse);
+                //}
 
                 _pipeline = pipeline;
                 _clientDiagnostics = clientDiagnostics;
@@ -128,6 +134,7 @@ namespace Azure.Core
 
                 if (_shouldPoll)
                 {
+                    UpdatePollUri();
                     _rawResponse = async
                         ? await GetResponseAsync(_pollUri, cancellationToken).ConfigureAwait(false)
                         : GetResponse(_pollUri, cancellationToken);
@@ -142,11 +149,12 @@ namespace Azure.Core
                         throw _clientDiagnostics.CreateRequestFailedException(finalResponse);
                     }
 
-                    if (_finalUri != null)
+                    string? finalUri = GetFinalUri();
+                    if (finalUri != null)
                     {
                         finalResponse = async
-                            ? await GetResponseAsync(_finalUri, cancellationToken).ConfigureAwait(false)
-                            : GetResponse(_finalUri, cancellationToken);
+                            ? await GetResponseAsync(finalUri, cancellationToken).ConfigureAwait(false)
+                            : GetResponse(finalUri, cancellationToken);
                     }
                     switch (finalResponse.Status)
                     {
@@ -307,49 +315,120 @@ namespace Azure.Core
                 Location
             }
 
-            private void InitializeScenarioInfo(string originalUri, OperationFinalStateVia finalStateVia)
+            private void InitializeScenarioInfo()
             {
-                _hasLocation = _rawResponse.Headers.TryGetValue("Location", out string? location);
-                string? GetFinalUri()
-                {
-                    if (_requestMethod == RequestMethod.Put || finalStateVia == OperationFinalStateVia.OriginalUri)
-                    {
-                        return originalUri;
-                    }
+                _originalHasLocation = _rawResponse.Headers.Contains("Location");
 
-                    if (finalStateVia == OperationFinalStateVia.Location)
-                    {
-                        return location;
-                    }
-
-                    return null;
-                }
-
-                if (_rawResponse.Headers.TryGetValue("Operation-Location", out string? operationLocation))
+                if (_rawResponse.Headers.Contains("Operation-Location"))
                 {
                     _headerFrom = HeaderFrom.OperationLocation;
-                    _pollUri = operationLocation;
-                    _finalUri = GetFinalUri();
                     return;
                 }
 
-                if (_rawResponse.Headers.TryGetValue("Azure-AsyncOperation", out string? azureAsyncOperation))
+                if (_rawResponse.Headers.Contains("Azure-AsyncOperation"))
                 {
                     _headerFrom = HeaderFrom.AzureAsyncOperation;
-                    _pollUri = azureAsyncOperation;
-                    _finalUri = GetFinalUri();
                     return;
                 }
 
-                if (_hasLocation)
+                if (_originalHasLocation)
                 {
                     _headerFrom = HeaderFrom.Location;
-                    _pollUri = location!;
                     return;
                 }
 
+                _pollUri = _originalUri;
                 _headerFrom = HeaderFrom.None;
-                _pollUri = originalUri;
+            }
+
+            //private void InitializeScenarioInfo(string originalUri, OperationFinalStateVia finalStateVia)
+            //{
+            //    _hasLocation = _rawResponse.Headers.TryGetValue("Location", out string? location);
+            //    string? GetFinalUri()
+            //    {
+            //        if (_requestMethod == RequestMethod.Put || finalStateVia == OperationFinalStateVia.OriginalUri)
+            //        {
+            //            return originalUri;
+            //        }
+
+            //        if (finalStateVia == OperationFinalStateVia.Location)
+            //        {
+            //            return location;
+            //        }
+
+            //        return null;
+            //    }
+
+            //    if (_rawResponse.Headers.TryGetValue("Operation-Location", out string? operationLocation))
+            //    {
+            //        _headerFrom = HeaderFrom.OperationLocation;
+            //        _pollUri = operationLocation;
+            //        _finalUri = GetFinalUri();
+            //        return;
+            //    }
+
+            //    if (_rawResponse.Headers.TryGetValue("Azure-AsyncOperation", out string? azureAsyncOperation))
+            //    {
+            //        _headerFrom = HeaderFrom.AzureAsyncOperation;
+            //        _pollUri = azureAsyncOperation;
+            //        _finalUri = GetFinalUri();
+            //        return;
+            //    }
+
+            //    if (_hasLocation)
+            //    {
+            //        _headerFrom = HeaderFrom.Location;
+            //        _pollUri = location!;
+            //        return;
+            //    }
+
+            //    _headerFrom = HeaderFrom.None;
+            //    _pollUri = originalUri;
+            //}
+
+            private void UpdatePollUri()
+            {
+                var hasLocation = _rawResponse.Headers.TryGetValue("Location", out string? location);
+                if (hasLocation)
+                {
+                    _lastKnownLocation = location;
+                }
+
+                switch (_headerFrom)
+                {
+                    case HeaderFrom.OperationLocation when _rawResponse.Headers.TryGetValue("Operation-Location", out string? operationLocation):
+                        _pollUri = operationLocation;
+                        return;
+                    case HeaderFrom.AzureAsyncOperation when _rawResponse.Headers.TryGetValue("Azure-AsyncOperation", out string? azureAsyncOperation):
+                        _pollUri = azureAsyncOperation;
+                        return;
+                    case HeaderFrom.Location when hasLocation:
+                        _pollUri = location!;
+                        return;
+                }
+            }
+
+            private string? GetFinalUri()
+            {
+                if (_headerFrom == HeaderFrom.OperationLocation || _headerFrom == HeaderFrom.AzureAsyncOperation)
+                {
+                    if (_requestMethod == RequestMethod.Delete)
+                    {
+                        return null;
+                    }
+
+                    if (_requestMethod == RequestMethod.Put || (_originalHasLocation && _finalStateVia == OperationFinalStateVia.OriginalUri))
+                    {
+                        return _originalUri;
+                    }
+
+                    if (_originalHasLocation && _finalStateVia == OperationFinalStateVia.Location)
+                    {
+                        return _lastKnownLocation;
+                    }
+                }
+
+                return null;
             }
         }
     }

--- a/test/AutoRest.TestServer.Tests/lro.cs
+++ b/test/AutoRest.TestServer.Tests/lro.cs
@@ -163,7 +163,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
         public Task LRODeleteAsyncNoRetrySucceeded() => TestStatus(async (host, pipeline) =>
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncNoRetrySucceededOperationAsync();
@@ -171,7 +170,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
         public Task LRODeleteAsyncNoRetrySucceeded_Sync() => TestStatus((host, pipeline) =>
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncNoRetrySucceededOperation();
@@ -179,39 +177,34 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
-        public Task LRODeleteAsyncRetryCanceled() => TestStatus(async (host, pipeline) =>
+        public Task LRODeleteAsyncRetryCanceled() => Test(async (host, pipeline) =>
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncRetrycanceledOperationAsync();
-            return await operation.WaitForCompletionAsync().ConfigureAwait(false);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync().ConfigureAwait(false));
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
-        public Task LRODeleteAsyncRetryCanceled_Sync() => TestStatus((host, pipeline) =>
+        public Task LRODeleteAsyncRetryCanceled_Sync() => Test((host, pipeline) =>
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncRetrycanceledOperation();
-            return operation.WaitForCompletion();
+            Assert.Throws<RequestFailedException>(() => operation.WaitForCompletion());
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
-        public Task LRODeleteAsyncRetryFailed() => TestStatus(async (host, pipeline) =>
+        public Task LRODeleteAsyncRetryFailed() => Test(async (host, pipeline) =>
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncRetryFailedOperationAsync();
-            return await operation.WaitForCompletionAsync().ConfigureAwait(false);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync().ConfigureAwait(false));
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
-        public Task LRODeleteAsyncRetryFailed_Sync() => TestStatus((host, pipeline) =>
+        public Task LRODeleteAsyncRetryFailed_Sync() => Test((host, pipeline) =>
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncRetryFailedOperation();
-            return operation.WaitForCompletion();
+            Assert.Throws<RequestFailedException>(() => operation.WaitForCompletion());
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
         public Task LRODeleteAsyncRetrySucceeded() => TestStatus(async (host, pipeline) =>
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncRetrySucceededOperationAsync();
@@ -219,7 +212,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("DELETE does final GET and restarts polling: https://github.com/Azure/autorest.testserver/issues/138")]
         public Task LRODeleteAsyncRetrySucceeded_Sync() => TestStatus((host, pipeline) =>
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartDeleteAsyncRetrySucceededOperation();
@@ -227,7 +219,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
         public Task LRODeleteInlineComplete() => TestStatus(async (host, pipeline) =>
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartDelete204SucceededOperationAsync();
@@ -235,7 +226,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
         public Task LRODeleteInlineComplete_Sync() => TestStatus((host, pipeline) =>
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartDelete204SucceededOperation();
@@ -379,7 +369,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
         public Task LROErrorDeleteNoLocation() => TestStatus(async (host, pipeline) =>
         {
             var operation = await new LrosaDsClient(ClientDiagnostics, pipeline, host).StartDelete204SucceededOperationAsync();
@@ -387,7 +376,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
         public Task LROErrorDeleteNoLocation_Sync() => TestStatus((host, pipeline) =>
         {
             var operation = new LrosaDsClient(ClientDiagnostics, pipeline, host).StartDelete204SucceededOperation();
@@ -459,21 +447,19 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
-        public Task LROErrorPostNoLocation() => TestStatus(async (host, pipeline) =>
+        public Task LROErrorPostNoLocation() => Test(async (host, pipeline) =>
         {
             var value = new Product();
             var operation = await new LrosaDsClient(ClientDiagnostics, pipeline, host).StartPost202NoLocationOperationAsync(value);
-            return await operation.WaitForCompletionAsync().ConfigureAwait(false);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync().ConfigureAwait(false));
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
-        public Task LROErrorPostNoLocation_Sync() => TestStatus((host, pipeline) =>
+        public Task LROErrorPostNoLocation_Sync() => Test((host, pipeline) =>
         {
             var value = new Product();
             var operation = new LrosaDsClient(ClientDiagnostics, pipeline, host).StartPost202NoLocationOperation(value);
-            return operation.WaitForCompletion();
+            Assert.Throws<RequestFailedException>(() => operation.WaitForCompletion());
         });
 
         [Test]
@@ -833,25 +819,23 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
         public Task LROPostDoubleHeadersFinalAzureHeaderGet() => Test(async (host, pipeline) =>
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartPostDoubleHeadersFinalAzureHeaderGetOperationAsync();
             var result = await operation.WaitForCompletionAsync().ConfigureAwait(false);
             Assert.AreEqual("100", result.Value.Id);
-            Assert.AreEqual("foo", result.Value.Name);
-            Assert.AreEqual("Succeeded", result.Value.ProvisioningState);
+            Assert.AreEqual(null, result.Value.Name);
+            Assert.AreEqual(null, result.Value.ProvisioningState);
         });
 
         [Test]
-        [Ignore("Support Operation Resource: https://github.com/Azure/autorest.csharp/issues/447")]
         public Task LROPostDoubleHeadersFinalAzureHeaderGet_Sync() => Test((host, pipeline) =>
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartPostDoubleHeadersFinalAzureHeaderGetOperation();
             var result = operation.WaitForCompletion();
             Assert.AreEqual("100", result.Value.Id);
-            Assert.AreEqual("foo", result.Value.Name);
-            Assert.AreEqual("Succeeded", result.Value.ProvisioningState);
+            Assert.AreEqual(null, result.Value.Name);
+            Assert.AreEqual(null, result.Value.ProvisioningState);
         });
 
         [Test]
@@ -896,32 +880,25 @@ namespace AutoRest.TestServer.Tests
             Assert.AreEqual(null, result.Value.ProvisioningState);
         });
 
+        // Note: This test changes if https://github.com/Azure/autorest.csharp/issues/300 is implemented.
         [Test]
-        [Ignore("Explicitly checks if final GET uses polled Location header, instead of original Location header")]
         public Task LROPostSuccededNoBody() => Test(async (host, pipeline) =>
         {
             var value = new Product();
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartPost202NoRetry204OperationAsync(value);
-            var result = await operation.WaitForCompletionAsync().ConfigureAwait(false);
-            Assert.AreEqual("100", result.Value.Id);
-            Assert.AreEqual("foo", result.Value.Name);
-            Assert.AreEqual("Succeeded", result.Value.ProvisioningState);
+            Assert.ThrowsAsync(Is.InstanceOf<JsonException>(), async () => await operation.WaitForCompletionAsync().ConfigureAwait(false));
         });
 
+        // Note: This test changes if https://github.com/Azure/autorest.csharp/issues/300 is implemented.
         [Test]
-        [Ignore("Explicitly checks if final GET uses polled Location header, instead of original Location header")]
         public Task LROPostSuccededNoBody_Sync() => Test((host, pipeline) =>
         {
             var value = new Product();
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartPost202NoRetry204Operation(value);
-            var result = operation.WaitForCompletion();
-            Assert.AreEqual("100", result.Value.Id);
-            Assert.AreEqual("foo", result.Value.Name);
-            Assert.AreEqual("Succeeded", result.Value.ProvisioningState);
+            Assert.Throws(Is.InstanceOf<JsonException>(), () => operation.WaitForCompletion());
         });
 
         [Test]
-        [Ignore("Explicitly checks if final GET uses polled Location header, instead of original Location header")]
         public Task LROPostSuccededWithBody() => TestStatus(async (host, pipeline) =>
         {
             var value = new Product();
@@ -930,7 +907,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Explicitly checks if final GET uses polled Location header, instead of original Location header")]
         public Task LROPostSuccededWithBody_Sync() => TestStatus((host, pipeline) =>
         {
             var value = new Product();
@@ -1291,7 +1267,7 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Retry on 500 logic: https://github.com/Azure/autorest.csharp/issues/398")]
+        [Ignore("Handle multiple responses: https://github.com/Azure/autorest.csharp/issues/413")]
         public Task LRORetryErrorDelete202Accepted200Succeeded() => Test(async (host, pipeline) =>
         {
             var operation = await new LRORetrysClient(ClientDiagnostics, pipeline, host).StartDeleteProvisioning202Accepted200SucceededOperationAsync();
@@ -1302,7 +1278,7 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Retry on 500 logic: https://github.com/Azure/autorest.csharp/issues/398")]
+        [Ignore("Handle multiple responses: https://github.com/Azure/autorest.csharp/issues/413")]
         public Task LRORetryErrorDelete202Accepted200Succeeded_Sync() => Test((host, pipeline) =>
         {
             var operation = new LRORetrysClient(ClientDiagnostics, pipeline, host).StartDeleteProvisioning202Accepted200SucceededOperation();
@@ -1417,7 +1393,7 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Retry on 500 logic: https://github.com/Azure/autorest.csharp/issues/398")]
+        [Ignore("Handle multiple responses: https://github.com/Azure/autorest.csharp/issues/413")]
         public Task LRORetryPutSucceededWithBody() => Test(async (host, pipeline) =>
         {
             var value = new Product();
@@ -1429,7 +1405,7 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("Retry on 500 logic: https://github.com/Azure/autorest.csharp/issues/398")]
+        [Ignore("Handle multiple responses: https://github.com/Azure/autorest.csharp/issues/413")]
         public Task LRORetryPutSucceededWithBody_Sync() => Test((host, pipeline) =>
         {
             var value = new Product();


### PR DESCRIPTION
Resolves: https://github.com/Azure/autorest.csharp/issues/447

- Uses logic to update poll URI information as you are polling
  - We call this 'last seen' or 'last known'. It is what seems to work best overall.
  - Because of this, we also keep track of lastKnownLocation, as that is used in 1 scenario for final GET.
- For the OL/AAO scenario, we no longer do a final GET for DELETE requests
  - This was also recommended because if something is deleted, the final GET is invalid.

This allowed several more tests to run and I realized we no longer were blocked on the Operation Response scenarios. So, those are currently also working.