### PR TITLE
Group management configurations into a single object

### DIFF
--- a/samples/AppConfiguration/Generated/Configuration.json
+++ b/samples/AppConfiguration/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"AppConfiguration","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "AppConfiguration",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/samples/Azure.AI.DocumentTranslation/Generated/Configuration.json
+++ b/samples/Azure.AI.DocumentTranslation/Generated/Configuration.json
@@ -1,1 +1,24 @@
-{"OutputFolder":".","Namespace":"Azure.AI.DocumentTranslation","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":true,"CredentialTypes":["AzureKeyCredential"],"CredentialScopes":[],"CredentialHeaderName":"Ocp-Apim-Subscription-Key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Azure.AI.DocumentTranslation",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": true,
+  "CredentialTypes": [
+    "AzureKeyCredential"
+  ],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "Ocp-Apim-Subscription-Key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/samples/Azure.AI.FormRecognizer/Generated/Configuration.json
+++ b/samples/Azure.AI.FormRecognizer/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"Azure.AI.FormRecognizer","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":false,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Azure.AI.FormRecognizer",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": false,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/samples/Azure.Management.Storage/Generated/Configuration.json
+++ b/samples/Azure.Management.Storage/Generated/Configuration.json
@@ -1,1 +1,41 @@
-{"OutputFolder":".","Namespace":"Azure.Management.Storage","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":true,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":true,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{"Operations":"Microsoft.Storage/operations","Skus":"Microsoft.Storage/skus","Usages":"Microsoft.Storage/locations/usages","PrivateLinkResources":"Microsoft.Storage/storageAccounts/privateLinkResources"},"OperationGroupToResource":{"Operations":"Operation","Skus":"Sku","Usages":"Usage","PrivateLinkResources":"PrivateLinkResource","StorageAccounts":"StorageAccount"},"ResourceRename":{"BlobServiceProperties":"BlobService","FileServiceProperties":"FileService"},"OperationGroupToParent":{"BlobContainers":"Microsoft.Storage/storageAccounts","FileShares":"Microsoft.Storage/storageAccounts","Usages":"subscriptions","StorageAccounts":"any"}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Azure.Management.Storage",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": true,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": true,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {
+    "Operations": "Microsoft.Storage/operations",
+    "Skus": "Microsoft.Storage/skus",
+    "Usages": "Microsoft.Storage/locations/usages",
+    "PrivateLinkResources": "Microsoft.Storage/storageAccounts/privateLinkResources"
+  },
+  "OperationGroupToResource": {
+    "Operations": "Operation",
+    "Skus": "Sku",
+    "Usages": "Usage",
+    "PrivateLinkResources": "PrivateLinkResource",
+    "StorageAccounts": "StorageAccount"
+  },
+  "ResourceRename": {
+    "BlobServiceProperties": "BlobService",
+    "FileServiceProperties": "FileService"
+  },
+  "OperationGroupToParent": {
+    "BlobContainers": "Microsoft.Storage/storageAccounts",
+    "FileShares": "Microsoft.Storage/storageAccounts",
+    "Usages": "subscriptions",
+    "StorageAccounts": "any"
+  }
+}

--- a/samples/Azure.Network.Management.Interface/Generated/Configuration.json
+++ b/samples/Azure.Network.Management.Interface/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"Azure.Network.Management.Interface","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Azure.Network.Management.Interface",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/samples/Azure.ResourceManager.Sample/Generated/Configuration.json
+++ b/samples/Azure.ResourceManager.Sample/Generated/Configuration.json
@@ -1,1 +1,47 @@
-{"OutputFolder":".","Namespace":"Azure.ResourceManager.Sample","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":true,"PublicClients":true,"ModelNamespace":false,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{"Operations":"Microsoft.Compute/operations","VirtualMachineExtensionImages":"Microsoft.Compute/locations/publishers/vmextension","VirtualMachineImages":"Microsoft.Compute/locations/publishers/vmimage","Usage":"Microsoft.Compute/locations/usages","VirtualMachineSizes":"Microsoft.Compute/locations/vmSizes","VirtualMachineScaleSetRollingUpgrades":"Microsoft.Compute/virtualMachineScaleSets/rollingUpgrades","LogAnalytics":"Microsoft.Compute/locations/logAnalytics"},"OperationGroupToResource":{"Operations":"Operation","VirtualMachineExtensionImages":"VirtualMachineExtensionImage","VirtualMachineImages":"VirtualMachineImage","Usage":"Usage","VirtualMachineSizes":"VirtualMachineSize","VirtualMachineScaleSetRollingUpgrades":"VirtualMachineScaleSetRollingUpgrade","LogAnalytics":"LogAnalyticsOperationResult"},"ResourceRename":{"SshPublicKey":"SshPublicKeyInfo","LogAnalyticsOperationResult":"LogAnalytics","SshPublicKeyResource":"SshPublicKey"},"OperationGroupToParent":{"LogAnalytics":"subscriptions","VirtualMachineExtensionImages":"Microsoft.Compute/locations/publishers","VirtualMachineImages":"Microsoft.Compute/locations","VirtualMachineScaleSetVMExtensions":"Microsoft.Compute/virtualMachineScaleSets"}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Azure.ResourceManager.Sample",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": true,
+  "PublicClients": true,
+  "ModelNamespace": false,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {
+    "Operations": "Microsoft.Compute/operations",
+    "VirtualMachineExtensionImages": "Microsoft.Compute/locations/publishers/vmextension",
+    "VirtualMachineImages": "Microsoft.Compute/locations/publishers/vmimage",
+    "Usage": "Microsoft.Compute/locations/usages",
+    "VirtualMachineSizes": "Microsoft.Compute/locations/vmSizes",
+    "VirtualMachineScaleSetRollingUpgrades": "Microsoft.Compute/virtualMachineScaleSets/rollingUpgrades",
+    "LogAnalytics": "Microsoft.Compute/locations/logAnalytics"
+  },
+  "OperationGroupToResource": {
+    "Operations": "Operation",
+    "VirtualMachineExtensionImages": "VirtualMachineExtensionImage",
+    "VirtualMachineImages": "VirtualMachineImage",
+    "Usage": "Usage",
+    "VirtualMachineSizes": "VirtualMachineSize",
+    "VirtualMachineScaleSetRollingUpgrades": "VirtualMachineScaleSetRollingUpgrade",
+    "LogAnalytics": "LogAnalyticsOperationResult"
+  },
+  "ResourceRename": {
+    "SshPublicKey": "SshPublicKeyInfo",
+    "LogAnalyticsOperationResult": "LogAnalytics",
+    "SshPublicKeyResource": "SshPublicKey"
+  },
+  "OperationGroupToParent": {
+    "LogAnalytics": "subscriptions",
+    "VirtualMachineExtensionImages": "Microsoft.Compute/locations/publishers",
+    "VirtualMachineImages": "Microsoft.Compute/locations",
+    "VirtualMachineScaleSetVMExtensions": "Microsoft.Compute/virtualMachineScaleSets"
+  }
+}

--- a/samples/Azure.Storage.Tables/Generated/Configuration.json
+++ b/samples/Azure.Storage.Tables/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"Azure.Storage.Tables","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Azure.Storage.Tables",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/samples/CognitiveSearch/Generated/Configuration.json
+++ b/samples/CognitiveSearch/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"CognitiveSearch","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "CognitiveSearch",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/samples/CognitiveServices.TextAnalytics/Generated/Configuration.json
+++ b/samples/CognitiveServices.TextAnalytics/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"CognitiveServices.TextAnalytics","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "CognitiveServices.TextAnalytics",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/src/AutoRest.CSharp/Common/AutoRest/Communication/StandaloneGeneratorRunner.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Communication/StandaloneGeneratorRunner.cs
@@ -40,7 +40,9 @@ namespace AutoRest.CSharp.AutoRest.Communication
         {
             using (var memoryStream = new MemoryStream())
             {
-                using (Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream))
+                JsonWriterOptions options = new JsonWriterOptions();
+                options.Indented = true;
+                using (Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream, options))
                 {
                     writer.WriteStartObject();
                     writer.WriteString(nameof(Configuration.OutputFolder), Path.GetRelativePath(configuration.OutputFolder, configuration.OutputFolder));
@@ -74,33 +76,7 @@ namespace AutoRest.CSharp.AutoRest.Communication
 
                     writer.WriteString(nameof(Configuration.CredentialHeaderName), configuration.CredentialHeaderName);
 
-                    writer.WriteStartObject(nameof(Configuration.OperationGroupToResourceType));
-                    foreach (var keyval in configuration.OperationGroupToResourceType)
-                    {
-                        writer.WriteString(keyval.Key, keyval.Value);
-                    }
-                    writer.WriteEndObject();
-
-                    writer.WriteStartObject(nameof(Configuration.OperationGroupToResource));
-                    foreach (var keyval in configuration.OperationGroupToResource)
-                    {
-                        writer.WriteString(keyval.Key, keyval.Value);
-                    }
-                    writer.WriteEndObject();
-
-                    writer.WriteStartObject(nameof(Configuration.ResourceRename));
-                    foreach (var keyval in configuration.ResourceRename)
-                    {
-                        writer.WriteString(keyval.Key, keyval.Value);
-                    }
-                    writer.WriteEndObject();
-
-                    writer.WriteStartObject(nameof(Configuration.OperationGroupToParent));
-                    foreach (var keyval in configuration.OperationGroupToParent)
-                    {
-                        writer.WriteString(keyval.Key, keyval.Value);
-                    }
-                    writer.WriteEndObject();
+                    configuration.MgmtConfiguration.SaveConfiguration(writer);
 
                     writer.WriteEndObject();
                 }
@@ -152,10 +128,7 @@ namespace AutoRest.CSharp.AutoRest.Communication
                 credentialScopes.ToArray(),
                 root.GetProperty(nameof(Configuration.CredentialHeaderName)).GetString(),
                 root.GetProperty(nameof(Configuration.LowLevelClient)).GetBoolean(),
-                root.GetProperty(nameof(Configuration.OperationGroupToResourceType)),
-                root.GetProperty(nameof(Configuration.OperationGroupToResource)),
-                root.GetProperty(nameof(Configuration.ResourceRename)),
-                root.GetProperty(nameof(Configuration.OperationGroupToParent))
+                MgmtConfiguration.LoadConfiguration(root)
             );
         }
     }

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
@@ -12,7 +12,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
 {
     internal class Configuration
     {
-        public Configuration(string outputFolder, string? ns, string? name, string[] sharedSourceFolders, bool saveInputs, bool azureArm, bool publicClients, bool modelNamespace, bool headAsBoolean, bool skipCSProjPackageReference, string[] credentialTypes, string[] credentialScopes, string credentialHeaderName, bool lowLevelClient, JsonElement? operationGroupToResourceType = default, JsonElement? operationGroupToResource = default, JsonElement? resourceRename = default, JsonElement? operationGroupToParent = default)
+        public Configuration(string outputFolder, string? ns, string? name, string[] sharedSourceFolders, bool saveInputs, bool azureArm, bool publicClients, bool modelNamespace, bool headAsBoolean, bool skipCSProjPackageReference, string[] credentialTypes, string[] credentialScopes, string credentialHeaderName, bool lowLevelClient, MgmtConfiguration mgmtConfiguration)
         {
             OutputFolder = outputFolder;
             Namespace = ns;
@@ -28,10 +28,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             CredentialTypes = credentialTypes;
             CredentialScopes = credentialScopes;
             CredentialHeaderName = credentialHeaderName;
-            OperationGroupToResourceType = operationGroupToResourceType?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationGroupToResourceType.ToString());
-            OperationGroupToResource = operationGroupToResource?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationGroupToResource.ToString());
-            ResourceRename = resourceRename?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(resourceRename.ToString());
-            OperationGroupToParent = operationGroupToParent?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationGroupToParent.ToString());
+            MgmtConfiguration = mgmtConfiguration;
         }
 
         public string OutputFolder { get; }
@@ -47,18 +44,14 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         public string[] CredentialTypes { get; }
         public string[] CredentialScopes { get; }
         public string CredentialHeaderName { get; }
-
         public static string ProjectRelativeDirectory = "../";
-        public IReadOnlyDictionary<string, string> OperationGroupToResourceType { get; }
-        public IReadOnlyDictionary<string, string> OperationGroupToResource { get; }
-        public IReadOnlyDictionary<string, string> ResourceRename { get; }
         public bool LowLevelClient { get; }
-        public IReadOnlyDictionary<string, string> OperationGroupToParent { get; }
+        public MgmtConfiguration MgmtConfiguration { get; }
 
         public static Configuration GetConfiguration(IPluginCommunication autoRest)
         {
             return new Configuration(
-                    TrimFileSuffix(GetRequiredOption<string>(autoRest, "output-folder")),
+                TrimFileSuffix(GetRequiredOption<string>(autoRest, "output-folder")),
                 autoRest.GetValue<string?>("namespace").GetAwaiter().GetResult(),
                 autoRest.GetValue<string?>("library-name").GetAwaiter().GetResult(),
                 GetRequiredOption<string[]>(autoRest, "shared-source-folders").Select(TrimFileSuffix).ToArray(),
@@ -72,10 +65,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 autoRest.GetValue<string[]?>("credential-scopes").GetAwaiter().GetResult() ?? Array.Empty<string>(),
                 autoRest.GetValue<string?>("credential-header-name").GetAwaiter().GetResult() ?? "api-key",
                 autoRest.GetValue<bool?>("low-level-client").GetAwaiter().GetResult() ?? false,
-                autoRest.GetValue<JsonElement?>("operation-group-to-resource-type").GetAwaiter().GetResult(),
-                autoRest.GetValue<JsonElement?>("operation-group-to-resource").GetAwaiter().GetResult(),
-                autoRest.GetValue<JsonElement?>("resource-rename").GetAwaiter().GetResult(),
-                autoRest.GetValue<JsonElement?>("operation-group-to-parent").GetAwaiter().GetResult()
+                MgmtConfiguration.GetConfiguration(autoRest)
             );
         }
 

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtConfiguration.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtConfiguration.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using AutoRest.CSharp.AutoRest.Communication;
+
+namespace AutoRest.CSharp.AutoRest.Plugins
+{
+    public class MgmtConfiguration
+    {
+        public MgmtConfiguration(JsonElement? operationGroupToResourceType = default, JsonElement? operationGroupToResource = default, JsonElement? resourceRename = default, JsonElement? operationGroupToParent = default)
+        {
+            OperationGroupToResourceType = operationGroupToResourceType?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationGroupToResourceType.ToString());
+            OperationGroupToResource = operationGroupToResource?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationGroupToResource.ToString());
+            ResourceRename = resourceRename?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(resourceRename.ToString());
+            OperationGroupToParent = operationGroupToParent?.ValueKind == JsonValueKind.Null ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationGroupToParent.ToString());
+        }
+
+        public IReadOnlyDictionary<string, string> OperationGroupToResourceType { get; }
+        public IReadOnlyDictionary<string, string> OperationGroupToResource { get; }
+        public IReadOnlyDictionary<string, string> ResourceRename { get; }
+        public IReadOnlyDictionary<string, string> OperationGroupToParent { get; }
+
+        internal static MgmtConfiguration GetConfiguration(IPluginCommunication autoRest)
+        {
+            return new MgmtConfiguration(
+                autoRest.GetValue<JsonElement?>("operation-group-to-resource-type").GetAwaiter().GetResult(),
+                autoRest.GetValue<JsonElement?>("operation-group-to-resource").GetAwaiter().GetResult(),
+                autoRest.GetValue<JsonElement?>("resource-rename").GetAwaiter().GetResult(),
+                autoRest.GetValue<JsonElement?>("operation-group-to-parent").GetAwaiter().GetResult()
+            );
+        }
+
+        internal void SaveConfiguration(Utf8JsonWriter writer)
+        {
+            writer.WriteStartObject(nameof(OperationGroupToResourceType));
+            foreach (var keyval in OperationGroupToResourceType)
+            {
+                writer.WriteString(keyval.Key, keyval.Value);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteStartObject(nameof(OperationGroupToResource));
+            foreach (var keyval in OperationGroupToResource)
+            {
+                writer.WriteString(keyval.Key, keyval.Value);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteStartObject(nameof(ResourceRename));
+            foreach (var keyval in ResourceRename)
+            {
+                writer.WriteString(keyval.Key, keyval.Value);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteStartObject(nameof(OperationGroupToParent));
+            foreach (var keyval in OperationGroupToParent)
+            {
+                writer.WriteString(keyval.Key, keyval.Value);
+            }
+            writer.WriteEndObject();
+        }
+
+        internal static MgmtConfiguration LoadConfiguration(JsonElement root)
+        {
+            return new MgmtConfiguration(
+                root.GetProperty(nameof(OperationGroupToResourceType)),
+                root.GetProperty(nameof(OperationGroupToResource)),
+                root.GetProperty(nameof(ResourceRename)),
+                root.GetProperty(nameof(OperationGroupToParent))
+            );
+        }
+    }
+}

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtOutputLibrary.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AutoRest.CSharp.AutoRest.Plugins;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Output.Models.Type.Decorate;
@@ -14,6 +15,7 @@ namespace AutoRest.CSharp.Output.Models.Types
     {
         private BuildContext<MgmtOutputLibrary> _context;
         private CodeModel _codeModel;
+        private MgmtConfiguration _mgmtConfiguration;
 
         private Dictionary<OperationGroup, MgmtRestClient>? _restClients;
         private Dictionary<OperationGroup, ResourceOperation>? _resourceOperations;
@@ -29,6 +31,7 @@ namespace AutoRest.CSharp.Output.Models.Types
         {
             _codeModel = codeModel;
             _context = context;
+            _mgmtConfiguration = context.Configuration.MgmtConfiguration;
             _operationGroups = new Dictionary<string, List<OperationGroup>>();
             _allSchemas = _codeModel.Schemas.Choices.Cast<Schema>()
                 .Concat(_codeModel.Schemas.SealedChoices)
@@ -242,7 +245,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             {
                 MapHttpMethodToOperation(operationsGroup);
                 string? resourceType;
-                operationsGroup.ResourceType = _context.Configuration.OperationGroupToResourceType.TryGetValue(operationsGroup.Key, out resourceType) ? resourceType : ResourceTypeBuilder.ConstructOperationResourceType(operationsGroup);
+                operationsGroup.ResourceType = _mgmtConfiguration.OperationGroupToResourceType.TryGetValue(operationsGroup.Key, out resourceType) ? resourceType : ResourceTypeBuilder.ConstructOperationResourceType(operationsGroup);
                 operationsGroup.IsTenantResource = TenantDetection.IsTenantOnly(operationsGroup);
                 string? resource;
                 ResourceTypes.Add(operationsGroup.ResourceType);
@@ -250,16 +253,16 @@ namespace AutoRest.CSharp.Output.Models.Types
 
                 // TODO better support for extension resources
                 string? parent;
-                if (_context.Configuration.OperationGroupToParent.TryGetValue(operationsGroup.Key, out parent))
+                if (_mgmtConfiguration.OperationGroupToParent.TryGetValue(operationsGroup.Key, out parent))
                 {
                     // If overriden, add parent to known types list (trusting user input)
                     ResourceTypes.Add(parent);
                 }
                 operationsGroup.Parent = parent ?? ParentDetection.GetParent(operationsGroup);
-                operationsGroup.Resource = _context.Configuration.OperationGroupToResource.TryGetValue(operationsGroup.Key, out resource) ? resource : SchemaDetection.GetSchema(operationsGroup).Name;
+                operationsGroup.Resource = _mgmtConfiguration.OperationGroupToResource.TryGetValue(operationsGroup.Key, out resource) ? resource : SchemaDetection.GetSchema(operationsGroup).Name;
                 AddOperationGroupToResourceMap(operationsGroup);
                 string? nameOverride;
-                if (_context.Configuration.ResourceRename.TryGetValue(operationsGroup.Resource, out nameOverride))
+                if (_mgmtConfiguration.ResourceRename.TryGetValue(operationsGroup.Resource, out nameOverride))
                 {
                     operationsGroup.Resource = nameOverride;
                 }
@@ -272,7 +275,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             foreach (var schema in _allSchemas)
             {
                 string? resourceName;
-                if (_context.Configuration.ResourceRename.TryGetValue(schema.Name, out resourceName))
+                if (_mgmtConfiguration.ResourceRename.TryGetValue(schema.Name, out resourceName))
                 {
                     schema.NameOverride = resourceName;
                 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Configuration.json
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"AdditionalPropertiesEx","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "AdditionalPropertiesEx",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/ExtensionClientName/Generated/Configuration.json
+++ b/test/TestProjects/ExtensionClientName/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"ExtensionClientName","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "ExtensionClientName",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/HeadAsBooleanTrue/Generated/Configuration.json
+++ b/test/TestProjects/HeadAsBooleanTrue/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"HeadAsBooleanTrue","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":true,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "HeadAsBooleanTrue",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": true,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/HeaderCollectionPrefix/Generated/Configuration.json
+++ b/test/TestProjects/HeaderCollectionPrefix/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"HeaderCollectionPrefix","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "HeaderCollectionPrefix",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/Inheritance/Generated/Configuration.json
+++ b/test/TestProjects/Inheritance/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"Inheritance","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "Inheritance",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/JsonAsBinary/Generated/Configuration.json
+++ b/test/TestProjects/JsonAsBinary/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"JsonAsBinary","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "JsonAsBinary",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/MgmtParent/Generated/Configuration.json
+++ b/test/TestProjects/MgmtParent/Generated/Configuration.json
@@ -1,1 +1,28 @@
-{"OutputFolder":".","Namespace":"MgmtParent","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":true,"PublicClients":true,"ModelNamespace":false,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{"VirtualMachineExtensionImages":"Microsoft.Compute/locations/publishers/vmextension"},"OperationGroupToResource":{"VirtualMachineExtensionImages":"VirtualMachineExtensionImage"},"ResourceRename":{},"OperationGroupToParent":{"VirtualMachineExtensionImages":"Microsoft.Compute/locations/publishers"}}
+{
+  "OutputFolder": ".",
+  "Namespace": "MgmtParent",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": true,
+  "PublicClients": true,
+  "ModelNamespace": false,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {
+    "VirtualMachineExtensionImages": "Microsoft.Compute/locations/publishers/vmextension"
+  },
+  "OperationGroupToResource": {
+    "VirtualMachineExtensionImages": "VirtualMachineExtensionImage"
+  },
+  "ResourceRename": {},
+  "OperationGroupToParent": {
+    "VirtualMachineExtensionImages": "Microsoft.Compute/locations/publishers"
+  }
+}

--- a/test/TestProjects/ModelNamespace/Generated/Configuration.json
+++ b/test/TestProjects/ModelNamespace/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"ModelNamespace","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":false,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "ModelNamespace",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": false,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/ModelShapes/Generated/Configuration.json
+++ b/test/TestProjects/ModelShapes/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"ModelShapes","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "ModelShapes",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/ModelWithConverterUsage/Generated/Configuration.json
+++ b/test/TestProjects/ModelWithConverterUsage/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"ModelWithConverterUsage","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "ModelWithConverterUsage",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/NameConflicts/Generated/Configuration.json
+++ b/test/TestProjects/NameConflicts/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"NameConflicts","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "NameConflicts",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/OperationGroupMappings/Generated/Configuration.json
+++ b/test/TestProjects/OperationGroupMappings/Generated/Configuration.json
@@ -1,1 +1,27 @@
-{"OutputFolder":".","Namespace":"OperationGroupMappings","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":true,"PublicClients":true,"ModelNamespace":false,"HeadAsBoolean":true,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{"Operations":"Microsoft.Compute/operations"},"OperationGroupToResource":{"Operations":"Operation","AvailabilitySets":"AvailabilitySet"},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "OperationGroupMappings",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": true,
+  "PublicClients": true,
+  "ModelNamespace": false,
+  "HeadAsBoolean": true,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {
+    "Operations": "Microsoft.Compute/operations"
+  },
+  "OperationGroupToResource": {
+    "Operations": "Operation",
+    "AvailabilitySets": "AvailabilitySet"
+  },
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/PublicClientCtor/Generated/Configuration.json
+++ b/test/TestProjects/PublicClientCtor/Generated/Configuration.json
@@ -1,1 +1,28 @@
-{"OutputFolder":".","Namespace":"PublicClientCtor","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":["TokenCredential","AzureKeyCredential"],"CredentialScopes":["https://fakeendpoint.azure.com/.default","https://dummyendpoint.azure.com/.default"],"CredentialHeaderName":"fake-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "PublicClientCtor",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [
+    "TokenCredential",
+    "AzureKeyCredential"
+  ],
+  "CredentialScopes": [
+    "https://fakeendpoint.azure.com/.default",
+    "https://dummyendpoint.azure.com/.default"
+  ],
+  "CredentialHeaderName": "fake-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/ResourceRename/Generated/Configuration.json
+++ b/test/TestProjects/ResourceRename/Generated/Configuration.json
@@ -1,1 +1,24 @@
-{"OutputFolder":".","Namespace":"ResourceRename","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":true,"PublicClients":true,"ModelNamespace":false,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{"SshPublicKeyResource":"SshPublicKeyInfo"},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "ResourceRename",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": true,
+  "PublicClients": true,
+  "ModelNamespace": false,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {
+    "SshPublicKeyResource": "SshPublicKeyInfo"
+  },
+  "OperationGroupToParent": {}
+}

--- a/test/TestProjects/TenantOnly/Generated/Configuration.json
+++ b/test/TestProjects/TenantOnly/Generated/Configuration.json
@@ -1,1 +1,31 @@
-{"OutputFolder":".","Namespace":"TenantOnly","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":true,"PublicClients":true,"ModelNamespace":false,"HeadAsBoolean":true,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{"AvailableBalances":"Microsoft.Billing/billingAccounts/billingProfiles/availableBalance","Agreements":"Microsoft.Billing/billingAccounts/agreements"},"OperationGroupToResource":{"BillingAccounts":"BillingAccount","AvailableBalances":"AvailableBalance","Agreements":"Agreement"},"ResourceRename":{},"OperationGroupToParent":{"Instructions":"Microsoft.Billing/billingAccounts/billingProfiles"}}
+{
+  "OutputFolder": ".",
+  "Namespace": "TenantOnly",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": true,
+  "PublicClients": true,
+  "ModelNamespace": false,
+  "HeadAsBoolean": true,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {
+    "AvailableBalances": "Microsoft.Billing/billingAccounts/billingProfiles/availableBalance",
+    "Agreements": "Microsoft.Billing/billingAccounts/agreements"
+  },
+  "OperationGroupToResource": {
+    "BillingAccounts": "BillingAccount",
+    "AvailableBalances": "AvailableBalance",
+    "Agreements": "Agreement"
+  },
+  "ResourceRename": {},
+  "OperationGroupToParent": {
+    "Instructions": "Microsoft.Billing/billingAccounts/billingProfiles"
+  }
+}

--- a/test/TestProjects/TypeSchemaMapping/Generated/Configuration.json
+++ b/test/TestProjects/TypeSchemaMapping/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"TypeSchemaMapping","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "TypeSchemaMapping",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/additionalProperties/Generated/Configuration.json
+++ b/test/TestServerProjects/additionalProperties/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"additionalProperties","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "additionalProperties",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Configuration.json
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"azure_parameter_grouping","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "azure_parameter_grouping",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/azure-special-properties/Generated/Configuration.json
+++ b/test/TestServerProjects/azure-special-properties/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"azure_special_properties","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "azure_special_properties",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-array/Generated/Configuration.json
+++ b/test/TestServerProjects/body-array/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_array","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_array",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-boolean/Generated/Configuration.json
+++ b/test/TestServerProjects/body-boolean/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_boolean","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_boolean",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-byte/Generated/Configuration.json
+++ b/test/TestServerProjects/body-byte/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_byte","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_byte",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-complex/Generated/Configuration.json
+++ b/test/TestServerProjects/body-complex/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_complex","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_complex",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-date/Generated/Configuration.json
+++ b/test/TestServerProjects/body-date/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_date","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_date",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-datetime-rfc1123/Generated/Configuration.json
+++ b/test/TestServerProjects/body-datetime-rfc1123/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_datetime_rfc1123","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_datetime_rfc1123",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-datetime/Generated/Configuration.json
+++ b/test/TestServerProjects/body-datetime/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_datetime","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_datetime",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-dictionary/Generated/Configuration.json
+++ b/test/TestServerProjects/body-dictionary/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_dictionary","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_dictionary",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-duration/Generated/Configuration.json
+++ b/test/TestServerProjects/body-duration/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_duration","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_duration",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-file/Generated/Configuration.json
+++ b/test/TestServerProjects/body-file/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_file","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_file",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-formdata-urlencoded/Generated/Configuration.json
+++ b/test/TestServerProjects/body-formdata-urlencoded/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_formdata_urlencoded","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_formdata_urlencoded",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-formdata/Generated/Configuration.json
+++ b/test/TestServerProjects/body-formdata/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_formdata","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_formdata",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-integer/Generated/Configuration.json
+++ b/test/TestServerProjects/body-integer/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_integer","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_integer",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-number/Generated/Configuration.json
+++ b/test/TestServerProjects/body-number/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_number","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_number",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-string/Generated/Configuration.json
+++ b/test/TestServerProjects/body-string/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_string","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_string",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/body-time/Generated/Configuration.json
+++ b/test/TestServerProjects/body-time/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"body_time","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "body_time",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/constants/Generated/Configuration.json
+++ b/test/TestServerProjects/constants/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"constants","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "constants",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/custom-baseUrl-more-options/Generated/Configuration.json
+++ b/test/TestServerProjects/custom-baseUrl-more-options/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"custom_baseUrl_more_options","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "custom_baseUrl_more_options",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/custom-baseUrl-paging/Generated/Configuration.json
+++ b/test/TestServerProjects/custom-baseUrl-paging/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"custom_baseUrl_paging","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "custom_baseUrl_paging",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/custom-baseUrl/Generated/Configuration.json
+++ b/test/TestServerProjects/custom-baseUrl/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"custom_baseUrl","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "custom_baseUrl",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/extensible-enums-swagger/Generated/Configuration.json
+++ b/test/TestServerProjects/extensible-enums-swagger/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"extensible_enums_swagger","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "extensible_enums_swagger",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/head/Generated/Configuration.json
+++ b/test/TestServerProjects/head/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"head","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "head",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/header/Generated/Configuration.json
+++ b/test/TestServerProjects/header/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"header","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "header",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/httpInfrastructure/Generated/Configuration.json
+++ b/test/TestServerProjects/httpInfrastructure/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"httpInfrastructure","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "httpInfrastructure",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/lro-parameterized-endpoints/Generated/Configuration.json
+++ b/test/TestServerProjects/lro-parameterized-endpoints/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"lro_parameterized_endpoints","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "lro_parameterized_endpoints",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/lro/Generated/Configuration.json
+++ b/test/TestServerProjects/lro/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"lro","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "lro",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/media_types/Generated/Configuration.json
+++ b/test/TestServerProjects/media_types/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"media_types","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "media_types",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/model-flattening/Generated/Configuration.json
+++ b/test/TestServerProjects/model-flattening/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"model_flattening","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "model_flattening",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/multiple-inheritance/Generated/Configuration.json
+++ b/test/TestServerProjects/multiple-inheritance/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"multiple_inheritance","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "multiple_inheritance",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/non-string-enum/Generated/Configuration.json
+++ b/test/TestServerProjects/non-string-enum/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"non_string_enum","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "non_string_enum",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/object-type/Generated/Configuration.json
+++ b/test/TestServerProjects/object-type/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"object_type","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "object_type",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/paging/Generated/Configuration.json
+++ b/test/TestServerProjects/paging/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"paging","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "paging",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/required-optional/Generated/Configuration.json
+++ b/test/TestServerProjects/required-optional/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"required_optional","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "required_optional",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/subscriptionId-apiVersion/Generated/Configuration.json
+++ b/test/TestServerProjects/subscriptionId-apiVersion/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"subscriptionId_apiVersion","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "subscriptionId_apiVersion",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/url-multi-collectionFormat/Generated/Configuration.json
+++ b/test/TestServerProjects/url-multi-collectionFormat/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"url_multi_collectionFormat","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "url_multi_collectionFormat",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/url/Generated/Configuration.json
+++ b/test/TestServerProjects/url/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"url","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "url",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/validation/Generated/Configuration.json
+++ b/test/TestServerProjects/validation/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"validation","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "validation",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/xml-service/Generated/Configuration.json
+++ b/test/TestServerProjects/xml-service/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"xml_service","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "xml_service",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}

--- a/test/TestServerProjects/xms-error-responses/Generated/Configuration.json
+++ b/test/TestServerProjects/xms-error-responses/Generated/Configuration.json
@@ -1,1 +1,22 @@
-{"OutputFolder":".","Namespace":"xms_error_responses","LibraryName":null,"SharedSourceFolders":["..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared","..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"],"AzureArm":false,"PublicClients":true,"ModelNamespace":true,"HeadAsBoolean":false,"SkipCSProjPackageReference":true,"LowLevelClient":false,"CredentialTypes":[],"CredentialScopes":[],"CredentialHeaderName":"api-key","OperationGroupToResourceType":{},"OperationGroupToResource":{},"ResourceRename":{},"OperationGroupToParent":{}}
+{
+  "OutputFolder": ".",
+  "Namespace": "xms_error_responses",
+  "LibraryName": null,
+  "SharedSourceFolders": [
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Generator.Shared",
+    "..\\..\\..\\..\\artifacts\\bin\\AutoRest.CSharp\\Debug\\netcoreapp3.1\\Azure.Core.Shared"
+  ],
+  "AzureArm": false,
+  "PublicClients": true,
+  "ModelNamespace": true,
+  "HeadAsBoolean": false,
+  "SkipCSProjPackageReference": true,
+  "LowLevelClient": false,
+  "CredentialTypes": [],
+  "CredentialScopes": [],
+  "CredentialHeaderName": "api-key",
+  "OperationGroupToResourceType": {},
+  "OperationGroupToResource": {},
+  "ResourceRename": {},
+  "OperationGroupToParent": {}
+}


### PR DESCRIPTION
https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/5726
- By combining all mgmt configs into as single class it will help avoid conflicts in the common files
- Pretty printing the config file will help avoid conflicts when two features edited different parts of the config file since its no longer on a single line