### PR TITLE
Catch exceptions and report as fatal instead

### DIFF
--- a/src/AutoRest.CSharp/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/AutoRest/Plugins/CSharpGen.cs
@@ -149,10 +149,17 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 await autoRest.WriteFile("CodeModel.yaml", codeModelYaml, "source-file-csharp");
             }
 
-            var project = await ExecuteAsync(codeModelTask, configuration);
-            await foreach (var file in project.GetGeneratedFilesAsync())
+            try
             {
-                await autoRest.WriteFile(file.Name, file.Text, "source-file-csharp");
+                var project = await ExecuteAsync(codeModelTask, configuration);
+                await foreach (var file in project.GetGeneratedFilesAsync())
+                {
+                    await autoRest.WriteFile(file.Name, file.Text, "source-file-csharp");
+                }
+            }
+            catch (Exception e)
+            {
+                await autoRest.Fatal($"Internal error in AutoRest.CSharp - Please file an issue at https://github.com/Azure/autorest.csharp/issues/new with a swagger that reproduces.\nException: {e.Message}\n{e.StackTrace}");
             }
 
             return true;

--- a/src/AutoRest.CSharp/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/AutoRest/Plugins/CSharpGen.cs
@@ -160,6 +160,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             catch (Exception e)
             {
                 await autoRest.Fatal($"Internal error in AutoRest.CSharp - Please file an issue at https://github.com/Azure/autorest.csharp/issues/new with a swagger that reproduces.\nException: {e.Message}\n{e.StackTrace}");
+                return false;
             }
 
             return true;


### PR DESCRIPTION
- It is very common to comment out 4 lines in CSharpGen.cs when
  debugging a crash, as we won't generate yaml needed to debug in VS
  if we throw an exception during code generation.
- By catching everything, and using autorest.Fatal() we still fail
  builds, but also complete the yaml write out above