### PR TITLE
Rename nuget package to Microsoft.Azure.AutoRest.CSharp and swap to single feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/eng/UpdateAzureSdkForNet.ps1
+++ b/eng/UpdateAzureSdkForNet.ps1
@@ -9,8 +9,8 @@ $RepoRoot = Resolve-Path "$PSScriptRoot/.."
 $PackagesProps = "$SdkRepoRoot\eng\Packages.Data.props"
 
 (Get-Content -Raw $PackagesProps) -replace`
-    '<PackageReference Update="AutoRest.CSharp" Version=".*?" />',
-    "<PackageReference Update=`"AutoRest.CSharp`" Version=`"$Version`" PrivateAssets=`"All`" />" | `
+    '<PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version=".*?" />',
+    "<PackageReference Update=`"Microsoft.Azure.AutoRest.CSharp`" Version=`"$Version`" PrivateAssets=`"All`" />" | `
     Set-Content $PackagesProps -NoNewline
 
 dotnet msbuild /restore /t:GenerateCode "$SdkRepoRoot\eng\service.proj"

--- a/readme.md
+++ b/readme.md
@@ -107,10 +107,10 @@ This way, every binding stays in lockstep with the current generator
 </configuration>
 ```
 
-2. Add a package reference to `AutoRest.CSharp` version `1.0.0-alpha.20201013.3` or later:
+2. Add a package reference to `Microsoft.Azure.AutoRest.CSharp` version `v3.0.0-beta.20210120.1` or later:
 
 ```xml
-<PackageReference Include="AutoRest.CSharp" Version="1.0.0-alpha.20201013.3" />
+<PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version=" v3.0.0-beta.20210120.1" />
 ```
 
 3. Add an `autorest.md` configuration file pointing to you swagger file:

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageId>Microsoft.Azure.AutoRest.CSharp</PackageId>
     <OutputType>Exe</OutputType>
     <Version>3.0.0</Version>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -28,8 +29,8 @@
     <Compile Include="../../src/assets/**/*.cs" />
     <TfmSpecificPackageFile Include="../../src/assets/" PackagePath="content" />
 
-    <Content Include="build\CodeGeneration.targets" PackagePath="build\AutoRest.CSharp.targets" />
-    <Content Include="build\CodeGeneration.targets" PackagePath="buildMultiTargeting\AutoRest.CSharp.targets" />
+    <Content Include="build\CodeGeneration.targets" PackagePath="build\Microsoft.Azure.AutoRest.CSharp.targets" />
+    <Content Include="build\CodeGeneration.targets" PackagePath="buildMultiTargeting\Microsoft.Azure.AutoRest.CSharp.targets" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,7 +48,7 @@
       <_RawUrl>$(_SourceRoot)$(_RelativePath.Replace('\', '/'))/*</_RawUrl>
       <_ReadmeMdPath>$(_RepoRoot)readme.md</_ReadmeMdPath>
       <_PackageJsonPath>$(_RepoRoot)package.json</_PackageJsonPath>
-      <_GeneratedPropsFilePath>$(IntermediateOutputPath)/AutoRest.CSharp.props</_GeneratedPropsFilePath>
+      <_GeneratedPropsFilePath>$(IntermediateOutputPath)/Microsoft.Azure.AutoRest.CSharp.props</_GeneratedPropsFilePath>
 
       <_ReadmeMdLines>$([System.IO.File]::ReadAllText($(_ReadmeMdPath)))</_ReadmeMdLines>
       <_PackageJsonLines>$([System.IO.File]::ReadAllText($(_PackageJsonPath)))</_PackageJsonLines>


### PR DESCRIPTION
- Fixes https://github.com/Azure/autorest.csharp/issues/991
- Tested by applying https://gist.github.com/chamons/47c56587b62a114ce364e08070c83d43 to azure-sdk-for-net and building one synapse lib with a local nuget feed