### PR TITLE
Speedup code-gen a bit

### DIFF
--- a/src/AutoRest.CSharp.V3/AutoRest.CSharp.V3.csproj
+++ b/src/AutoRest.CSharp.V3/AutoRest.CSharp.V3.csproj
@@ -7,6 +7,7 @@
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
     <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoRest.CSharp.V3/AutoRest/Plugins/GeneratedCodeWorkspace.cs
+++ b/src/AutoRest.CSharp.V3/AutoRest/Plugins/GeneratedCodeWorkspace.cs
@@ -32,11 +32,16 @@ namespace AutoRest.CSharp.V3.AutoRest.Plugins
 
         public void AddGeneratedFile(string name, string text)
         {
-            _project = _project.AddDocument(GeneratedFolder + "/" + name, text, GeneratedFolders).Project;
+            var document = _project.AddDocument(GeneratedFolder + "/" + name, text, GeneratedFolders);
+            var root = document.GetSyntaxRootAsync().Result;
+            Debug.Assert(root != null);
+            root = root.WithAdditionalAnnotations(Simplifier.Annotation);
+            _project = document.WithSyntaxRoot(root).Project;
         }
 
         public async IAsyncEnumerable<(string Name, string Text)> GetGeneratedFilesAsync()
         {
+            List<Task<Document>> documents = new List<Task<Document>>();
             foreach (Document document in _project.Documents)
             {
                 // Skip writing shared files or originals
@@ -45,18 +50,23 @@ namespace AutoRest.CSharp.V3.AutoRest.Plugins
                     continue;
                 }
 
-                var root = await document.GetSyntaxRootAsync()!;
-
-                Debug.Assert(root != null);
-
-                root = root.WithAdditionalAnnotations(Simplifier.Annotation);
-                var simplified = document.WithSyntaxRoot(root);
-                simplified = await Simplifier.ReduceAsync(simplified);
-                simplified = await Formatter.FormatAsync(simplified);
-
-                SourceText text = await simplified.GetTextAsync();
-                yield return (document.Name, text.ToString());
+                documents.Add(Task.Run(() => ProcessDocument(document)));
             }
+
+            foreach (var task in documents)
+            {
+                var processed = await task;
+                var text = await processed.GetSyntaxTreeAsync();
+
+                yield return (processed.Name, text.ToString());
+            }
+        }
+
+        private static async Task<Document> ProcessDocument(Document document)
+        {
+            document = await Simplifier.ReduceAsync(document);
+            document = await Formatter.FormatAsync(document);
+            return document;
         }
 
         public static GeneratedCodeWorkspace Create(string projectDirectory, string sharedSourceFolder)
@@ -66,16 +76,19 @@ namespace AutoRest.CSharp.V3.AutoRest.Plugins
             Project generatedCodeProject = workspace.AddProject("GeneratedCode", LanguageNames.CSharp);
 
             var corlibLocation = typeof(object).Assembly.Location;
+            var references = new List<MetadataReference>();
 
-            generatedCodeProject = generatedCodeProject.AddMetadataReference(MetadataReference.CreateFromFile(corlibLocation));
+            references.Add(MetadataReference.CreateFromFile(corlibLocation));
 
             var trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? "").Split(Path.PathSeparator);
             foreach (var tpl in trustedAssemblies)
             {
-                generatedCodeProject = generatedCodeProject.AddMetadataReference(MetadataReference.CreateFromFile(tpl));
+                references.Add(MetadataReference.CreateFromFile(tpl));
             }
 
-            generatedCodeProject = generatedCodeProject.WithCompilationOptions(new CSharpCompilationOptions(
+            generatedCodeProject = generatedCodeProject
+                .AddMetadataReferences(references)
+                .WithCompilationOptions(new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Annotations));
 
             var generatedCodeDirectory = Path.Combine(projectDirectory, "Generated");


### PR DESCRIPTION
Use Roslyn APIs better to cause fewer allocations and parallelize processing. This is especially visible on  large projects.