### PR TITLE
Fix member remover

### DIFF
--- a/src/AutoRest.CSharp.V3/AutoRest.CSharp.V3.csproj
+++ b/src/AutoRest.CSharp.V3/AutoRest.CSharp.V3.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0-beta3-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0-2.final" />
     <PackageReference Include="YamlDotNet" Version="8.0.0-emit-default-values0565" />
     <PackageReference Include="CaseExtensions" Version="1.0.3" />
   </ItemGroup>

--- a/src/AutoRest.CSharp.V3/AutoRest/Plugins/GeneratedCodeWorkspace.cs
+++ b/src/AutoRest.CSharp.V3/AutoRest/Plugins/GeneratedCodeWorkspace.cs
@@ -65,7 +65,7 @@ namespace AutoRest.CSharp.V3.AutoRest.Plugins
 
         private static async Task<Document> ProcessDocument(Document document)
         {
-            var compilation = document.Project.GetCompilationAsync().GetAwaiter().GetResult();
+            var compilation = await document.Project.GetCompilationAsync();
             Debug.Assert(compilation != null);
 
             var syntaxTree = await document.GetSyntaxTreeAsync();

--- a/src/AutoRest.CSharp.V3/AutoRest/Plugins/MemberRemoverRewriter.cs
+++ b/src/AutoRest.CSharp.V3/AutoRest/Plugins/MemberRemoverRewriter.cs
@@ -62,7 +62,7 @@ namespace AutoRest.CSharp.V3.AutoRest.Plugins
 
             foreach (var attributeData in namedTypeSymbol.GetAttributes())
             {
-                if (attributeData.AttributeClass.Equals(_suppressAttribute))
+                if (attributeData.AttributeClass?.Equals(_suppressAttribute) == true)
                 {
                     suppressions ??= new List<Supression>();
                     var name = attributeData.ConstructorArguments[0].Value as string;

--- a/src/assets/Generator.Shared/CodeGenSuppressAttribute.cs
+++ b/src/assets/Generator.Shared/CodeGenSuppressAttribute.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Azure.Core
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Struct)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Struct, AllowMultiple = true)]
     internal class CodeGenSuppressAttribute : Attribute
     {
         public string Member { get; }

--- a/test/TestProjects/TypeSchemaMapping/Generated/Models/CustomizedModel.cs
+++ b/test/TestProjects/TypeSchemaMapping/Generated/Models/CustomizedModel.cs
@@ -12,5 +12,16 @@ namespace CustomNamespace
     /// <summary> The Model. </summary>
     internal partial class CustomizedModel
     {
+
+        /// <summary> Initializes a new instance of CustomizedModel. </summary>
+        /// <param name="propertyRenamedAndTypeChanged"> . </param>
+        /// <param name="customizedFancyField"> Fruit. </param>
+        /// <param name="daysOfWeek"> Day of week. </param>
+        internal CustomizedModel(int? propertyRenamedAndTypeChanged, CustomFruitEnum customizedFancyField, CustomDaysOfWeek daysOfWeek)
+        {
+            PropertyRenamedAndTypeChanged = propertyRenamedAndTypeChanged;
+            CustomizedFancyField = customizedFancyField;
+            DaysOfWeek = daysOfWeek;
+        }
     }
 }

--- a/test/TestProjects/TypeSchemaMapping/Generated/Models/CustomizedModel.cs
+++ b/test/TestProjects/TypeSchemaMapping/Generated/Models/CustomizedModel.cs
@@ -12,16 +12,5 @@ namespace CustomNamespace
     /// <summary> The Model. </summary>
     internal partial class CustomizedModel
     {
-
-        /// <summary> Initializes a new instance of CustomizedModel. </summary>
-        /// <param name="propertyRenamedAndTypeChanged"> . </param>
-        /// <param name="customizedFancyField"> Fruit. </param>
-        /// <param name="daysOfWeek"> Day of week. </param>
-        internal CustomizedModel(int? propertyRenamedAndTypeChanged, CustomFruitEnum customizedFancyField, CustomDaysOfWeek daysOfWeek)
-        {
-            PropertyRenamedAndTypeChanged = propertyRenamedAndTypeChanged;
-            CustomizedFancyField = customizedFancyField;
-            DaysOfWeek = daysOfWeek;
-        }
     }
 }


### PR DESCRIPTION
Run it after all the types were generated because strange things happen if some types are not found.

Fixes: https://github.com/Azure/autorest.csharp/issues/601