### PR TITLE
Add convinience methods for converting ResponseWithHeaders to Response

### DIFF
--- a/src/assets/Generator.Shared/ResponseWithHeaders{T,THeaders}.cs
+++ b/src/assets/Generator.Shared/ResponseWithHeaders{T,THeaders}.cs
@@ -21,5 +21,7 @@ namespace Azure.Core
         public override T Value { get; }
 
         public THeaders Headers { get; }
+
+        public static implicit operator Response(ResponseWithHeaders<T, THeaders> self) => self.GetRawResponse();
     }
 }

--- a/src/assets/Generator.Shared/ResponseWithHeaders{THeaders}.cs
+++ b/src/assets/Generator.Shared/ResponseWithHeaders{THeaders}.cs
@@ -18,5 +18,7 @@ namespace Azure.Core
         public Response GetRawResponse() => _rawResponse;
 
         public THeaders Headers { get; }
+
+        public static implicit operator Response(ResponseWithHeaders<THeaders> self) => self.GetRawResponse();
     }
 }


### PR DESCRIPTION
Now that data-plane clients wrap RestClients directly we need a convenient way to convert `ResponseWithHeaders<>` to `Response`