### PR TITLE
Send large longs in a correct notation

### DIFF
--- a/src/assets/Generator.Shared/RequestHeaderExtensions.cs
+++ b/src/assets/Generator.Shared/RequestHeaderExtensions.cs
@@ -31,6 +31,11 @@ namespace Azure.Core
             headers.Add(name, value.ToString(TypeFormatters.DefaultNumberFormat, CultureInfo.InvariantCulture));
         }
 
+        public static void Add(this RequestHeaders headers, string name, long value)
+        {
+            headers.Add(name, value.ToString(TypeFormatters.DefaultNumberFormat, CultureInfo.InvariantCulture));
+        }
+
         public static void Add(this RequestHeaders headers, string name, DateTimeOffset value, string format)
         {
             headers.Add(name, TypeFormatters.ToString(value, format));

--- a/test/AutoRest.TestServer.Tests/header.cs
+++ b/test/AutoRest.TestServer.Tests/header.cs
@@ -67,6 +67,21 @@ namespace AutoRest.TestServer.Tests
         public Task HeaderParameterLongPositive() => TestStatus(async (host, pipeline) => await new HeaderClient(ClientDiagnostics, pipeline, host).ParamLongAsync( scenario: "positive", 105));
 
         [Test]
+        public async Task HeaderParameterLongPositiveMaxLong()
+        {
+            string value = null;
+            using var testServer = new InProcTestServer(async content =>
+            {
+                value = content.Request.Headers["value"];
+                await content.Response.Body.FlushAsync();
+            });
+
+            await new HeaderClient(ClientDiagnostics, InProcTestBase.HttpPipeline, testServer.Address).ParamLongAsync(scenario: "positive", long.MaxValue);
+
+            Assert.AreEqual(long.MaxValue.ToString("G"), value);
+        }
+
+        [Test]
         public Task HeaderParameterLongNegative() => TestStatus(async (host, pipeline) => await new HeaderClient(ClientDiagnostics, pipeline, host).ParamLongAsync( scenario: "negative", -2));
 
         [Test]


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.csharp/issues/990