### PR TITLE
Revert (mistaken?) change to .NET Core SDK on global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.301",
+    "version": "3.0.100",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
Merging this will revert the .NET Core SDK requirements back to version 3.0.100 as documented in the readme

- Currently if following the project's readme, you cannot build since 3.0 is documented, while 3.1 is required in `global.json`
- Given netcore3.0 reached end of support March 2020, maybe this change was deliberate
- See alternative PR: "Update the readme to list/link to the correct .NET Core SDK" #970
- Tested by running `dotnet build` with only 3.0.103, 5.0.100, 5.0.101 SDKs installed (`ls '\Program Files\dotnet\sdk\'`)
- Original change made in commit d1028d8fab1c94cffb7db89f9746298d51c4c8ea/2020-09-15