### PR TITLE
Make required input properties readonly again

### DIFF
--- a/eng/SmokeTestInputs.txt
+++ b/eng/SmokeTestInputs.txt
@@ -65,7 +65,7 @@ https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a34
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/eventgrid/data-plane/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/eventgrid/resource-manager/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/eventhub/resource-manager/readme.md
-https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/graphrbac/data-plane/readme.md
+https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/graphrbac/data-plane/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/guestconfiguration/resource-manager/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/hanaonazure/resource-manager/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/hardwaresecuritymodules/resource-manager/readme.md

--- a/eng/SmokeTestInputs.txt
+++ b/eng/SmokeTestInputs.txt
@@ -65,7 +65,7 @@ https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a34
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/eventgrid/data-plane/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/eventgrid/resource-manager/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/eventhub/resource-manager/readme.md
-https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/graphrbac/data-plane/readme.md
+https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/graphrbac/data-plane/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/guestconfiguration/resource-manager/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/hanaonazure/resource-manager/readme.md
 https://github.com/Azure/azure-rest-api-specs/blob/49fc16354df7211f8392c56884a3437138317d1f/specification/hardwaresecuritymodules/resource-manager/readme.md

--- a/samples/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer/Generated/Models/TrainRequest.cs
+++ b/samples/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer/Generated/Models/TrainRequest.cs
@@ -36,7 +36,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary> Source path containing the training documents. </summary>
-        public string Source { get; set; }
+        public string Source { get; }
         /// <summary> Filter to apply to the documents in the source path for training. </summary>
         public TrainSourceFilter SourceFilter { get; set; }
         /// <summary> Use label file for training a model. </summary>

--- a/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/AccountSasParameters.cs
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/AccountSasParameters.cs
@@ -47,11 +47,11 @@ namespace Azure.Management.Storage.Models
         }
 
         /// <summary> The signed services accessible with the account SAS. Possible values include: Blob (b), Queue (q), Table (t), File (f). </summary>
-        public Services Services { get; set; }
+        public Services Services { get; }
         /// <summary> The signed resource types that are accessible with the account SAS. Service (s): Access to service-level APIs; Container (c): Access to container-level APIs; Object (o): Access to object-level APIs for blobs, queue messages, table entities, and files. </summary>
-        public SignedResourceTypes ResourceTypes { get; set; }
+        public SignedResourceTypes ResourceTypes { get; }
         /// <summary> The signed permissions for the account SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p). </summary>
-        public Permissions Permissions { get; set; }
+        public Permissions Permissions { get; }
         /// <summary> An IP address or a range of IP addresses from which to accept requests. </summary>
         public string IPAddressOrRange { get; set; }
         /// <summary> The protocol permitted for a request made with the account SAS. </summary>
@@ -59,7 +59,7 @@ namespace Azure.Management.Storage.Models
         /// <summary> The time at which the SAS becomes valid. </summary>
         public DateTimeOffset? SharedAccessStartTime { get; set; }
         /// <summary> The time at which the shared access signature becomes invalid. </summary>
-        public DateTimeOffset SharedAccessExpiryTime { get; set; }
+        public DateTimeOffset SharedAccessExpiryTime { get; }
         /// <summary> The key to sign the account SAS token with. </summary>
         public string KeyToSign { get; set; }
     }

--- a/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/LeaseContainerRequest.cs
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/LeaseContainerRequest.cs
@@ -33,7 +33,7 @@ namespace Azure.Management.Storage.Models
         }
 
         /// <summary> Specifies the lease action. Can be one of the available actions. </summary>
-        public LeaseContainerRequestAction Action { get; set; }
+        public LeaseContainerRequestAction Action { get; }
         /// <summary> Identifies the lease. Can be specified in any valid GUID string format. </summary>
         public string LeaseId { get; set; }
         /// <summary> Optional. For a break action, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. </summary>

--- a/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/ServiceSasParameters.cs
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/ServiceSasParameters.cs
@@ -66,7 +66,7 @@ namespace Azure.Management.Storage.Models
         }
 
         /// <summary> The canonical path to the signed resource. </summary>
-        public string CanonicalizedResource { get; set; }
+        public string CanonicalizedResource { get; }
         /// <summary> The signed services accessible with the service SAS. Possible values include: Blob (b), Container (c), File (f), Share (s). </summary>
         public SignedResource? Resource { get; set; }
         /// <summary> The signed permissions for the service SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p). </summary>

--- a/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/StorageAccountCheckNameAvailabilityParameters.cs
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/StorageAccountCheckNameAvailabilityParameters.cs
@@ -35,8 +35,8 @@ namespace Azure.Management.Storage.Models
         }
 
         /// <summary> The storage account name. </summary>
-        public string Name { get; set; }
+        public string Name { get; }
         /// <summary> The type of resource, Microsoft.Storage/storageAccounts. </summary>
-        public string Type { get; set; }
+        public string Type { get; }
     }
 }

--- a/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/StorageAccountCreateParameters.cs
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/StorageAccountCreateParameters.cs
@@ -67,11 +67,11 @@ namespace Azure.Management.Storage.Models
         }
 
         /// <summary> Required. Gets or sets the SKU name. </summary>
-        public Sku Sku { get; set; }
+        public Sku Sku { get; }
         /// <summary> Required. Indicates the type of storage account. </summary>
-        public Kind Kind { get; set; }
+        public Kind Kind { get; }
         /// <summary> Required. Gets or sets the location of the resource. This will be one of the supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.). The geo region of a resource cannot be changed once it is created, but if an identical geo region is specified on update, the request will succeed. </summary>
-        public string Location { get; set; }
+        public string Location { get; }
         /// <summary> Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. </summary>
         public IDictionary<string, string> Tags { get; set; }
         /// <summary> The identity of the resource. </summary>

--- a/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/StorageAccountRegenerateKeyParameters.cs
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage/Generated/Models/StorageAccountRegenerateKeyParameters.cs
@@ -25,6 +25,6 @@ namespace Azure.Management.Storage.Models
         }
 
         /// <summary> The name of storage keys that want to be regenerated, possible values are key1, key2, kerb1, kerb2. </summary>
-        public string KeyName { get; set; }
+        public string KeyName { get; }
     }
 }

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/AnalyzeRequest.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/AnalyzeRequest.cs
@@ -41,7 +41,7 @@ namespace CognitiveSearch.Models
         }
 
         /// <summary> The text to break into tokens. </summary>
-        public string Text { get; set; }
+        public string Text { get; }
         /// <summary> The name of the analyzer to use to break the given text. If this parameter is not specified, you must specify a tokenizer instead. The tokenizer and analyzer parameters are mutually exclusive. </summary>
         public AnalyzerName? Analyzer { get; set; }
         /// <summary> The name of the tokenizer to use to break the given text. If this parameter is not specified, you must specify an analyzer instead. The tokenizer and analyzer parameters are mutually exclusive. </summary>

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/AutocompleteRequest.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/AutocompleteRequest.cs
@@ -56,7 +56,7 @@ namespace CognitiveSearch.Models
         }
 
         /// <summary> The search text on which to base autocomplete results. </summary>
-        public string SearchText { get; set; }
+        public string SearchText { get; }
         /// <summary> Specifies the mode for Autocomplete. The default is &apos;oneTerm&apos;. Use &apos;twoTerms&apos; to get shingles and &apos;oneTermWithContext&apos; to use the current context while producing auto-completed terms. </summary>
         public AutocompleteMode? AutocompleteMode { get; set; }
         /// <summary> An OData expression that filters the documents used to produce completed terms for the Autocomplete result. </summary>
@@ -72,7 +72,7 @@ namespace CognitiveSearch.Models
         /// <summary> The comma-separated list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester. </summary>
         public string SearchFields { get; set; }
         /// <summary> The name of the suggester as specified in the suggesters collection that&apos;s part of the index definition. </summary>
-        public string SuggesterName { get; set; }
+        public string SuggesterName { get; }
         /// <summary> The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5. </summary>
         public int? Top { get; set; }
     }

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/IndexBatch.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/IndexBatch.cs
@@ -34,6 +34,6 @@ namespace CognitiveSearch.Models
         }
 
         /// <summary> The actions in the batch. </summary>
-        public IList<IndexAction> Actions { get; set; }
+        public IList<IndexAction> Actions { get; }
     }
 }

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SuggestRequest.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SuggestRequest.cs
@@ -70,13 +70,13 @@ namespace CognitiveSearch.Models
         /// <summary> The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. </summary>
         public string OrderBy { get; set; }
         /// <summary> The search text to use to suggest documents. Must be at least 1 character, and no more than 100 characters. </summary>
-        public string SearchText { get; set; }
+        public string SearchText { get; }
         /// <summary> The comma-separated list of field names to search for the specified search text. Target fields must be included in the specified suggester. </summary>
         public string SearchFields { get; set; }
         /// <summary> The comma-separated list of fields to retrieve. If unspecified, only the key field will be included in the results. </summary>
         public string Select { get; set; }
         /// <summary> The name of the suggester as specified in the suggesters collection that&apos;s part of the index definition. </summary>
-        public string SuggesterName { get; set; }
+        public string SuggesterName { get; }
         /// <summary> The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5. </summary>
         public int? Top { get; set; }
     }

--- a/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/LanguageBatchInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/LanguageBatchInput.cs
@@ -33,6 +33,6 @@ namespace CognitiveServices.TextAnalytics.Models
             Documents = documents;
         }
 
-        public IList<LanguageInput> Documents { get; set; }
+        public IList<LanguageInput> Documents { get; }
     }
 }

--- a/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/LanguageInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/LanguageInput.cs
@@ -42,8 +42,8 @@ namespace CognitiveServices.TextAnalytics.Models
         }
 
         /// <summary> Unique, non-empty document identifier. </summary>
-        public string Id { get; set; }
-        public string Text { get; set; }
+        public string Id { get; }
+        public string Text { get; }
         public string CountryHint { get; set; }
     }
 }

--- a/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageBatchInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageBatchInput.cs
@@ -34,6 +34,6 @@ namespace CognitiveServices.TextAnalytics.Models
         }
 
         /// <summary> The set of documents to process as part of this batch. </summary>
-        public IList<MultiLanguageInput> Documents { get; set; }
+        public IList<MultiLanguageInput> Documents { get; }
     }
 }

--- a/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageInput.cs
@@ -42,9 +42,9 @@ namespace CognitiveServices.TextAnalytics.Models
         }
 
         /// <summary> A unique, non-empty document identifier. </summary>
-        public string Id { get; set; }
+        public string Id { get; }
         /// <summary> The input text to process. </summary>
-        public string Text { get; set; }
+        public string Text { get; }
         /// <summary> (Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use &quot;en&quot; for English; &quot;es&quot; for Spanish etc. If not set, use &quot;en&quot; for English as default. </summary>
         public string Language { get; set; }
     }

--- a/src/AutoRest.CSharp.V3/Output/Models/Types/ObjectType.cs
+++ b/src/AutoRest.CSharp.V3/Output/Models/Types/ObjectType.cs
@@ -380,7 +380,9 @@ namespace AutoRest.CSharp.V3.Output.Models.Types
                     SourceMemberMapping? memberMapping = _sourceTypeMapping?.GetForMember(name);
                     bool isReadOnly = IsStruct ||
                                       objectSchema.IsOutputOnly ||
-                                      property.ReadOnly == true;
+                                      property.ReadOnly == true ||
+                                      // Required properties of input objects should be readonly
+                                      (property.Required == true && objectSchema.IsInputOnly);
 
                     if (property.IsDiscriminator == true)
                     {

--- a/test/AutoRest.TestServer.Tests/ModelShapeTests.cs
+++ b/test/AutoRest.TestServer.Tests/ModelShapeTests.cs
@@ -19,10 +19,20 @@ namespace AutoRest.TestServer.Tests
         public void RequiredPropertiesAreSetableInMixedModels()
         {
             var requiredInt = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredInt", BindingFlags.Public | BindingFlags.Instance);
-            var requiredString = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredInt", BindingFlags.Public | BindingFlags.Instance);
+            var requiredString = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredString", BindingFlags.Public | BindingFlags.Instance);
 
             Assert.NotNull(requiredInt.SetMethod);
             Assert.NotNull(requiredString.SetMethod);
+        }
+
+        [Test]
+        public void RequiredPropertiesAreNotSetableInMixedModels()
+        {
+            var requiredInt = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredInt", BindingFlags.Public | BindingFlags.Instance);
+            var requiredString = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredString", BindingFlags.Public | BindingFlags.Instance);
+
+            Assert.Null(requiredInt.SetMethod);
+            Assert.Null(requiredString.SetMethod);
         }
     }
 }

--- a/test/AutoRest.TestServer.Tests/ModelShapeTests.cs
+++ b/test/AutoRest.TestServer.Tests/ModelShapeTests.cs
@@ -26,10 +26,10 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void RequiredPropertiesAreNotSetableInMixedModels()
+        public void RequiredPropertiesAreNotSetableInInputModels()
         {
-            var requiredInt = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredInt", BindingFlags.Public | BindingFlags.Instance);
-            var requiredString = TypeAsserts.HasProperty(typeof(MixedModel), "RequiredString", BindingFlags.Public | BindingFlags.Instance);
+            var requiredInt = TypeAsserts.HasProperty(typeof(InputModel), "RequiredInt", BindingFlags.Public | BindingFlags.Instance);
+            var requiredString = TypeAsserts.HasProperty(typeof(InputModel), "RequiredString", BindingFlags.Public | BindingFlags.Instance);
 
             Assert.Null(requiredInt.SetMethod);
             Assert.Null(requiredString.SetMethod);

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
@@ -30,7 +30,7 @@ namespace AdditionalPropertiesEx.Models
             AdditionalProperties = additionalProperties ?? new Dictionary<string, object>();
         }
 
-        public int Id { get; set; }
+        public int Id { get; }
         internal IDictionary<string, object> AdditionalProperties { get; }
         /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();

--- a/test/TestProjects/ModelShapes/Generated/Models/InputModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/InputModel.cs
@@ -61,10 +61,10 @@ namespace ModelShapes.Models
             NonRequiredIntList = nonRequiredIntList;
         }
 
-        public string RequiredString { get; set; }
-        public int RequiredInt { get; set; }
-        public IList<string> RequiredStringList { get; set; }
-        public IList<int> RequiredIntList { get; set; }
+        public string RequiredString { get; }
+        public int RequiredInt { get; }
+        public IList<string> RequiredStringList { get; }
+        public IList<int> RequiredIntList { get; }
         public string NonRequiredString { get; set; }
         public int? NonRequiredInt { get; set; }
         public IList<string> NonRequiredStringList { get; set; }

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostRequiredParameters.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostRequiredParameters.cs
@@ -43,7 +43,7 @@ namespace azure_parameter_grouping.Models
         /// <summary> Query parameter with default. </summary>
         public int? Query { get; set; }
         /// <summary> Path parameter. </summary>
-        public string Path { get; set; }
-        public int Body { get; set; }
+        public string Path { get; }
+        public int Body { get; }
     }
 }

--- a/test/TestServerProjects/azure-special-properties/Generated/Models/HeaderCustomNamedRequestIdParamGroupingParameters.cs
+++ b/test/TestServerProjects/azure-special-properties/Generated/Models/HeaderCustomNamedRequestIdParamGroupingParameters.cs
@@ -25,6 +25,6 @@ namespace azure_special_properties.Models
         }
 
         /// <summary> The fooRequestId. </summary>
-        public string FooClientRequestId { get; set; }
+        public string FooClientRequestId { get; }
     }
 }

--- a/test/TestServerProjects/model-flattening/Generated/Models/FlattenParameterGroup.cs
+++ b/test/TestServerProjects/model-flattening/Generated/Models/FlattenParameterGroup.cs
@@ -50,11 +50,11 @@ namespace model_flattening.Models
         }
 
         /// <summary> Product name with value &apos;groupproduct&apos;. </summary>
-        public string Name { get; set; }
+        public string Name { get; }
         /// <summary> Simple body product to put. </summary>
         public SimpleProduct SimpleBodyProduct { get; set; }
         /// <summary> Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles. </summary>
-        public string ProductId { get; set; }
+        public string ProductId { get; }
         /// <summary> Description of product. </summary>
         public string Description { get; set; }
         /// <summary> Display name of product. </summary>

--- a/test/TestServerProjects/paging/Generated/Models/CustomParameterGroup.cs
+++ b/test/TestServerProjects/paging/Generated/Models/CustomParameterGroup.cs
@@ -31,8 +31,8 @@ namespace paging.Models
         }
 
         /// <summary> Sets the api version to use. </summary>
-        public string ApiVersion { get; set; }
+        public string ApiVersion { get; }
         /// <summary> Sets the tenant to use. </summary>
-        public string Tenant { get; set; }
+        public string Tenant { get; }
     }
 }

--- a/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesWithOffsetOptions.cs
+++ b/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesWithOffsetOptions.cs
@@ -31,7 +31,7 @@ namespace paging.Models
         /// <summary> Sets the maximum number of items to return in the response. </summary>
         public int? Maxresults { get; set; }
         /// <summary> Offset of return value. </summary>
-        public int Offset { get; set; }
+        public int Offset { get; }
         /// <summary> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </summary>
         public int? Timeout { get; set; }
     }

--- a/test/TestServerProjects/required-optional/Generated/Models/ArrayWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/ArrayWrapper.cs
@@ -33,6 +33,6 @@ namespace required_optional.Models
             Value = value;
         }
 
-        public IList<string> Value { get; set; }
+        public IList<string> Value { get; }
     }
 }

--- a/test/TestServerProjects/required-optional/Generated/Models/ClassWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/ClassWrapper.cs
@@ -24,6 +24,6 @@ namespace required_optional.Models
             Value = value;
         }
 
-        public Product Value { get; set; }
+        public Product Value { get; }
     }
 }

--- a/test/TestServerProjects/required-optional/Generated/Models/IntWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/IntWrapper.cs
@@ -17,6 +17,6 @@ namespace required_optional.Models
             Value = value;
         }
 
-        public int Value { get; set; }
+        public int Value { get; }
     }
 }

--- a/test/TestServerProjects/required-optional/Generated/Models/Product.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/Product.cs
@@ -26,7 +26,7 @@ namespace required_optional.Models
             Name = name;
         }
 
-        public int Id { get; set; }
+        public int Id { get; }
         public string Name { get; set; }
     }
 }

--- a/test/TestServerProjects/required-optional/Generated/Models/StringWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/StringWrapper.cs
@@ -24,6 +24,6 @@ namespace required_optional.Models
             Value = value;
         }
 
-        public string Value { get; set; }
+        public string Value { get; }
     }
 }


### PR DESCRIPTION
Went overboard with a previous change.

Bring some readonly properties back along with tests.