### PR TITLE
Make x-ms-header-collection-prefix dictionaries case-insensitive

### DIFF
--- a/src/assets/Generator.Shared/ResponseHeadersExtensions.cs
+++ b/src/assets/Generator.Shared/ResponseHeadersExtensions.cs
@@ -74,7 +74,7 @@ namespace Azure.Core
 
         public static bool TryGetValue(this ResponseHeaders headers, string prefix, out IDictionary<string, string> value)
         {
-            value = new Dictionary<string, string>();
+            value = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (HttpHeader item in headers)
             {

--- a/test/AutoRest.TestServer.Tests/HeaderCollectionPrefixTests.cs
+++ b/test/AutoRest.TestServer.Tests/HeaderCollectionPrefixTests.cs
@@ -39,8 +39,11 @@ namespace AutoRest.TestServer.Tests
             Assert.True(requestHeaders.TryGetValue("x-ms-meta-c", out value) && value == "c");
 
             Assert.True(responseHeaders.Headers.Metadata.TryGetValue("a", out value) && value == "a");
+            Assert.True(responseHeaders.Headers.Metadata.TryGetValue("A", out value) && value == "a");
             Assert.True(responseHeaders.Headers.Metadata.TryGetValue("b", out value) && value == "b");
             Assert.True(responseHeaders.Headers.Metadata.TryGetValue("c", out value) && value == "c");
+
+            Assert.False(responseHeaders.Headers.Metadata.IsReadOnly);
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.csharp/issues/1040