### PR TITLE
Enable runtime roll forward 

### DIFF
--- a/src/AutoRest.CSharp.V3/package.json
+++ b/src/AutoRest.CSharp.V3/package.json
@@ -3,7 +3,7 @@
   "name": "@autorest/csharp-v3",
   "description": "See readme.md for details",
   "scripts": {
-    "start": "dotnet ./AutoRest.CSharp.V3.dll --server"
+    "start": "dotnet --roll-forward Major ./AutoRest.CSharp.V3.dll --server"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
To allow running when .net 3.0 is not installed but later version is.