### PR TITLE
Don't trim Operations from the client name if it's the entire name

### DIFF
--- a/samples/Azure.Storage.Management/Azure.Storage.Management/Generated/Operations/OperationsClient.cs
+++ b/samples/Azure.Storage.Management/Azure.Storage.Management/Generated/Operations/OperationsClient.cs
@@ -14,15 +14,15 @@ using Azure.Storage.Management.Models;
 
 namespace Azure.Storage.Management
 {
-    public partial class Client
+    public partial class OperationsClient
     {
         private readonly ClientDiagnostics clientDiagnostics;
         private readonly HttpPipeline pipeline;
-        internal RestClient RestClient { get; }
-        /// <summary> Initializes a new instance of Client. </summary>
-        internal Client(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string host = "https://management.azure.com", string ApiVersion = "2019-06-01")
+        internal OperationsRestClient RestClient { get; }
+        /// <summary> Initializes a new instance of OperationsClient. </summary>
+        internal OperationsClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string host = "https://management.azure.com", string ApiVersion = "2019-06-01")
         {
-            RestClient = new RestClient(clientDiagnostics, pipeline, host, ApiVersion);
+            RestClient = new OperationsRestClient(clientDiagnostics, pipeline, host, ApiVersion);
             this.clientDiagnostics = clientDiagnostics;
             this.pipeline = pipeline;
         }

--- a/samples/Azure.Storage.Management/Azure.Storage.Management/Generated/Operations/OperationsRestClient.cs
+++ b/samples/Azure.Storage.Management/Azure.Storage.Management/Generated/Operations/OperationsRestClient.cs
@@ -16,14 +16,14 @@ using Azure.Storage.Management.Models;
 
 namespace Azure.Storage.Management
 {
-    internal partial class RestClient
+    internal partial class OperationsRestClient
     {
         private string host;
         private string ApiVersion;
         private ClientDiagnostics clientDiagnostics;
         private HttpPipeline pipeline;
-        /// <summary> Initializes a new instance of RestClient. </summary>
-        public RestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string host = "https://management.azure.com", string ApiVersion = "2019-06-01")
+        /// <summary> Initializes a new instance of OperationsRestClient. </summary>
+        public OperationsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string host = "https://management.azure.com", string ApiVersion = "2019-06-01")
         {
             if (host == null)
             {
@@ -55,7 +55,7 @@ namespace Azure.Storage.Management
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<OperationListResult>> ListAsync(CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("Client.List");
+            using var scope = clientDiagnostics.CreateScope("OperationsClient.List");
             scope.Start();
             try
             {
@@ -83,7 +83,7 @@ namespace Azure.Storage.Management
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<OperationListResult> List(CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("Client.List");
+            using var scope = clientDiagnostics.CreateScope("OperationsClient.List");
             scope.Start();
             try
             {
@@ -127,7 +127,7 @@ namespace Azure.Storage.Management
                 throw new ArgumentNullException(nameof(nextLink));
             }
 
-            using var scope = clientDiagnostics.CreateScope("Client.List");
+            using var scope = clientDiagnostics.CreateScope("OperationsClient.List");
             scope.Start();
             try
             {
@@ -161,7 +161,7 @@ namespace Azure.Storage.Management
                 throw new ArgumentNullException(nameof(nextLink));
             }
 
-            using var scope = clientDiagnostics.CreateScope("Client.List");
+            using var scope = clientDiagnostics.CreateScope("OperationsClient.List");
             scope.Start();
             try
             {

--- a/src/AutoRest.CSharp.V3/Output/Builders/ClientBuilder.cs
+++ b/src/AutoRest.CSharp.V3/Output/Builders/ClientBuilder.cs
@@ -161,7 +161,7 @@ namespace AutoRest.CSharp.V3.Output.Builders
             name = string.IsNullOrEmpty(name) ? "Service" : name.ToCleanName();
 
             var operationsSuffix = "Operations";
-            if (name.EndsWith(operationsSuffix))
+            if (name.EndsWith(operationsSuffix) && name.Length > operationsSuffix.Length)
             {
                 name = name.Substring(0, name.Length - operationsSuffix.Length);
             }


### PR DESCRIPTION
Storage ended up having `Client` and `RestClient` types because we've trimmed too much.