### PR TITLE
Fix feature/v3 integration with azure-sdk-for-net

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1001,7 +1001,7 @@ input-file: "swagger-document"
 
 ```yaml
 # autorest-core version
-version: 3.1.0-dev.3
+version: 3.0.6371
 save-inputs: true
 use: $(this-folder)/artifacts/bin/AutoRest.CSharp/Debug/netcoreapp3.0/
 clear-output-folder: true

--- a/src/assets/Generator.Shared/FormUrlEncodedContent.cs
+++ b/src/assets/Generator.Shared/FormUrlEncodedContent.cs
@@ -13,13 +13,13 @@ namespace Azure.Core
 {
     internal class FormUrlEncodedContent : RequestContent
     {
-        private List<KeyValuePair<string?, string?>> _values = new List<KeyValuePair<string?, string?>>();
+        private List<KeyValuePair<string, string>> _values = new List<KeyValuePair<string, string>>();
         private Encoding Latin1 = Encoding.GetEncoding("iso-8859-1");
-        private byte[] _bytes = new byte[0];
+        private byte[] _bytes = Array.Empty<byte>();
 
         public void Add (string parameter, string value)
         {
-            _values.Add(new KeyValuePair<string?, string?> (parameter, value));
+            _values.Add(new KeyValuePair<string, string> (parameter, value));
         }
 
         private void BuildIfNeeded ()
@@ -55,7 +55,7 @@ namespace Azure.Core
         }
 
         // Taken with love from https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs#L21-L53
-        private byte[] GetContentByteArray(IEnumerable<KeyValuePair<string?, string?>> nameValueCollection)
+        private byte[] GetContentByteArray(IEnumerable<KeyValuePair<string, string>> nameValueCollection)
         {
             if (nameValueCollection == null)
             {
@@ -64,7 +64,7 @@ namespace Azure.Core
 
             // Encode and concatenate data
             StringBuilder builder = new StringBuilder();
-            foreach (KeyValuePair<string?, string?> pair in nameValueCollection)
+            foreach (KeyValuePair<string, string> pair in nameValueCollection)
             {
                 if (builder.Length > 0)
                 {
@@ -79,7 +79,7 @@ namespace Azure.Core
             return Latin1.GetBytes(builder.ToString());
         }
 
-        private static string Encode(string? data)
+        private static string Encode(string data)
         {
             if (string.IsNullOrEmpty(data))
             {


### PR DESCRIPTION
- Autorest core 3.0.6372 and above crash due to directive ordering bug Tim is digging into now
- New shared code does not compile cleanly with azure-sdk-for-net rules