### PR TITLE
Fix LRO create request from relative path on Unix

### DIFF
--- a/src/assets/Generator.Shared/ArmOperationHelpers.cs
+++ b/src/assets/Generator.Shared/ArmOperationHelpers.cs
@@ -174,7 +174,7 @@ namespace Azure.Core
             Request request = message.Request;
             request.Method = RequestMethod.Get;
 
-            if (Uri.TryCreate(link, UriKind.Absolute, out var nextLink))
+            if (Uri.TryCreate(link, UriKind.Absolute, out var nextLink) && nextLink.Scheme != "file")
             {
                 request.Uri.Reset(nextLink);
             }


### PR DESCRIPTION
On the netcoreapp2.1 Uri.TryCreate has a different behavior when link is relative path.

See issue here:
https://github.com/Azure/autorest.csharp/issues/1058