### PR TITLE
Update build.yml

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -85,6 +85,7 @@ jobs:
             RepoName: azure-sdk-for-net
             PRBranchName: auto-update-autorest
             CommitMsg: Update AutoRest C# version to $(AutorestCSharpVersion)
+            PRBody: Update AutoRest C# version to $(AutorestCSharpVersion)
             PRTitle:  Update AutoRest C# version
             PushArgs: -f
             WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net


### PR DESCRIPTION
@chidozieononiwu after your PR https://github.com/Azure/azure-sdk-tools/pull/899 we broke some usages of the template, which caused some PRs like https://github.com/Azure/azure-sdk-for-net/pull/14561 to have "not-specified" as the PRBody. 