### PR TITLE
Update v3 code generation for HEAD API calls to return Response<bool> instead of Response

### DIFF
--- a/samples/AppConfiguration/AppConfiguration/Generated/ServiceClient.cs
+++ b/samples/AppConfiguration/AppConfiguration/Generated/ServiceClient.cs
@@ -44,13 +44,13 @@ namespace AppConfiguration
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> CheckKeysAsync(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> CheckKeysAsync(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckKeys");
             scope.Start();
             try
             {
-                return (await RestClient.CheckKeysAsync(name, after, acceptDatetime, cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.CheckKeysAsync(name, after, acceptDatetime, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -64,13 +64,13 @@ namespace AppConfiguration
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response CheckKeys(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
+        public virtual Response<bool> CheckKeys(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckKeys");
             scope.Start();
             try
             {
-                return RestClient.CheckKeys(name, after, acceptDatetime, cancellationToken).GetRawResponse();
+                return RestClient.CheckKeys(name, after, acceptDatetime, cancellationToken);
             }
             catch (Exception e)
             {
@@ -86,13 +86,13 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> CheckKeyValuesAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> CheckKeyValuesAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckKeyValues");
             scope.Start();
             try
             {
-                return (await RestClient.CheckKeyValuesAsync(key, label, after, acceptDatetime, select, cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.CheckKeyValuesAsync(key, label, after, acceptDatetime, select, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -108,13 +108,13 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response CheckKeyValues(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public virtual Response<bool> CheckKeyValues(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckKeyValues");
             scope.Start();
             try
             {
-                return RestClient.CheckKeyValues(key, label, after, acceptDatetime, select, cancellationToken).GetRawResponse();
+                return RestClient.CheckKeyValues(key, label, after, acceptDatetime, select, cancellationToken);
             }
             catch (Exception e)
             {
@@ -261,13 +261,13 @@ namespace AppConfiguration
         /// <param name="ifNoneMatch"> Used to perform an operation only if the targeted resource&apos;s etag does not match the value provided. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> CheckKeyValueAsync(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> CheckKeyValueAsync(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckKeyValue");
             scope.Start();
             try
             {
-                return (await RestClient.CheckKeyValueAsync(key, label, acceptDatetime, ifMatch, ifNoneMatch, select, cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.CheckKeyValueAsync(key, label, acceptDatetime, ifMatch, ifNoneMatch, select, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -284,13 +284,13 @@ namespace AppConfiguration
         /// <param name="ifNoneMatch"> Used to perform an operation only if the targeted resource&apos;s etag does not match the value provided. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response CheckKeyValue(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public virtual Response<bool> CheckKeyValue(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckKeyValue");
             scope.Start();
             try
             {
-                return RestClient.CheckKeyValue(key, label, acceptDatetime, ifMatch, ifNoneMatch, select, cancellationToken).GetRawResponse();
+                return RestClient.CheckKeyValue(key, label, acceptDatetime, ifMatch, ifNoneMatch, select, cancellationToken);
             }
             catch (Exception e)
             {
@@ -305,13 +305,13 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> CheckLabelsAsync(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> CheckLabelsAsync(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckLabels");
             scope.Start();
             try
             {
-                return (await RestClient.CheckLabelsAsync(name, after, acceptDatetime, select, cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.CheckLabelsAsync(name, after, acceptDatetime, select, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -326,13 +326,13 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response CheckLabels(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
+        public virtual Response<bool> CheckLabels(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckLabels");
             scope.Start();
             try
             {
-                return RestClient.CheckLabels(name, after, acceptDatetime, select, cancellationToken).GetRawResponse();
+                return RestClient.CheckLabels(name, after, acceptDatetime, select, cancellationToken);
             }
             catch (Exception e)
             {
@@ -432,13 +432,13 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> CheckRevisionsAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> CheckRevisionsAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckRevisions");
             scope.Start();
             try
             {
-                return (await RestClient.CheckRevisionsAsync(key, label, after, acceptDatetime, select, cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.CheckRevisionsAsync(key, label, after, acceptDatetime, select, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -454,13 +454,13 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response CheckRevisions(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
+        public virtual Response<bool> CheckRevisions(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("ServiceClient.CheckRevisions");
             scope.Start();
             try
             {
-                return RestClient.CheckRevisions(key, label, after, acceptDatetime, select, cancellationToken).GetRawResponse();
+                return RestClient.CheckRevisions(key, label, after, acceptDatetime, select, cancellationToken);
             }
             catch (Exception e)
             {

--- a/samples/AppConfiguration/AppConfiguration/Generated/ServiceRestClient.cs
+++ b/samples/AppConfiguration/AppConfiguration/Generated/ServiceRestClient.cs
@@ -161,7 +161,7 @@ namespace AppConfiguration
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<ServiceCheckKeysHeaders>> CheckKeysAsync(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, ServiceCheckKeysHeaders>> CheckKeysAsync(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckKeysRequest(name, after, acceptDatetime);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -169,7 +169,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckKeysHeaders>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -180,7 +181,7 @@ namespace AppConfiguration
         /// <param name="after"> Instructs the server to return elements that appear after the element referred to by the specified token. </param>
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<ServiceCheckKeysHeaders> CheckKeys(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, ServiceCheckKeysHeaders> CheckKeys(string name = null, string after = null, string acceptDatetime = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckKeysRequest(name, after, acceptDatetime);
             _pipeline.Send(message, cancellationToken);
@@ -188,7 +189,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckKeysHeaders>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -328,7 +330,7 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<ServiceCheckKeyValuesHeaders>> CheckKeyValuesAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, ServiceCheckKeyValuesHeaders>> CheckKeyValuesAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckKeyValuesRequest(key, label, after, acceptDatetime, select);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -336,7 +338,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckKeyValuesHeaders>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -349,7 +352,7 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<ServiceCheckKeyValuesHeaders> CheckKeyValues(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, ServiceCheckKeyValuesHeaders> CheckKeyValues(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Head6ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckKeyValuesRequest(key, label, after, acceptDatetime, select);
             _pipeline.Send(message, cancellationToken);
@@ -357,7 +360,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckKeyValuesHeaders>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -708,7 +712,7 @@ namespace AppConfiguration
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="key"/> is null. </exception>
-        public async Task<ResponseWithHeaders<ServiceCheckKeyValueHeaders>> CheckKeyValueAsync(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, ServiceCheckKeyValueHeaders>> CheckKeyValueAsync(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             if (key == null)
             {
@@ -721,7 +725,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckKeyValueHeaders>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -736,7 +741,7 @@ namespace AppConfiguration
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="key"/> is null. </exception>
-        public ResponseWithHeaders<ServiceCheckKeyValueHeaders> CheckKeyValue(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, ServiceCheckKeyValueHeaders> CheckKeyValue(string key, string label = null, string acceptDatetime = null, string ifMatch = null, string ifNoneMatch = null, IEnumerable<Head7ItemsItem> select = null, CancellationToken cancellationToken = default)
         {
             if (key == null)
             {
@@ -749,7 +754,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckKeyValueHeaders>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -878,7 +884,7 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<ServiceCheckLabelsHeaders>> CheckLabelsAsync(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, ServiceCheckLabelsHeaders>> CheckLabelsAsync(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckLabelsRequest(name, after, acceptDatetime, select);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -886,7 +892,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckLabelsHeaders>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -898,7 +905,7 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<ServiceCheckLabelsHeaders> CheckLabels(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, ServiceCheckLabelsHeaders> CheckLabels(string name = null, string after = null, string acceptDatetime = null, IEnumerable<string> select = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckLabelsRequest(name, after, acceptDatetime, select);
             _pipeline.Send(message, cancellationToken);
@@ -906,7 +913,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckLabelsHeaders>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -1232,7 +1240,7 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<ServiceCheckRevisionsHeaders>> CheckRevisionsAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, ServiceCheckRevisionsHeaders>> CheckRevisionsAsync(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckRevisionsRequest(key, label, after, acceptDatetime, select);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -1240,7 +1248,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckRevisionsHeaders>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -1253,7 +1262,7 @@ namespace AppConfiguration
         /// <param name="acceptDatetime"> Requests the server to respond with the state of the resource at the specified time. </param>
         /// <param name="select"> Used to select what fields are present in the returned resource(s). </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<ServiceCheckRevisionsHeaders> CheckRevisions(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, ServiceCheckRevisionsHeaders> CheckRevisions(string key = null, string label = null, string after = null, string acceptDatetime = null, IEnumerable<Enum5> select = null, CancellationToken cancellationToken = default)
         {
             using var message = CreateCheckRevisionsRequest(key, label, after, acceptDatetime, select);
             _pipeline.Send(message, cancellationToken);
@@ -1261,7 +1270,8 @@ namespace AppConfiguration
             switch (message.Response.Status)
             {
                 case 200:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, ServiceCheckRevisionsHeaders>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }

--- a/samples/SignalR/SignalR/Generated/HealthApiClient.cs
+++ b/samples/SignalR/SignalR/Generated/HealthApiClient.cs
@@ -36,7 +36,7 @@ namespace SignalR
 
         /// <summary> Get service health status. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadIndexAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadIndexAsync(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HealthApiClient.HeadIndex");
             scope.Start();
@@ -53,7 +53,7 @@ namespace SignalR
 
         /// <summary> Get service health status. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadIndex(CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadIndex(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HealthApiClient.HeadIndex");
             scope.Start();

--- a/samples/SignalR/SignalR/Generated/HealthApiRestClient.cs
+++ b/samples/SignalR/SignalR/Generated/HealthApiRestClient.cs
@@ -47,7 +47,7 @@ namespace SignalR
 
         /// <summary> Get service health status. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<Response> HeadIndexAsync(CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadIndexAsync(CancellationToken cancellationToken = default)
         {
             using var message = CreateHeadIndexRequest();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -55,7 +55,8 @@ namespace SignalR
             {
                 case 200:
                 case 503:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -63,7 +64,7 @@ namespace SignalR
 
         /// <summary> Get service health status. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public Response HeadIndex(CancellationToken cancellationToken = default)
+        public Response<bool> HeadIndex(CancellationToken cancellationToken = default)
         {
             using var message = CreateHeadIndexRequest();
             _pipeline.Send(message, cancellationToken);
@@ -71,7 +72,8 @@ namespace SignalR
             {
                 case 200:
                 case 503:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }

--- a/samples/SignalR/SignalR/Generated/WebSocketConnectionApiClient.cs
+++ b/samples/SignalR/SignalR/Generated/WebSocketConnectionApiClient.cs
@@ -463,7 +463,7 @@ namespace SignalR
         /// <summary> Check if the connection with the given connectionId exists. </summary>
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckDefaultHubConnectionExistenceAsync(string connectionId, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckDefaultHubConnectionExistenceAsync(string connectionId, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckDefaultHubConnectionExistence");
             scope.Start();
@@ -481,7 +481,7 @@ namespace SignalR
         /// <summary> Check if the connection with the given connectionId exists. </summary>
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckDefaultHubConnectionExistence(string connectionId, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckDefaultHubConnectionExistence(string connectionId, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckDefaultHubConnectionExistence");
             scope.Start();
@@ -656,7 +656,7 @@ namespace SignalR
         /// <param name="hub"> The String to use. </param>
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckConnectionExistenceAsync(string hub, string connectionId, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckConnectionExistenceAsync(string hub, string connectionId, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckConnectionExistence");
             scope.Start();
@@ -675,7 +675,7 @@ namespace SignalR
         /// <param name="hub"> The String to use. </param>
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckConnectionExistence(string hub, string connectionId, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckConnectionExistence(string hub, string connectionId, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckConnectionExistence");
             scope.Start();
@@ -849,7 +849,7 @@ namespace SignalR
         /// <summary> Check if there are any client connections inside the given group. </summary>
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckDefaultHubGroupExistenceAsync(string group, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckDefaultHubGroupExistenceAsync(string group, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckDefaultHubGroupExistence");
             scope.Start();
@@ -867,7 +867,7 @@ namespace SignalR
         /// <summary> Check if there are any client connections inside the given group. </summary>
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckDefaultHubGroupExistence(string group, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckDefaultHubGroupExistence(string group, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckDefaultHubGroupExistence");
             scope.Start();
@@ -1008,7 +1008,7 @@ namespace SignalR
         /// <param name="hub"> The String to use. </param>
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckGroupExistenceAsync(string hub, string group, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckGroupExistenceAsync(string hub, string group, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckGroupExistence");
             scope.Start();
@@ -1027,7 +1027,7 @@ namespace SignalR
         /// <param name="hub"> The String to use. </param>
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckGroupExistence(string hub, string group, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckGroupExistence(string hub, string group, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckGroupExistence");
             scope.Start();
@@ -1081,7 +1081,7 @@ namespace SignalR
         /// <summary> Check if there are any client connections connected for the given user. </summary>
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckDefaultHubUserExistenceAsync(string user, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckDefaultHubUserExistenceAsync(string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckDefaultHubUserExistence");
             scope.Start();
@@ -1099,7 +1099,7 @@ namespace SignalR
         /// <summary> Check if there are any client connections connected for the given user. </summary>
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckDefaultHubUserExistence(string user, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckDefaultHubUserExistence(string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckDefaultHubUserExistence");
             scope.Start();
@@ -1232,7 +1232,7 @@ namespace SignalR
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckUserExistenceInDefaultHubGroupAsync(string group, string user, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckUserExistenceInDefaultHubGroupAsync(string group, string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckUserExistenceInDefaultHubGroup");
             scope.Start();
@@ -1251,7 +1251,7 @@ namespace SignalR
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckUserExistenceInDefaultHubGroup(string group, string user, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckUserExistenceInDefaultHubGroup(string group, string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckUserExistenceInDefaultHubGroup");
             scope.Start();
@@ -1422,7 +1422,7 @@ namespace SignalR
         /// <param name="hub"> The String to use. </param>
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckUserExistenceAsync(string hub, string user, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckUserExistenceAsync(string hub, string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckUserExistence");
             scope.Start();
@@ -1441,7 +1441,7 @@ namespace SignalR
         /// <param name="hub"> The String to use. </param>
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckUserExistence(string hub, string user, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckUserExistence(string hub, string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckUserExistence");
             scope.Start();
@@ -1581,7 +1581,7 @@ namespace SignalR
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> HeadCheckUserExistenceInGroupAsync(string hub, string group, string user, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> HeadCheckUserExistenceInGroupAsync(string hub, string group, string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckUserExistenceInGroup");
             scope.Start();
@@ -1601,7 +1601,7 @@ namespace SignalR
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response HeadCheckUserExistenceInGroup(string hub, string group, string user, CancellationToken cancellationToken = default)
+        public virtual Response<bool> HeadCheckUserExistenceInGroup(string hub, string group, string user, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("WebSocketConnectionApiClient.HeadCheckUserExistenceInGroup");
             scope.Start();

--- a/samples/SignalR/SignalR/Generated/WebSocketConnectionApiRestClient.cs
+++ b/samples/SignalR/SignalR/Generated/WebSocketConnectionApiRestClient.cs
@@ -849,7 +849,7 @@ namespace SignalR
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> is null. </exception>
-        public async Task<Response> HeadCheckDefaultHubConnectionExistenceAsync(string connectionId, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckDefaultHubConnectionExistenceAsync(string connectionId, CancellationToken cancellationToken = default)
         {
             if (connectionId == null)
             {
@@ -863,7 +863,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -873,7 +874,7 @@ namespace SignalR
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> is null. </exception>
-        public Response HeadCheckDefaultHubConnectionExistence(string connectionId, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckDefaultHubConnectionExistence(string connectionId, CancellationToken cancellationToken = default)
         {
             if (connectionId == null)
             {
@@ -887,7 +888,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -1217,7 +1219,7 @@ namespace SignalR
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/> or <paramref name="connectionId"/> is null. </exception>
-        public async Task<Response> HeadCheckConnectionExistenceAsync(string hub, string connectionId, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckConnectionExistenceAsync(string hub, string connectionId, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -1235,7 +1237,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -1246,7 +1249,7 @@ namespace SignalR
         /// <param name="connectionId"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/> or <paramref name="connectionId"/> is null. </exception>
-        public Response HeadCheckConnectionExistence(string hub, string connectionId, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckConnectionExistence(string hub, string connectionId, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -1264,7 +1267,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -1579,7 +1583,7 @@ namespace SignalR
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
-        public async Task<Response> HeadCheckDefaultHubGroupExistenceAsync(string group, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckDefaultHubGroupExistenceAsync(string group, CancellationToken cancellationToken = default)
         {
             if (group == null)
             {
@@ -1593,7 +1597,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -1603,7 +1608,7 @@ namespace SignalR
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
-        public Response HeadCheckDefaultHubGroupExistence(string group, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckDefaultHubGroupExistence(string group, CancellationToken cancellationToken = default)
         {
             if (group == null)
             {
@@ -1617,7 +1622,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -1894,7 +1900,7 @@ namespace SignalR
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/> or <paramref name="group"/> is null. </exception>
-        public async Task<Response> HeadCheckGroupExistenceAsync(string hub, string group, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckGroupExistenceAsync(string hub, string group, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -1912,7 +1918,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -1923,7 +1930,7 @@ namespace SignalR
         /// <param name="group"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/> or <paramref name="group"/> is null. </exception>
-        public Response HeadCheckGroupExistence(string hub, string group, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckGroupExistence(string hub, string group, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -1941,7 +1948,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -2025,7 +2033,7 @@ namespace SignalR
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="user"/> is null. </exception>
-        public async Task<Response> HeadCheckDefaultHubUserExistenceAsync(string user, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckDefaultHubUserExistenceAsync(string user, CancellationToken cancellationToken = default)
         {
             if (user == null)
             {
@@ -2039,7 +2047,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -2049,7 +2058,7 @@ namespace SignalR
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="user"/> is null. </exception>
-        public Response HeadCheckDefaultHubUserExistence(string user, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckDefaultHubUserExistence(string user, CancellationToken cancellationToken = default)
         {
             if (user == null)
             {
@@ -2063,7 +2072,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -2308,7 +2318,7 @@ namespace SignalR
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="user"/> is null. </exception>
-        public async Task<Response> HeadCheckUserExistenceInDefaultHubGroupAsync(string group, string user, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckUserExistenceInDefaultHubGroupAsync(string group, string user, CancellationToken cancellationToken = default)
         {
             if (group == null)
             {
@@ -2326,7 +2336,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -2337,7 +2348,7 @@ namespace SignalR
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="user"/> is null. </exception>
-        public Response HeadCheckUserExistenceInDefaultHubGroup(string group, string user, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckUserExistenceInDefaultHubGroup(string group, string user, CancellationToken cancellationToken = default)
         {
             if (group == null)
             {
@@ -2355,7 +2366,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -2664,7 +2676,7 @@ namespace SignalR
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/> or <paramref name="user"/> is null. </exception>
-        public async Task<Response> HeadCheckUserExistenceAsync(string hub, string user, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckUserExistenceAsync(string hub, string user, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -2682,7 +2694,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -2693,7 +2706,7 @@ namespace SignalR
         /// <param name="user"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/> or <paramref name="user"/> is null. </exception>
-        public Response HeadCheckUserExistence(string hub, string user, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckUserExistence(string hub, string user, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -2711,7 +2724,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -2995,7 +3009,7 @@ namespace SignalR
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/>, <paramref name="group"/>, or <paramref name="user"/> is null. </exception>
-        public async Task<Response> HeadCheckUserExistenceInGroupAsync(string hub, string group, string user, CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> HeadCheckUserExistenceInGroupAsync(string hub, string group, string user, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -3017,7 +3031,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -3029,7 +3044,7 @@ namespace SignalR
         /// <param name="user"> Target user Id. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="hub"/>, <paramref name="group"/>, or <paramref name="user"/> is null. </exception>
-        public Response HeadCheckUserExistenceInGroup(string hub, string group, string user, CancellationToken cancellationToken = default)
+        public Response<bool> HeadCheckUserExistenceInGroup(string hub, string group, string user, CancellationToken cancellationToken = default)
         {
             if (hub == null)
             {
@@ -3051,7 +3066,8 @@ namespace SignalR
                 case 200:
                 case 400:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }

--- a/src/AutoRest.CSharp.V3/Generation/Writers/RestClientWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/RestClientWriter.cs
@@ -523,7 +523,17 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                         }
                         else if (returnType != null)
                         {
-                            value = Constant.Default(returnType.WithNullable(true));
+                            if (operation.Request.HttpMethod == RequestMethod.Head &&
+                                returnType.IsFrameworkType &&
+                                returnType.FrameworkType == typeof(bool))
+                            {
+                                writer.Line($"{returnType} {valueVariable:D} = {responseVariable}.Status >= 200 && {responseVariable}.Status < 300;");
+                                value = new Reference(valueVariable.ActualName, returnType);
+                            }
+                            else
+                            {
+                                value = Constant.Default(returnType.WithNullable(true));
+                            }
                         }
 
                         switch (kind)

--- a/src/AutoRest.CSharp.V3/Output/Models/RestClient.cs
+++ b/src/AutoRest.CSharp.V3/Output/Models/RestClient.cs
@@ -304,6 +304,12 @@ namespace AutoRest.CSharp.V3.Output.Models
             }
 
             var responseType = ReduceResponses(clientResponse);
+            if (responseType == null &&
+                request.HttpMethod == RequestMethod.Head &&
+                clientResponse.Count == 1)
+            {
+                responseType = new CSharpType(typeof(bool));
+            }
 
             return new RestClientMethod(
                 operationName,

--- a/test/AutoRest.TestServer.Tests/Infrastructure/TestServerTestBase.cs
+++ b/test/AutoRest.TestServer.Tests/Infrastructure/TestServerTestBase.cs
@@ -73,10 +73,23 @@ namespace AutoRest.TestServer.Tests.Infrastructure
             return TestStatus(GetScenarioName(), test, ignoreScenario, useSimplePipeline);
         }
 
+        public Task TestHeadStatus(Func<Uri, HttpPipeline, Task<Response<bool>>> test, bool ignoreScenario = false, bool useSimplePipeline = false)
+        {
+            return TestHeadStatus(GetScenarioName(), test, ignoreScenario, useSimplePipeline);
+        }
+
         private Task TestStatus(string scenario, Func<Uri, HttpPipeline, Task<Response>> test, bool ignoreScenario = false, bool useSimplePipeline = false) => Test(scenario, async (host, pipeline) =>
         {
             var response = await test(host, pipeline);
             Assert.That(response.Status, Is.EqualTo(200).Or.EqualTo(201).Or.EqualTo(202).Or.EqualTo(204), "Unexpected response " + response.ReasonPhrase);
+        }, ignoreScenario, useSimplePipeline);
+
+        private Task TestHeadStatus(string scenario, Func<Uri, HttpPipeline, Task<Response<bool>>> test, bool ignoreScenario = false, bool useSimplePipeline = false) => Test(scenario, async (host, pipeline) =>
+        {
+            var response = await test(host, pipeline);
+            Assert.That(response.Value, Is.True, "Unexpected response value");
+            var rawResponse = response.GetRawResponse();
+            Assert.That(rawResponse.Status, Is.EqualTo(200).Or.EqualTo(201).Or.EqualTo(202).Or.EqualTo(204), "Unexpected response " + rawResponse.ReasonPhrase);
         }, ignoreScenario, useSimplePipeline);
 
         public Task Test(Action<Uri, HttpPipeline> test, bool ignoreScenario = false, bool useSimplePipeline = false)

--- a/test/AutoRest.TestServer.Tests/httpInfrastructure.cs
+++ b/test/AutoRest.TestServer.Tests/httpInfrastructure.cs
@@ -186,7 +186,7 @@ namespace AutoRest.TestServer.Tests
 
         [Test]
         [IgnoreOnTestServer(TestServerVersion.V2, "404 error")]
-        public Task HttpRedirect300Head() => TestStatus(async (host, pipeline) =>
+        public Task HttpRedirect300Head() => TestHeadStatus(async (host, pipeline) =>
             await new HttpRedirectsClient(ClientDiagnostics, pipeline, host).Head300Async());
 
         [Test]
@@ -206,7 +206,7 @@ namespace AutoRest.TestServer.Tests
             await new HttpRedirectsClient(ClientDiagnostics, pipeline, host).Get302Async());
 
         [Test]
-        public Task HttpRedirect302Head() => TestStatus(async (host, pipeline) =>
+        public Task HttpRedirect302Head() => TestHeadStatus(async (host, pipeline) =>
             await new HttpRedirectsClient(ClientDiagnostics, pipeline, host).Head302Async());
 
         [Test]
@@ -230,7 +230,7 @@ namespace AutoRest.TestServer.Tests
             await new HttpRedirectsClient(ClientDiagnostics, pipeline, host).Get307Async());
 
         [Test]
-        public Task HttpRedirect307Head() => TestStatus(async (host, pipeline) =>
+        public Task HttpRedirect307Head() => TestHeadStatus(async (host, pipeline) =>
             await new HttpRedirectsClient(ClientDiagnostics, pipeline, host).Head307Async());
 
         [Test]
@@ -251,7 +251,7 @@ namespace AutoRest.TestServer.Tests
             await new HttpRedirectsClient(ClientDiagnostics, pipeline, host).Put307Async());
 
         [Test]
-        public Task HttpRetry408Head() => TestStatus(async (host, pipeline) =>
+        public Task HttpRetry408Head() => TestHeadStatus(async (host, pipeline) =>
             await new HttpRetryClient(ClientDiagnostics, pipeline, host).Head408Async());
 
         [Test]
@@ -326,7 +326,7 @@ namespace AutoRest.TestServer.Tests
         });
 
         [Test]
-        public Task HttpSuccess200Head() => TestStatus(async (host, pipeline) =>
+        public Task HttpSuccess200Head() => TestHeadStatus(async (host, pipeline) =>
             await new HttpSuccessClient(ClientDiagnostics, pipeline, host).Head200Async());
 
         [Test]
@@ -378,7 +378,7 @@ namespace AutoRest.TestServer.Tests
             await new HttpSuccessClient(ClientDiagnostics, pipeline, host).Delete204Async());
 
         [Test]
-        public Task HttpSuccess204Head() => TestStatus(async (host, pipeline) =>
+        public Task HttpSuccess204Head() => TestHeadStatus(async (host, pipeline) =>
             await new HttpSuccessClient(ClientDiagnostics, pipeline, host).Head204Async());
 
         [Test]
@@ -399,7 +399,8 @@ namespace AutoRest.TestServer.Tests
             var response = await new HttpSuccessClient(ClientDiagnostics, pipeline, host).Head404Async();
 
             // 404 is considered success in this test
-            Assert.AreEqual(404, response.Status);
+            Assert.IsFalse(response.Value);
+            Assert.AreEqual(404, response.GetRawResponse().Status);
         });
 
         [Test]

--- a/test/TestServerProjects/azure-special-properties/Generated/HeaderClient.cs
+++ b/test/TestServerProjects/azure-special-properties/Generated/HeaderClient.cs
@@ -110,13 +110,13 @@ namespace azure_special_properties
         /// <summary> Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request. </summary>
         /// <param name="fooClientRequestId"> The fooRequestId. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> CustomNamedRequestIdHeadAsync(string fooClientRequestId, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> CustomNamedRequestIdHeadAsync(string fooClientRequestId, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HeaderClient.CustomNamedRequestIdHead");
             scope.Start();
             try
             {
-                return (await RestClient.CustomNamedRequestIdHeadAsync(fooClientRequestId, cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.CustomNamedRequestIdHeadAsync(fooClientRequestId, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -128,13 +128,13 @@ namespace azure_special_properties
         /// <summary> Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request. </summary>
         /// <param name="fooClientRequestId"> The fooRequestId. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response CustomNamedRequestIdHead(string fooClientRequestId, CancellationToken cancellationToken = default)
+        public virtual Response<bool> CustomNamedRequestIdHead(string fooClientRequestId, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HeaderClient.CustomNamedRequestIdHead");
             scope.Start();
             try
             {
-                return RestClient.CustomNamedRequestIdHead(fooClientRequestId, cancellationToken).GetRawResponse();
+                return RestClient.CustomNamedRequestIdHead(fooClientRequestId, cancellationToken);
             }
             catch (Exception e)
             {

--- a/test/TestServerProjects/azure-special-properties/Generated/HeaderRestClient.cs
+++ b/test/TestServerProjects/azure-special-properties/Generated/HeaderRestClient.cs
@@ -171,7 +171,7 @@ namespace azure_special_properties
         /// <param name="fooClientRequestId"> The fooRequestId. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="fooClientRequestId"/> is null. </exception>
-        public async Task<ResponseWithHeaders<HeaderCustomNamedRequestIdHeadHeaders>> CustomNamedRequestIdHeadAsync(string fooClientRequestId, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, HeaderCustomNamedRequestIdHeadHeaders>> CustomNamedRequestIdHeadAsync(string fooClientRequestId, CancellationToken cancellationToken = default)
         {
             if (fooClientRequestId == null)
             {
@@ -185,7 +185,8 @@ namespace azure_special_properties
             {
                 case 200:
                 case 404:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HeaderCustomNamedRequestIdHeadHeaders>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -195,7 +196,7 @@ namespace azure_special_properties
         /// <param name="fooClientRequestId"> The fooRequestId. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="fooClientRequestId"/> is null. </exception>
-        public ResponseWithHeaders<HeaderCustomNamedRequestIdHeadHeaders> CustomNamedRequestIdHead(string fooClientRequestId, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, HeaderCustomNamedRequestIdHeadHeaders> CustomNamedRequestIdHead(string fooClientRequestId, CancellationToken cancellationToken = default)
         {
             if (fooClientRequestId == null)
             {
@@ -209,7 +210,8 @@ namespace azure_special_properties
             {
                 case 200:
                 case 404:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HeaderCustomNamedRequestIdHeadHeaders>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }

--- a/test/TestServerProjects/httpInfrastructure/Generated/HttpRedirectsClient.cs
+++ b/test/TestServerProjects/httpInfrastructure/Generated/HttpRedirectsClient.cs
@@ -37,13 +37,13 @@ namespace httpInfrastructure
 
         /// <summary> Return 300 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head300Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head300Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head300");
             scope.Start();
             try
             {
-                return (await RestClient.Head300Async(cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.Head300Async(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -54,13 +54,13 @@ namespace httpInfrastructure
 
         /// <summary> Return 300 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head300(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head300(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head300");
             scope.Start();
             try
             {
-                return RestClient.Head300(cancellationToken).GetRawResponse();
+                return RestClient.Head300(cancellationToken);
             }
             catch (Exception e)
             {
@@ -105,13 +105,13 @@ namespace httpInfrastructure
 
         /// <summary> Return 301 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head301Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head301Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head301");
             scope.Start();
             try
             {
-                return (await RestClient.Head301Async(cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.Head301Async(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -122,13 +122,13 @@ namespace httpInfrastructure
 
         /// <summary> Return 301 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head301(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head301(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head301");
             scope.Start();
             try
             {
-                return RestClient.Head301(cancellationToken).GetRawResponse();
+                return RestClient.Head301(cancellationToken);
             }
             catch (Exception e)
             {
@@ -207,13 +207,13 @@ namespace httpInfrastructure
 
         /// <summary> Return 302 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head302Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head302Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head302");
             scope.Start();
             try
             {
-                return (await RestClient.Head302Async(cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.Head302Async(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -224,13 +224,13 @@ namespace httpInfrastructure
 
         /// <summary> Return 302 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head302(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head302(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head302");
             scope.Start();
             try
             {
-                return RestClient.Head302(cancellationToken).GetRawResponse();
+                return RestClient.Head302(cancellationToken);
             }
             catch (Exception e)
             {
@@ -343,13 +343,13 @@ namespace httpInfrastructure
 
         /// <summary> Redirect with 307, resulting in a 200 success. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head307Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head307Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head307");
             scope.Start();
             try
             {
-                return (await RestClient.Head307Async(cancellationToken).ConfigureAwait(false)).GetRawResponse();
+                return await RestClient.Head307Async(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -360,13 +360,13 @@ namespace httpInfrastructure
 
         /// <summary> Redirect with 307, resulting in a 200 success. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head307(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head307(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRedirectsClient.Head307");
             scope.Start();
             try
             {
-                return RestClient.Head307(cancellationToken).GetRawResponse();
+                return RestClient.Head307(cancellationToken);
             }
             catch (Exception e)
             {

--- a/test/TestServerProjects/httpInfrastructure/Generated/HttpRedirectsRestClient.cs
+++ b/test/TestServerProjects/httpInfrastructure/Generated/HttpRedirectsRestClient.cs
@@ -49,7 +49,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 300 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<HttpRedirectsHead300Headers>> Head300Async(CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, HttpRedirectsHead300Headers>> Head300Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead300Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -58,7 +58,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 300:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead300Headers>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -66,7 +67,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 300 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<HttpRedirectsHead300Headers> Head300(CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, HttpRedirectsHead300Headers> Head300(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead300Request();
             _pipeline.Send(message, cancellationToken);
@@ -75,7 +76,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 300:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead300Headers>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -165,7 +167,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 301 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<HttpRedirectsHead301Headers>> Head301Async(CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, HttpRedirectsHead301Headers>> Head301Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead301Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -174,7 +176,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 301:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead301Headers>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -182,7 +185,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 301 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<HttpRedirectsHead301Headers> Head301(CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, HttpRedirectsHead301Headers> Head301(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead301Request();
             _pipeline.Send(message, cancellationToken);
@@ -191,7 +194,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 301:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead301Headers>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -308,7 +312,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 302 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<HttpRedirectsHead302Headers>> Head302Async(CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, HttpRedirectsHead302Headers>> Head302Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead302Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -317,7 +321,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 302:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead302Headers>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -325,7 +330,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 302 status code and redirect to /http/success/200. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<HttpRedirectsHead302Headers> Head302(CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, HttpRedirectsHead302Headers> Head302(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead302Request();
             _pipeline.Send(message, cancellationToken);
@@ -334,7 +339,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 302:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead302Headers>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -502,7 +508,7 @@ namespace httpInfrastructure
 
         /// <summary> Redirect with 307, resulting in a 200 success. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<ResponseWithHeaders<HttpRedirectsHead307Headers>> Head307Async(CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<bool, HttpRedirectsHead307Headers>> Head307Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead307Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -511,7 +517,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 307:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead307Headers>(value, headers, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -519,7 +526,7 @@ namespace httpInfrastructure
 
         /// <summary> Redirect with 307, resulting in a 200 success. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public ResponseWithHeaders<HttpRedirectsHead307Headers> Head307(CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<bool, HttpRedirectsHead307Headers> Head307(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead307Request();
             _pipeline.Send(message, cancellationToken);
@@ -528,7 +535,8 @@ namespace httpInfrastructure
             {
                 case 200:
                 case 307:
-                    return ResponseWithHeaders.FromValue(headers, message.Response);
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return ResponseWithHeaders.FromValue<bool, HttpRedirectsHead307Headers>(value, headers, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }

--- a/test/TestServerProjects/httpInfrastructure/Generated/HttpRetryClient.cs
+++ b/test/TestServerProjects/httpInfrastructure/Generated/HttpRetryClient.cs
@@ -36,7 +36,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 408 status code, then 200 after retry. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head408Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head408Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRetryClient.Head408");
             scope.Start();
@@ -53,7 +53,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 408 status code, then 200 after retry. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head408(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head408(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpRetryClient.Head408");
             scope.Start();

--- a/test/TestServerProjects/httpInfrastructure/Generated/HttpRetryRestClient.cs
+++ b/test/TestServerProjects/httpInfrastructure/Generated/HttpRetryRestClient.cs
@@ -49,14 +49,15 @@ namespace httpInfrastructure
 
         /// <summary> Return 408 status code, then 200 after retry. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<Response> Head408Async(CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> Head408Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead408Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
                 case 200:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -64,14 +65,15 @@ namespace httpInfrastructure
 
         /// <summary> Return 408 status code, then 200 after retry. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public Response Head408(CancellationToken cancellationToken = default)
+        public Response<bool> Head408(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead408Request();
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
                 case 200:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }

--- a/test/TestServerProjects/httpInfrastructure/Generated/HttpSuccessClient.cs
+++ b/test/TestServerProjects/httpInfrastructure/Generated/HttpSuccessClient.cs
@@ -36,7 +36,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 200 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head200Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head200Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpSuccessClient.Head200");
             scope.Start();
@@ -53,7 +53,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 200 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head200(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head200(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpSuccessClient.Head200");
             scope.Start();
@@ -478,7 +478,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 204 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head204Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head204Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpSuccessClient.Head204");
             scope.Start();
@@ -495,7 +495,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 204 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head204(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head204(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpSuccessClient.Head204");
             scope.Start();
@@ -648,7 +648,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 404 status code. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> Head404Async(CancellationToken cancellationToken = default)
+        public virtual async Task<Response<bool>> Head404Async(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpSuccessClient.Head404");
             scope.Start();
@@ -665,7 +665,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 404 status code. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Head404(CancellationToken cancellationToken = default)
+        public virtual Response<bool> Head404(CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("HttpSuccessClient.Head404");
             scope.Start();

--- a/test/TestServerProjects/httpInfrastructure/Generated/HttpSuccessRestClient.cs
+++ b/test/TestServerProjects/httpInfrastructure/Generated/HttpSuccessRestClient.cs
@@ -49,14 +49,15 @@ namespace httpInfrastructure
 
         /// <summary> Return 200 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<Response> Head200Async(CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> Head200Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead200Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
                 case 200:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -64,14 +65,15 @@ namespace httpInfrastructure
 
         /// <summary> Return 200 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public Response Head200(CancellationToken cancellationToken = default)
+        public Response<bool> Head200(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead200Request();
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
                 case 200:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -668,14 +670,15 @@ namespace httpInfrastructure
 
         /// <summary> Return 204 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<Response> Head204Async(CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> Head204Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead204Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
                 case 204:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -683,14 +686,15 @@ namespace httpInfrastructure
 
         /// <summary> Return 204 status code if successful. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public Response Head204(CancellationToken cancellationToken = default)
+        public Response<bool> Head204(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead204Request();
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
                 case 204:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }
@@ -899,7 +903,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 404 status code. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public async Task<Response> Head404Async(CancellationToken cancellationToken = default)
+        public async Task<Response<bool>> Head404Async(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead404Request();
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -907,7 +911,8 @@ namespace httpInfrastructure
             {
                 case 204:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
             }
@@ -915,7 +920,7 @@ namespace httpInfrastructure
 
         /// <summary> Return 404 status code. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public Response Head404(CancellationToken cancellationToken = default)
+        public Response<bool> Head404(CancellationToken cancellationToken = default)
         {
             using var message = CreateHead404Request();
             _pipeline.Send(message, cancellationToken);
@@ -923,7 +928,8 @@ namespace httpInfrastructure
             {
                 case 204:
                 case 404:
-                    return message.Response;
+                    bool value = message.Response.Status >= 200 && message.Response.Status < 300;
+                    return Response.FromValue(value, message.Response);
                 default:
                     throw _clientDiagnostics.CreateRequestFailedException(message.Response);
             }


### PR DESCRIPTION
This updates the v3 code generator to have the Operations/RestOperations return `Response<bool>` instead of just `Response` for HEAD API calls.  `true`/`false` is defined similarly to how I saw prior versions of autorest do it (https://github.com/Azure/autorest.common/blob/b9ca0fb9f2c5e69993054ceabf84e336b2d73f58/src/AzureExtensions.cs#L93).  I found my way here through azure/azure-sdk-for-net#14235, and code changes that come about from this can be seen here (https://github.com/AtOMiCNebula/azure-sdk-for-net/commit/fb6e34a1411299350d0c74b670a08bb3dc60c330, for viewing purposes only, I know a bot handles most of the codegen updates).  Some test fixes will be needed too once the new codegen arrives in the Resources project (https://github.com/AtOMiCNebula/azure-sdk-for-net/commit/f06b0d3b20915447276fd7f44578cd29cb0c921a), though it's currently still pinned to an older autorest.csharp, so not yet.  I'm sure you can offer suggestions on the right way to organize that. :smile:

Happy to make any changes here!  I don't grok where the line with M4 ends and this one begins, so if part of this should go into M4 or not, I'd appreciate pointers.  It'd probably be nice to have better API usability in other languages too, but I haven't looked into them at all to know if they have the same shortcoming as the C# code generator did here.

Thanks!