### PR TITLE
Update .NET SDK and runtime to 2.2 for Ubuntu 20 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@microsoft.azure/autorest.modeler": "2.3.55",
     "autorest": "^2.0.4255",
     "coffee-script": "^1.11.1",
-    "dotnet-sdk-2.0.0": "^1.4.4",
+    "dotnet-sdk-2.2": "^2.2.1005",
     "gulp": "^3.9.1",
     "gulp-filter": "^5.0.0",
     "gulp-line-ending-corrector": "^1.0.1",
@@ -51,6 +51,6 @@
     "yarn": "^1.0.2"
   },
   "dependencies": {
-    "dotnet-2.0.0": "^1.4.4"
+    "dotnet-2.2": "^2.2.1005"
   }
 }


### PR DESCRIPTION
This change fixes an issue (https://github.com/Azure/autorest/issues/3601) which reports that the `@microsoft.azure/autorest.csharp` generator no longer works on Ubuntu 20 (neither in WSL 2 or native Ubuntu 20).  The reason for this is that the version of .NET Core used (2.0) doesn't support libssl 1.1, resulting in this error at runtime:

```
No usable version of the libssl was found
```

The fix is to update the .NET Core version to 2.2 which contains a fix for this issue.