### PR TITLE
Hide paging classes

### DIFF
--- a/samples/AppConfiguration/Generated/Models/KeyListResult.Serialization.cs
+++ b/samples/AppConfiguration/Generated/Models/KeyListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace AppConfiguration.Models
 {
-    public partial class KeyListResult
+    internal partial class KeyListResult
     {
         internal static KeyListResult DeserializeKeyListResult(JsonElement element)
         {

--- a/samples/AppConfiguration/Generated/Models/KeyListResult.cs
+++ b/samples/AppConfiguration/Generated/Models/KeyListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace AppConfiguration.Models
 {
     /// <summary> The result of a list request. </summary>
-    public partial class KeyListResult
+    internal partial class KeyListResult
     {
         /// <summary> Initializes a new instance of KeyListResult. </summary>
         internal KeyListResult()

--- a/samples/AppConfiguration/Generated/Models/KeyValueListResult.Serialization.cs
+++ b/samples/AppConfiguration/Generated/Models/KeyValueListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace AppConfiguration.Models
 {
-    public partial class KeyValueListResult
+    internal partial class KeyValueListResult
     {
         internal static KeyValueListResult DeserializeKeyValueListResult(JsonElement element)
         {

--- a/samples/AppConfiguration/Generated/Models/KeyValueListResult.cs
+++ b/samples/AppConfiguration/Generated/Models/KeyValueListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace AppConfiguration.Models
 {
     /// <summary> The result of a list request. </summary>
-    public partial class KeyValueListResult
+    internal partial class KeyValueListResult
     {
         /// <summary> Initializes a new instance of KeyValueListResult. </summary>
         internal KeyValueListResult()

--- a/samples/AppConfiguration/Generated/Models/LabelListResult.Serialization.cs
+++ b/samples/AppConfiguration/Generated/Models/LabelListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace AppConfiguration.Models
 {
-    public partial class LabelListResult
+    internal partial class LabelListResult
     {
         internal static LabelListResult DeserializeLabelListResult(JsonElement element)
         {

--- a/samples/AppConfiguration/Generated/Models/LabelListResult.cs
+++ b/samples/AppConfiguration/Generated/Models/LabelListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace AppConfiguration.Models
 {
     /// <summary> The result of a list request. </summary>
-    public partial class LabelListResult
+    internal partial class LabelListResult
     {
         /// <summary> Initializes a new instance of LabelListResult. </summary>
         internal LabelListResult()

--- a/samples/Azure.Management.Storage/Generated/Models/BlobServiceItems.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/BlobServiceItems.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class BlobServiceItems
+    internal partial class BlobServiceItems
     {
         internal static BlobServiceItems DeserializeBlobServiceItems(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/BlobServiceItems.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/BlobServiceItems.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The BlobServiceItems. </summary>
-    public partial class BlobServiceItems
+    internal partial class BlobServiceItems
     {
         /// <summary> Initializes a new instance of BlobServiceItems. </summary>
         internal BlobServiceItems()

--- a/samples/Azure.Management.Storage/Generated/Models/EncryptionScopeListResult.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/EncryptionScopeListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class EncryptionScopeListResult
+    internal partial class EncryptionScopeListResult
     {
         internal static EncryptionScopeListResult DeserializeEncryptionScopeListResult(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/EncryptionScopeListResult.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/EncryptionScopeListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> List of encryption scopes requested, and if paging is required, a URL to the next page of encryption scopes. </summary>
-    public partial class EncryptionScopeListResult
+    internal partial class EncryptionScopeListResult
     {
         /// <summary> Initializes a new instance of EncryptionScopeListResult. </summary>
         internal EncryptionScopeListResult()

--- a/samples/Azure.Management.Storage/Generated/Models/FileShareItems.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/FileShareItems.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class FileShareItems
+    internal partial class FileShareItems
     {
         internal static FileShareItems DeserializeFileShareItems(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/FileShareItems.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/FileShareItems.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> Response schema. Contains list of shares returned, and if paging is requested or required, a URL to next page of shares. </summary>
-    public partial class FileShareItems
+    internal partial class FileShareItems
     {
         /// <summary> Initializes a new instance of FileShareItems. </summary>
         internal FileShareItems()

--- a/samples/Azure.Management.Storage/Generated/Models/ListContainerItems.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ListContainerItems.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class ListContainerItems
+    internal partial class ListContainerItems
     {
         internal static ListContainerItems DeserializeListContainerItems(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/ListContainerItems.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ListContainerItems.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> Response schema. Contains list of blobs returned, and if paging is requested or required, a URL to next page of containers. </summary>
-    public partial class ListContainerItems
+    internal partial class ListContainerItems
     {
         /// <summary> Initializes a new instance of ListContainerItems. </summary>
         internal ListContainerItems()

--- a/samples/Azure.Management.Storage/Generated/Models/ObjectReplicationPolicies.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ObjectReplicationPolicies.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class ObjectReplicationPolicies
+    internal partial class ObjectReplicationPolicies
     {
         internal static ObjectReplicationPolicies DeserializeObjectReplicationPolicies(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/ObjectReplicationPolicies.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ObjectReplicationPolicies.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> List storage account object replication policies. </summary>
-    public partial class ObjectReplicationPolicies
+    internal partial class ObjectReplicationPolicies
     {
         /// <summary> Initializes a new instance of ObjectReplicationPolicies. </summary>
         internal ObjectReplicationPolicies()

--- a/samples/Azure.Management.Storage/Generated/Models/OperationListResult.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/OperationListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class OperationListResult
+    internal partial class OperationListResult
     {
         internal static OperationListResult DeserializeOperationListResult(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/OperationListResult.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/OperationListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> Result of the request to list Storage operations. It contains a list of operations and a URL link to get the next set of results. </summary>
-    public partial class OperationListResult
+    internal partial class OperationListResult
     {
         /// <summary> Initializes a new instance of OperationListResult. </summary>
         internal OperationListResult()

--- a/samples/Azure.Management.Storage/Generated/Models/StorageAccountListResult.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/StorageAccountListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class StorageAccountListResult
+    internal partial class StorageAccountListResult
     {
         internal static StorageAccountListResult DeserializeStorageAccountListResult(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/StorageAccountListResult.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/StorageAccountListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class StorageAccountListResult
+    internal partial class StorageAccountListResult
     {
         /// <summary> Initializes a new instance of StorageAccountListResult. </summary>
         internal StorageAccountListResult()

--- a/samples/Azure.Management.Storage/Generated/Models/StorageSkuListResult.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/StorageSkuListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class StorageSkuListResult
+    internal partial class StorageSkuListResult
     {
         internal static StorageSkuListResult DeserializeStorageSkuListResult(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/StorageSkuListResult.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/StorageSkuListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The response from the List Storage SKUs operation. </summary>
-    public partial class StorageSkuListResult
+    internal partial class StorageSkuListResult
     {
         /// <summary> Initializes a new instance of StorageSkuListResult. </summary>
         internal StorageSkuListResult()

--- a/samples/Azure.Management.Storage/Generated/Models/UsageListResult.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/UsageListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class UsageListResult
+    internal partial class UsageListResult
     {
         internal static UsageListResult DeserializeUsageListResult(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/UsageListResult.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/UsageListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The response from the List Usages operation. </summary>
-    public partial class UsageListResult
+    internal partial class UsageListResult
     {
         /// <summary> Initializes a new instance of UsageListResult. </summary>
         internal UsageListResult()

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceIPConfigurationListResult.Serialization.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceIPConfigurationListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Network.Management.Interface.Models
 {
-    public partial class NetworkInterfaceIPConfigurationListResult
+    internal partial class NetworkInterfaceIPConfigurationListResult
     {
         internal static NetworkInterfaceIPConfigurationListResult DeserializeNetworkInterfaceIPConfigurationListResult(JsonElement element)
         {

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceIPConfigurationListResult.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceIPConfigurationListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Network.Management.Interface.Models
 {
     /// <summary> Response for list ip configurations API service call. </summary>
-    public partial class NetworkInterfaceIPConfigurationListResult
+    internal partial class NetworkInterfaceIPConfigurationListResult
     {
         /// <summary> Initializes a new instance of NetworkInterfaceIPConfigurationListResult. </summary>
         internal NetworkInterfaceIPConfigurationListResult()

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceListResult.Serialization.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Network.Management.Interface.Models
 {
-    public partial class NetworkInterfaceListResult
+    internal partial class NetworkInterfaceListResult
     {
         internal static NetworkInterfaceListResult DeserializeNetworkInterfaceListResult(JsonElement element)
         {

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceListResult.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Network.Management.Interface.Models
 {
     /// <summary> Response for the ListNetworkInterface API service call. </summary>
-    public partial class NetworkInterfaceListResult
+    internal partial class NetworkInterfaceListResult
     {
         /// <summary> Initializes a new instance of NetworkInterfaceListResult. </summary>
         internal NetworkInterfaceListResult()

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceLoadBalancerListResult.Serialization.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceLoadBalancerListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Network.Management.Interface.Models
 {
-    public partial class NetworkInterfaceLoadBalancerListResult
+    internal partial class NetworkInterfaceLoadBalancerListResult
     {
         internal static NetworkInterfaceLoadBalancerListResult DeserializeNetworkInterfaceLoadBalancerListResult(JsonElement element)
         {

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceLoadBalancerListResult.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceLoadBalancerListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Network.Management.Interface.Models
 {
     /// <summary> Response for list ip configurations API service call. </summary>
-    public partial class NetworkInterfaceLoadBalancerListResult
+    internal partial class NetworkInterfaceLoadBalancerListResult
     {
         /// <summary> Initializes a new instance of NetworkInterfaceLoadBalancerListResult. </summary>
         internal NetworkInterfaceLoadBalancerListResult()

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceTapConfigurationListResult.Serialization.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceTapConfigurationListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Network.Management.Interface.Models
 {
-    public partial class NetworkInterfaceTapConfigurationListResult
+    internal partial class NetworkInterfaceTapConfigurationListResult
     {
         internal static NetworkInterfaceTapConfigurationListResult DeserializeNetworkInterfaceTapConfigurationListResult(JsonElement element)
         {

--- a/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceTapConfigurationListResult.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/NetworkInterfaceTapConfigurationListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Network.Management.Interface.Models
 {
     /// <summary> Response for list tap configurations API service call. </summary>
-    public partial class NetworkInterfaceTapConfigurationListResult
+    internal partial class NetworkInterfaceTapConfigurationListResult
     {
         /// <summary> Initializes a new instance of NetworkInterfaceTapConfigurationListResult. </summary>
         internal NetworkInterfaceTapConfigurationListResult()

--- a/src/AutoRest.CSharp/Input/SchemaUsageProvider.cs
+++ b/src/AutoRest.CSharp/Input/SchemaUsageProvider.cs
@@ -27,7 +27,23 @@ namespace AutoRest.CSharp.Input
                 {
                     foreach (var operationResponse in operation.Responses)
                     {
-                        Apply(operationResponse.ResponseSchema, SchemaTypeUsage.Model | SchemaTypeUsage.Output);
+                        var paging = operation.Language.Default.Paging;
+                        if (paging != null && operationResponse.ResponseSchema is ObjectSchema objectSchema)
+                        {
+                            Apply(operationResponse.ResponseSchema, SchemaTypeUsage.Output);
+                            foreach (var property in objectSchema.Properties)
+                            {
+                                var itemName = paging.ItemName ?? "value";
+                                if (property.SerializedName == itemName)
+                                {
+                                    Apply(property.Schema, SchemaTypeUsage.Model | SchemaTypeUsage.Output);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            Apply(operationResponse.ResponseSchema, SchemaTypeUsage.Model | SchemaTypeUsage.Output);
+                        }
                     }
 
                     foreach (var operationResponse in operation.Exceptions)

--- a/src/AutoRest.CSharp/Properties/launchSettings.json
+++ b/src/AutoRest.CSharp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "additionalProperties": {
       "commandName": "Project",
-      "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestServerProjects\\additionalProperties\\Generated"
+      "commandLineArgs": "--standalone d:\\github\\azure\\net\\sdk\\deviceupdate\\Azure.Iot.DeviceUpdate\\src\\Generated\\"
     },
     "AdditionalPropertiesEx": {
       "commandName": "Project",

--- a/src/AutoRest.CSharp/Properties/launchSettings.json
+++ b/src/AutoRest.CSharp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "additionalProperties": {
       "commandName": "Project",
-      "commandLineArgs": "--standalone d:\\github\\azure\\net\\sdk\\deviceupdate\\Azure.Iot.DeviceUpdate\\src\\Generated\\"
+      "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestServerProjects\\additionalProperties\\Generated"
     },
     "AdditionalPropertiesEx": {
       "commandName": "Project",

--- a/test/AutoRest.TestServer.Tests/paging.cs
+++ b/test/AutoRest.TestServer.Tests/paging.cs
@@ -857,5 +857,11 @@ namespace AutoRest.TestServer.Tests
             }
             Assert.AreEqual(1, count);
         });
+
+        [Test]
+        public void PagingModelsAreHidden()
+        {
+            Assert.IsFalse(typeof(ProductResult).IsPublic);
+        }
     }
 }

--- a/test/TestServerProjects/custom-baseUrl-paging/Generated/Models/ProductResult.Serialization.cs
+++ b/test/TestServerProjects/custom-baseUrl-paging/Generated/Models/ProductResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace custom_baseUrl_paging.Models
 {
-    public partial class ProductResult
+    internal partial class ProductResult
     {
         internal static ProductResult DeserializeProductResult(JsonElement element)
         {

--- a/test/TestServerProjects/custom-baseUrl-paging/Generated/Models/ProductResult.cs
+++ b/test/TestServerProjects/custom-baseUrl-paging/Generated/Models/ProductResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace custom_baseUrl_paging.Models
 {
     /// <summary> The ProductResult. </summary>
-    public partial class ProductResult
+    internal partial class ProductResult
     {
         /// <summary> Initializes a new instance of ProductResult. </summary>
         internal ProductResult()

--- a/test/TestServerProjects/paging/Generated/Models/OdataProductResult.Serialization.cs
+++ b/test/TestServerProjects/paging/Generated/Models/OdataProductResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace paging.Models
 {
-    public partial class OdataProductResult
+    internal partial class OdataProductResult
     {
         internal static OdataProductResult DeserializeOdataProductResult(JsonElement element)
         {

--- a/test/TestServerProjects/paging/Generated/Models/OdataProductResult.cs
+++ b/test/TestServerProjects/paging/Generated/Models/OdataProductResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace paging.Models
 {
     /// <summary> The OdataProductResult. </summary>
-    public partial class OdataProductResult
+    internal partial class OdataProductResult
     {
         /// <summary> Initializes a new instance of OdataProductResult. </summary>
         internal OdataProductResult()

--- a/test/TestServerProjects/paging/Generated/Models/ProductResult.Serialization.cs
+++ b/test/TestServerProjects/paging/Generated/Models/ProductResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace paging.Models
 {
-    public partial class ProductResult
+    internal partial class ProductResult
     {
         internal static ProductResult DeserializeProductResult(JsonElement element)
         {

--- a/test/TestServerProjects/paging/Generated/Models/ProductResult.cs
+++ b/test/TestServerProjects/paging/Generated/Models/ProductResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace paging.Models
 {
     /// <summary> The ProductResult. </summary>
-    public partial class ProductResult
+    internal partial class ProductResult
     {
         /// <summary> Initializes a new instance of ProductResult. </summary>
         internal ProductResult()

--- a/test/TestServerProjects/paging/Generated/Models/ProductResultValue.Serialization.cs
+++ b/test/TestServerProjects/paging/Generated/Models/ProductResultValue.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace paging.Models
 {
-    public partial class ProductResultValue
+    internal partial class ProductResultValue
     {
         internal static ProductResultValue DeserializeProductResultValue(JsonElement element)
         {

--- a/test/TestServerProjects/paging/Generated/Models/ProductResultValue.cs
+++ b/test/TestServerProjects/paging/Generated/Models/ProductResultValue.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace paging.Models
 {
     /// <summary> The ProductResultValue. </summary>
-    public partial class ProductResultValue
+    internal partial class ProductResultValue
     {
         /// <summary> Initializes a new instance of ProductResultValue. </summary>
         internal ProductResultValue()

--- a/test/TestServerProjects/paging/Generated/Models/ProductResultValueWithXMSClientName.Serialization.cs
+++ b/test/TestServerProjects/paging/Generated/Models/ProductResultValueWithXMSClientName.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace paging.Models
 {
-    public partial class ProductResultValueWithXMSClientName
+    internal partial class ProductResultValueWithXMSClientName
     {
         internal static ProductResultValueWithXMSClientName DeserializeProductResultValueWithXMSClientName(JsonElement element)
         {

--- a/test/TestServerProjects/paging/Generated/Models/ProductResultValueWithXMSClientName.cs
+++ b/test/TestServerProjects/paging/Generated/Models/ProductResultValueWithXMSClientName.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace paging.Models
 {
     /// <summary> The ProductResultValueWithXMSClientName. </summary>
-    public partial class ProductResultValueWithXMSClientName
+    internal partial class ProductResultValueWithXMSClientName
     {
         /// <summary> Initializes a new instance of ProductResultValueWithXMSClientName. </summary>
         internal ProductResultValueWithXMSClientName()


### PR DESCRIPTION
Something I've noticed when reviewing https://apiview.dev/Assemblies/Review/c51bcc4cd8964fb9a4a3ed52877d2d16 is that we generate public Pageable schemas that are not used by any other part of API.