### PR TITLE
Handle long query parameters

### DIFF
--- a/src/assets/Generator.Shared/RequestUriBuilderExtensions.cs
+++ b/src/assets/Generator.Shared/RequestUriBuilderExtensions.cs
@@ -87,6 +87,11 @@ namespace Azure.Core
             builder.AppendQuery(name, value.ToString(TypeFormatters.DefaultNumberFormat, CultureInfo.InvariantCulture), escape);
         }
 
+        public static void AppendQuery(this RequestUriBuilder builder, string name, long value, bool escape = true)
+        {
+            builder.AppendQuery(name, value.ToString(TypeFormatters.DefaultNumberFormat, CultureInfo.InvariantCulture), escape);
+        }
+
         public static void AppendQuery(this RequestUriBuilder builder, string name, TimeSpan value, bool escape = true)
         {
             builder.AppendQuery(name, XmlConvert.ToString(value), escape);

--- a/test/AutoRest.TestServer.Tests/url-query.cs
+++ b/test/AutoRest.TestServer.Tests/url-query.cs
@@ -135,6 +135,22 @@ namespace AutoRest.TestServer.Tests
         [Test]
         public void UrlQueriesArrayMultiValid() => TestStatus(async (host, pipeline) => await new url_multi_collectionFormat.QueriesClient(ClientDiagnostics, pipeline, host).ArrayStringMultiValidAsync( new[] { "ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", "" }));
 
+        [Test]
+        public async Task UrlQueriesLongMaxValue()
+        {
+            string queryValue = null;
+            using var testServer = new InProcTestServer(async content =>
+            {
+                queryValue = content.Request.Query["longQuery"];
+                await content.Response.Body.FlushAsync();
+            });
+
+            var client = new QueriesClient(ClientDiagnostics, InProcTestBase.HttpPipeline, testServer.Address);
+            await client.GetLongNullAsync(long.MaxValue);
+
+            Assert.AreEqual("9223372036854775807", queryValue);
+        }
+
         public override IEnumerable<string> AdditionalKnownScenarios { get; } = new string[]
         {
             "UrlQueriesBoolFalse",


### PR DESCRIPTION
Large long values were falling into the float overload and having scientific format.