### PR TITLE
Add optional cref hints to inheritdoc comments

### DIFF
--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/FacetResult.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/FacetResult.cs
@@ -44,7 +44,7 @@ namespace CognitiveSearch.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public object this[string key]

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/FacetResult.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/FacetResult.cs
@@ -44,7 +44,7 @@ namespace CognitiveSearch.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public object this[string key]

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/IndexAction.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/IndexAction.cs
@@ -35,23 +35,23 @@ namespace CognitiveSearch.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, object value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public object this[string key]

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SearchResult.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SearchResult.cs
@@ -51,7 +51,7 @@ namespace CognitiveSearch.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public object this[string key]

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SearchResult.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SearchResult.cs
@@ -51,7 +51,7 @@ namespace CognitiveSearch.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public object this[string key]

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SuggestResult.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SuggestResult.cs
@@ -53,7 +53,7 @@ namespace CognitiveSearch.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public object this[string key]

--- a/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SuggestResult.cs
+++ b/samples/CognitiveSearch/CognitiveSearch/Generated/Models/SuggestResult.cs
@@ -53,7 +53,7 @@ namespace CognitiveSearch.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public object this[string key]

--- a/src/AutoRest.CSharp.V3/Generation/Writers/DocumentationWriterExtensions.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/DocumentationWriterExtensions.cs
@@ -12,11 +12,18 @@ namespace AutoRest.CSharp.V3.Generation.Writers
 {
     internal static class DocumentationWriterExtensions
     {
-        private static readonly char[] _newLineChars = {'\r', '\n'};
+        private static readonly char[] _newLineChars = { '\r', '\n' };
 
-        public static CodeWriter WriteXmlDocumentationInheritDoc(this CodeWriter writer)
+        public static CodeWriter WriteXmlDocumentationInheritDoc(this CodeWriter writer, string? cref = null)
         {
-            return writer.Line($"/// <inheritdoc />");
+            if (string.IsNullOrWhiteSpace(cref))
+            {
+                return writer.Line($"/// <inheritdoc />");
+            }
+            else
+            {
+                return writer.Line($"/// <inheritdoc cref=\"{cref}\"/>");
+            }
         }
 
         public static CodeWriter WriteXmlDocumentationSummary(this CodeWriter writer, string? text)

--- a/src/AutoRest.CSharp.V3/Generation/Writers/ModelWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ModelWriter.cs
@@ -36,6 +36,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
         private void WriteObjectSchema(CodeWriter writer, ObjectType schema)
         {
             const string collectionOfT = "ICollection{T}.";
+            const string readonlyCollectionOfT = "IReadOnlyCollection{T}.";
             using (writer.Namespace(schema.Declaration.Namespace))
             {
                 List<CSharpType> implementsTypes = new List<CSharpType>();
@@ -122,7 +123,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                             .Line($"public {iCollectionKeyType} Keys => {additionalProperties}.Keys;")
                             .WriteXmlDocumentationInheritDoc()
                             .Line($"public {iCollectionItemType} Values => {additionalProperties}.Values;")
-                            .WriteXmlDocumentationInheritDoc($"{collectionOfT}Count")
+                            .WriteXmlDocumentationInheritDoc($"{(isReadonly ? readonlyCollectionOfT : collectionOfT)}Count")
                             .Line($"int {iCollectionKeyValuePairType}.Count => {additionalProperties}.Count;");
 
                         if (!isReadonly)

--- a/src/AutoRest.CSharp.V3/Generation/Writers/ModelWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ModelWriter.cs
@@ -35,6 +35,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
 
         private void WriteObjectSchema(CodeWriter writer, ObjectType schema)
         {
+            const string collectionOfT = "Collection{T}.";
             using (writer.Namespace(schema.Declaration.Namespace))
             {
                 List<CSharpType> implementsTypes = new List<CSharpType>();
@@ -121,7 +122,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                             .Line($"public {iCollectionKeyType} Keys => {additionalProperties}.Keys;")
                             .WriteXmlDocumentationInheritDoc()
                             .Line($"public {iCollectionItemType} Values => {additionalProperties}.Values;")
-                            .WriteXmlDocumentationInheritDoc()
+                            .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Count")
                             .Line($"int {iCollectionKeyValuePairType}.Count => {additionalProperties}.Count;");
 
                         if (!isReadonly)
@@ -131,17 +132,17 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                                 .Line($"public void Add({keyType} key, {itemType} value) => {additionalProperties}.Add(key, value);")
                                 .WriteXmlDocumentationInheritDoc()
                                 .Line($"public bool Remove({keyType} key) => {additionalProperties}.Remove(key);")
-                                .WriteXmlDocumentationInheritDoc()
+                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}IsReadOnly")
                                 .Line($"bool {iCollectionKeyValuePairType}.IsReadOnly => {additionalProperties}.IsReadOnly;")
-                                .WriteXmlDocumentationInheritDoc()
+                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Add")
                                 .Line($"void {iCollectionKeyValuePairType}.Add({keyValuePairType} value) => {additionalProperties}.Add(value);")
-                                .WriteXmlDocumentationInheritDoc()
+                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Remove")
                                 .Line($"bool {iCollectionKeyValuePairType}.Remove({keyValuePairType} value) => {additionalProperties}.Remove(value);")
-                                .WriteXmlDocumentationInheritDoc()
+                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Contains")
                                 .Line($"bool {iCollectionKeyValuePairType}.Contains({keyValuePairType} value) => {additionalProperties}.Contains(value);")
-                                .WriteXmlDocumentationInheritDoc()
+                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}CopyTo")
                                 .Line($"void {iCollectionKeyValuePairType}.CopyTo({keyValuePairType}[] destination, int offset) => {additionalProperties}.CopyTo(destination, offset);")
-                                .WriteXmlDocumentationInheritDoc()
+                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Clear")
                                 .Line($"void {iCollectionKeyValuePairType}.Clear() => {additionalProperties}.Clear();");
                         }
 

--- a/src/AutoRest.CSharp.V3/Generation/Writers/ModelWriter.cs
+++ b/src/AutoRest.CSharp.V3/Generation/Writers/ModelWriter.cs
@@ -35,7 +35,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
 
         private void WriteObjectSchema(CodeWriter writer, ObjectType schema)
         {
-            const string collectionOfT = "Collection{T}.";
+            const string collectionOfT = "ICollection{T}.";
             using (writer.Namespace(schema.Declaration.Namespace))
             {
                 List<CSharpType> implementsTypes = new List<CSharpType>();
@@ -122,7 +122,7 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                             .Line($"public {iCollectionKeyType} Keys => {additionalProperties}.Keys;")
                             .WriteXmlDocumentationInheritDoc()
                             .Line($"public {iCollectionItemType} Values => {additionalProperties}.Values;")
-                            .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Count")
+                            .WriteXmlDocumentationInheritDoc($"{collectionOfT}Count")
                             .Line($"int {iCollectionKeyValuePairType}.Count => {additionalProperties}.Count;");
 
                         if (!isReadonly)
@@ -132,17 +132,17 @@ namespace AutoRest.CSharp.V3.Generation.Writers
                                 .Line($"public void Add({keyType} key, {itemType} value) => {additionalProperties}.Add(key, value);")
                                 .WriteXmlDocumentationInheritDoc()
                                 .Line($"public bool Remove({keyType} key) => {additionalProperties}.Remove(key);")
-                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}IsReadOnly")
+                                .WriteXmlDocumentationInheritDoc($"{collectionOfT}IsReadOnly")
                                 .Line($"bool {iCollectionKeyValuePairType}.IsReadOnly => {additionalProperties}.IsReadOnly;")
-                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Add")
+                                .WriteXmlDocumentationInheritDoc($"{collectionOfT}Add")
                                 .Line($"void {iCollectionKeyValuePairType}.Add({keyValuePairType} value) => {additionalProperties}.Add(value);")
-                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Remove")
+                                .WriteXmlDocumentationInheritDoc($"{collectionOfT}Remove")
                                 .Line($"bool {iCollectionKeyValuePairType}.Remove({keyValuePairType} value) => {additionalProperties}.Remove(value);")
-                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Contains")
+                                .WriteXmlDocumentationInheritDoc($"{collectionOfT}Contains")
                                 .Line($"bool {iCollectionKeyValuePairType}.Contains({keyValuePairType} value) => {additionalProperties}.Contains(value);")
-                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}CopyTo")
+                                .WriteXmlDocumentationInheritDoc($"{collectionOfT}CopyTo")
                                 .Line($"void {iCollectionKeyValuePairType}.CopyTo({keyValuePairType}[] destination, int offset) => {additionalProperties}.CopyTo(destination, offset);")
-                                .WriteXmlDocumentationInheritDoc($"I{collectionOfT}Clear")
+                                .WriteXmlDocumentationInheritDoc($"{collectionOfT}Clear")
                                 .Line($"void {iCollectionKeyValuePairType}.Clear() => {additionalProperties}.Clear();");
                         }
 

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
@@ -36,23 +36,23 @@ namespace AdditionalPropertiesEx.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, object value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public object this[string key]

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModelStruct.cs
@@ -43,23 +43,23 @@ namespace AdditionalPropertiesEx.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, object value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public object this[string key]

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
@@ -45,7 +45,7 @@ namespace AdditionalPropertiesEx.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public string this[string key]

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
@@ -45,7 +45,7 @@ namespace AdditionalPropertiesEx.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public string this[string key]

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
@@ -43,7 +43,7 @@ namespace AdditionalPropertiesEx.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public string this[string key]

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
@@ -43,7 +43,7 @@ namespace AdditionalPropertiesEx.Models
         public IEnumerable<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public IEnumerable<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
         int IReadOnlyCollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public string this[string key]

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPInPropertiesWithAPString.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPInPropertiesWithAPString.cs
@@ -67,23 +67,23 @@ namespace additionalProperties.Models
         public ICollection<string> Keys => MoreAdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<string> Values => MoreAdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, string>>.Count => MoreAdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, string value) => MoreAdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => MoreAdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, string>>.IsReadOnly => MoreAdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> value) => MoreAdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> value) => MoreAdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> value) => MoreAdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] destination, int offset) => MoreAdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, string>>.Clear() => MoreAdditionalProperties.Clear();
         /// <inheritdoc />
         public string this[string key]

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPObject.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPObject.cs
@@ -51,23 +51,23 @@ namespace additionalProperties.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, object value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public object this[string key]

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPString.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPString.cs
@@ -51,23 +51,23 @@ namespace additionalProperties.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, string value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, string>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, string>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public string this[string key]

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPTrue.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPTrue.cs
@@ -51,23 +51,23 @@ namespace additionalProperties.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, object value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public object this[string key]

--- a/test/TestServerProjects/body-complex/Generated/Models/SmartSalmon.cs
+++ b/test/TestServerProjects/body-complex/Generated/Models/SmartSalmon.cs
@@ -52,23 +52,23 @@ namespace body_complex.Models
         public ICollection<string> Keys => AdditionalProperties.Keys;
         /// <inheritdoc />
         public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Count"/>
         int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
         /// <inheritdoc />
         public void Add(string key, object value) => AdditionalProperties.Add(key, value);
         /// <inheritdoc />
         public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc />
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
         void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
         /// <inheritdoc />
         public object this[string key]


### PR DESCRIPTION
# Summary
The purpose of this change is to avoid inheritdoc ambiguous inheritance warnings by allowing the generator to add `cref=` hints to inheritdoc comments.