### PR TITLE
Support additional types in WriteObjectValue

### DIFF
--- a/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
+++ b/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
@@ -63,14 +63,23 @@ namespace Azure.Core
                 case float f:
                     writer.WriteNumberValue(f);
                     break;
+                case long l:
+                    writer.WriteNumberValue(l);
+                    break;
                 case string s:
                     writer.WriteStringValue(s);
                     break;
                 case bool b:
                     writer.WriteBooleanValue(b);
                     break;
+                case Guid g:
+                    writer.WriteStringValue(g);
+                    break;
                 case DateTimeOffset dateTimeOffset:
                     writer.WriteStringValue(dateTimeOffset,"S");
+                    break;
+                case DateTime dateTime:
+                    writer.WriteStringValue(dateTime, "S");
                     break;
                 case IEnumerable<KeyValuePair<string, object>> enumerable:
                     writer.WriteStartObject();


### PR DESCRIPTION
Tables rest client attempts to serialize a few additional types that were not currently handled.