### PR TITLE
Revert to Z suffix for 00:00 offset for compat reasons

### DIFF
--- a/src/AutoRest.CSharp.V3/Generation/Writers/JsonCodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/JsonCodeWriterExtensions.cs
@@ -160,7 +160,14 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                                  frameworkType == typeof(DateTime) ||
                                  frameworkType == typeof(TimeSpan))
                         {
-                            writer.AppendRaw("WriteStringValue");
+                            if (valueSerialization.Format == SerializationFormat.DateTime_Unix)
+                            {
+                                writer.AppendRaw("WriteNumberValue");
+                            }
+                            else
+                            {
+                                writer.AppendRaw("WriteStringValue");
+                            }
                             writeFormat = true;
                         }
 

--- a/src/assets/Generator.Shared/JsonElementExtensions.cs
+++ b/src/assets/Generator.Shared/JsonElementExtensions.cs
@@ -63,9 +63,8 @@ namespace Azure.Core
 
         public static DateTimeOffset GetDateTimeOffset(in this JsonElement element, string format) => format switch
         {
-            "D" => element.GetDateTimeOffset(),
-            "U" => DateTimeOffset.FromUnixTimeSeconds(element.GetInt64()),
-            _ => TypeFormatters.ParseDateTimeOffset(element.GetString())
+            "U" when element.ValueKind == JsonValueKind.Number => DateTimeOffset.FromUnixTimeSeconds(element.GetInt64()),
+            _ => TypeFormatters.ParseDateTimeOffset(element.GetString(), format)
         };
 
         public static TimeSpan GetTimeSpan(in this JsonElement element, string format) =>

--- a/src/assets/Generator.Shared/TypeFormatters.cs
+++ b/src/assets/Generator.Shared/TypeFormatters.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Xml;
 
@@ -19,6 +20,7 @@ namespace Azure.Core
         {
             "D" => value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             "U" => value.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+            "O" when value.Offset == TimeSpan.Zero => value.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture),
             _ => value.ToString(format, CultureInfo.InvariantCulture)
         };
 
@@ -107,8 +109,14 @@ namespace Azure.Core
             }
         }
 
-        public static DateTimeOffset ParseDateTimeOffset(string value) =>
-            DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+        public static DateTimeOffset ParseDateTimeOffset(string value, string format)
+        {
+            return format switch
+            {
+                "U" => DateTimeOffset.FromUnixTimeSeconds(long.Parse(value)),
+                _ => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal)
+            };
+        }
 
         public static TimeSpan ParseTimeSpan(string value, string format) => format switch
         {

--- a/src/assets/Generator.Shared/TypeFormatters.cs
+++ b/src/assets/Generator.Shared/TypeFormatters.cs
@@ -12,6 +12,7 @@ namespace Azure.Core
 {
     internal class TypeFormatters
     {
+        private const string RoundtripZFormat = "yyyy-MM-ddTHH:mm:ss.fffffffZ";
         public static string DefaultNumberFormat { get; } = "G";
 
         public static string ToString(bool value) => value ? "true" : "false";
@@ -20,7 +21,8 @@ namespace Azure.Core
         {
             "D" => value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             "U" => value.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
-            "O" when value.Offset == TimeSpan.Zero => value.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture),
+            "O" when value.Offset == TimeSpan.Zero => value.ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
+            "o" when value.Offset == TimeSpan.Zero => value.ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
             _ => value.ToString(format, CultureInfo.InvariantCulture)
         };
 

--- a/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
+++ b/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
@@ -38,6 +38,13 @@ namespace Azure.Core
             }
         }
 
+        public static void WriteNumberValue(this Utf8JsonWriter writer, DateTimeOffset value, string format)
+        {
+            if (format != "U") throw new ArgumentOutOfRangeException(format, "Only 'U' format is supported when writing a DateTimeOffset as a Number.");
+
+            writer.WriteNumberValue(value.ToUnixTimeSeconds());
+        }
+
         public static void WriteObjectValue(this Utf8JsonWriter writer, object value)
         {
             switch (value)

--- a/src/assets/Generator.Shared/XElementExtensions.cs
+++ b/src/assets/Generator.Shared/XElementExtensions.cs
@@ -21,7 +21,7 @@ namespace Azure.Core
         public static DateTimeOffset GetDateTimeOffsetValue(this XElement element, string format) => format switch
         {
             "U" => DateTimeOffset.FromUnixTimeSeconds((long)element),
-            _ => TypeFormatters.ParseDateTimeOffset(element.Value)
+            _ => TypeFormatters.ParseDateTimeOffset(element.Value, format)
         };
 
         public static TimeSpan GetTimeSpanValue(this XElement element, string format) => TypeFormatters.ParseTimeSpan(element.Value, format);

--- a/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
+++ b/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
@@ -17,6 +17,8 @@ namespace Azure.Core.Tests
             new object[] { "O", new DateTimeOffset(3155378975999999999, default), "9999-12-31T23:59:59.9999999Z" },
             new object[] { "O", new DateTimeOffset(3155378975999999999, new TimeSpan(1, 0, 0)), "9999-12-31T23:59:59.9999999+01:00" },
 
+            new object[] { "o", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, default), "2020-05-04T03:02:01.1230000Z" },
+
             new object[] { "D", new DateTimeOffset(2020, 05, 04, 0,0,0,0, default), "2020-05-04" },
 
             new object[] { "U", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 0, default), "1588561321" },

--- a/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
+++ b/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class TypeFormatterTests
+    {
+        public static object[] DateTimeOffsetCases =
+        {
+            new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, default), "2020-05-04T03:02:01.1230000Z" },
+            new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, new TimeSpan(1, 0, 0)), "2020-05-04T03:02:01.1230000+01:00" },
+            new object[] { "O", new DateTimeOffset(3155378975999999999, default), "9999-12-31T23:59:59.9999999Z" },
+            new object[] { "O", new DateTimeOffset(3155378975999999999, new TimeSpan(1, 0, 0)), "9999-12-31T23:59:59.9999999+01:00" },
+
+            new object[] { "D", new DateTimeOffset(2020, 05, 04, 0,0,0,0, default), "2020-05-04" },
+
+            new object[] { "U", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 0, default), "1588561321" },
+
+            new object[] { "R", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 0, default), "Mon, 04 May 2020 03:02:01 GMT" },
+            new object[] { "R", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 0, new TimeSpan(1, 0, 0)), "Mon, 04 May 2020 02:02:01 GMT" },
+        };
+
+        [TestCaseSource(nameof(DateTimeOffsetCases))]
+        public void FormatsDatesAsString(string format, DateTimeOffset date, string expected)
+        {
+            var formatted = TypeFormatters.ToString(date, format);
+            Assert.AreEqual(expected, formatted);
+            Assert.AreEqual(date, TypeFormatters.ParseDateTimeOffset(formatted, format));
+        }
+
+        [TestCaseSource(nameof(DateTimeOffsetCases))]
+        public void FormatsDatesAsJson(string format, DateTimeOffset date, string expected)
+        {
+            using MemoryStream memoryStream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(memoryStream))
+            {
+                if (format == "U")
+                {
+                    writer.WriteNumberValue(date, format);
+                }
+                else
+                {
+                    writer.WriteStringValue(date, format);
+                }
+            }
+
+            var formatted = JsonDocument.Parse(memoryStream.ToArray()).RootElement;
+            Assert.AreEqual(expected, formatted.ToString());
+            Assert.AreEqual(date, formatted.GetDateTimeOffset(format));
+        }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/body-array.cs
+++ b/test/AutoRest.TestServer.Tests/body-array.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -213,9 +214,9 @@ namespace AutoRest.TestServer.Tests
             var result = await new ArrayClient(ClientDiagnostics, pipeline, host).GetDateValidAsync();
             CollectionAssert.AreEqual(new[]
             {
-                DateTimeOffset.Parse("2000-12-01"),
-                DateTimeOffset.Parse("1980-01-02"),
-                DateTimeOffset.Parse("1492-10-12"),
+                DateTimeOffset.Parse("2000-12-01", styles: DateTimeStyles.AssumeUniversal),
+                DateTimeOffset.Parse("1980-01-02", styles: DateTimeStyles.AssumeUniversal),
+                DateTimeOffset.Parse("1492-10-12", styles: DateTimeStyles.AssumeUniversal),
             }, result.Value);
         });
 

--- a/test/AutoRest.TestServer.Tests/body-complex.cs
+++ b/test/AutoRest.TestServer.Tests/body-complex.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -223,8 +224,8 @@ namespace AutoRest.TestServer.Tests
         public Task GetComplexPrimitiveDate() => Test(async (host, pipeline) =>
         {
             var result = await new PrimitiveClient(ClientDiagnostics, pipeline, host).GetDateAsync();
-            Assert.AreEqual(DateTimeOffset.Parse("0001-01-01"), result.Value.Field);
-            Assert.AreEqual(DateTimeOffset.Parse("2016-02-29"), result.Value.Leap);
+            Assert.AreEqual(DateTimeOffset.Parse("0001-01-01", styles: DateTimeStyles.AssumeUniversal), result.Value.Field);
+            Assert.AreEqual(DateTimeOffset.Parse("2016-02-29", styles: DateTimeStyles.AssumeUniversal), result.Value.Leap);
         });
 
         [Test]
@@ -232,8 +233,8 @@ namespace AutoRest.TestServer.Tests
         {
             var value = new DateWrapper
             {
-                Field = DateTimeOffset.Parse("0001-01-01"),
-                Leap = DateTimeOffset.Parse("2016-02-29")
+                Field = DateTimeOffset.Parse("0001-01-01", styles: DateTimeStyles.AssumeUniversal),
+                Leap = DateTimeOffset.Parse("2016-02-29", styles: DateTimeStyles.AssumeUniversal)
             };
             return await new PrimitiveClient(ClientDiagnostics, pipeline, host).PutDateAsync( value);
         });

--- a/test/AutoRest.TestServer.Tests/body-date.cs
+++ b/test/AutoRest.TestServer.Tests/body-date.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading.Tasks;
 using AutoRest.TestServer.Tests.Infrastructure;
@@ -25,14 +26,14 @@ namespace AutoRest.TestServer.Tests
         public Task GetDateMax() => Test(async (host, pipeline) =>
         {
             var result = await new DateClient(ClientDiagnostics, pipeline, host).GetMaxDateAsync();
-            Assert.AreEqual(DateTimeOffset.Parse("9999-12-31"), result.Value);
+            Assert.AreEqual(DateTimeOffset.Parse("9999-12-31", styles: DateTimeStyles.AssumeUniversal), result.Value);
         });
 
         [Test]
         public Task GetDateMin() => Test(async (host, pipeline) =>
         {
             var result = await new DateClient(ClientDiagnostics, pipeline, host).GetMinDateAsync();
-            Assert.AreEqual(DateTimeOffset.Parse("0001-01-01"), result.Value);
+            Assert.AreEqual(DateTimeOffset.Parse("0001-01-01", styles: DateTimeStyles.AssumeUniversal), result.Value);
         });
 
         [Test]

--- a/test/AutoRest.TestServer.Tests/body-datetime.cs
+++ b/test/AutoRest.TestServer.Tests/body-datetime.cs
@@ -69,6 +69,7 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
+        [IgnoreOnTestServer(TestServerVersion.V2, "Request not matched")]
         public Task PutDateTimeMaxUtc7MS() => TestStatus(async (host, pipeline) =>
         {
             var value = DateTimeOffset.Parse("9999-12-31T23:59:59.9999999Z");

--- a/test/AutoRest.TestServer.Tests/body-datetime.cs
+++ b/test/AutoRest.TestServer.Tests/body-datetime.cs
@@ -69,7 +69,6 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        [Ignore("https://github.com/Azure/autorest.csharp/issues/391")]
         public Task PutDateTimeMaxUtc7MS() => TestStatus(async (host, pipeline) =>
         {
             var value = DateTimeOffset.Parse("9999-12-31T23:59:59.9999999Z");

--- a/test/AutoRest.TestServer.Tests/body-dictionary.cs
+++ b/test/AutoRest.TestServer.Tests/body-dictionary.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml;
@@ -242,9 +243,9 @@ namespace AutoRest.TestServer.Tests
             var result = await new DictionaryClient(ClientDiagnostics, pipeline, host).GetDateValidAsync();
             CollectionAssert.AreEqual(new Dictionary<string, DateTimeOffset>
             {
-                { "0", DateTimeOffset.Parse("2000-12-01") },
-                { "1", DateTimeOffset.Parse("1980-01-02") },
-                { "2", DateTimeOffset.Parse("1492-10-12") }
+                { "0", DateTimeOffset.Parse("2000-12-01", styles: DateTimeStyles.AssumeUniversal) },
+                { "1", DateTimeOffset.Parse("1980-01-02", styles: DateTimeStyles.AssumeUniversal) },
+                { "2", DateTimeOffset.Parse("1492-10-12", styles: DateTimeStyles.AssumeUniversal) }
             }, result.Value);
         });
 
@@ -258,7 +259,7 @@ namespace AutoRest.TestServer.Tests
         public Task GetDictionaryDateWithNull() => Test((host, pipeline) =>
         {
             // Non-nullable item type
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await new DictionaryClient(ClientDiagnostics, pipeline, host).GetDateInvalidNullAsync());
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await new DictionaryClient(ClientDiagnostics, pipeline, host).GetDateInvalidNullAsync());
         });
 
         [Test]

--- a/test/TestServerProjects/body-integer/Generated/IntRestClient.cs
+++ b/test/TestServerProjects/body-integer/Generated/IntRestClient.cs
@@ -601,7 +601,7 @@ namespace body_integer
             request.Uri = uri;
             request.Headers.Add("Content-Type", "application/json");
             using var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteStringValue(intBody, "U");
+            content.JsonWriter.WriteNumberValue(intBody, "U");
             request.Content = content;
             return message;
         }


### PR DESCRIPTION
Some services don't like `+00:00` and prefer the `Z` suffix, it's allowed by the spec so add a special case.

Also fix unix time writing.

Fixes https://github.com/Azure/autorest.csharp/issues/787