### PR TITLE
Update the readme to list/link to the correct .NET Core SDK

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@
 ## Prerequisites
 
 - [NodeJS (14.x.x)](https://nodejs.org/en/) 
-- [.NET Core SDK (3.0.100)](https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- [.NET Core SDK (3.1.301)](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 - [PowerShell Core 7](https://github.com/PowerShell/PowerShell/releases/latest)
 - [Java](https://www.java.com/en/download/) (for V2 testserver)
 - `npm install` (at root)


### PR DESCRIPTION
Merging this will update the readme prerequisite list to specify and link to .NET Core SDK 3.1

- Currently if following the project's readme, you cannot build since 3.0 is documented, while 3.1 is required in `global.json`
- Given netcore3.0 reached end of support March 2020, while netcore3.1 is an LTS this seems like the preferable SDK
- See alternative PR: "Revert (mistaken?) change to .NET Core SDK on global.json"
- Tested by running `dotnet build` with only 3.1.404, 5.0.100, 5.0.101 SDKs installed (`ls '\Program Files\dotnet\sdk\'`)
- Requirement changed in commit d1028d8fab1c94cffb7db89f9746298d51c4c8ea/2020-09-15