### PR TITLE
Add help content

### DIFF
--- a/src/AutoRest.CSharp/readme.md
+++ b/src/AutoRest.CSharp/readme.md
@@ -44,7 +44,7 @@ help-content:
       description: Pass shared folder paths through here. Common values point to the shared generator assets and shared azure core assets in autorest.csharp
       type: string
     - key: public-clients
-      description: Whether to have your client public. Defaults to `false`.
+      description: Whether to generate public client. Defaults to `false`.
       type: bool
     - key: model-namespace
       description: Whether to add a separate namespace of Models, more specifically adding `{value-from-namespace-flag}.Models`. Defaults to `true`.

--- a/src/AutoRest.CSharp/readme.md
+++ b/src/AutoRest.CSharp/readme.md
@@ -29,3 +29,24 @@ pipeline:
     input: csharpproj
     scope: output-scope
 ```
+
+## Help
+```yaml
+help-content:
+  csharp: # type: Help as defined in autorest-core/help.ts
+    activationScope: csharp
+    categoryFriendlyName: C# Generator
+    settings:
+    - key: library-name
+      description: The name of your library. This is what will be displayed on NuGet.
+      type: string
+    - key: shared-source-folders
+      description: Pass shared folder paths through here. Common values point to the shared generator assets and shared azure core assets in autorest.csharp
+      type: string
+    - key: public-clients
+      description: Whether to have your client public. Defaults to `false`.
+      type: bool
+    - key: model-namespace
+      description: Whether to add a separate namespace of Models, more specifically adding `{value-from-namespace-flag}.Models`. Defaults to `true`.
+      type: bool
+```


### PR DESCRIPTION
Adding back the `help-content` field to the autorest configuration so it can present information when running `--help`
Copied csharp flags from the docs https://github.com/Azure/autorest/blob/master/docs/generate/flags.md
![image](https://user-images.githubusercontent.com/1031227/109714186-f273a080-7b56-11eb-8f10-195bfd1de2eb.png)
