### PR TITLE
[LLC] Fix apiVersion and options being ctor params

### DIFF
--- a/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
+++ b/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
@@ -23,6 +23,7 @@ namespace Azure.AI.DocumentTranslation
         protected HttpPipeline Pipeline { get; }
         private const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
         private string endpoint;
+        private readonly string apiVersion;
 
         /// <summary> Initializes a new instance of DocumentTranslationClient for mocking. </summary>
         protected DocumentTranslationClient()
@@ -47,6 +48,7 @@ namespace Azure.AI.DocumentTranslation
             options ??= new AzureAIDocumentTranslationClientOptions();
             Pipeline = HttpPipelineBuilder.Build(options, new AzureKeyCredentialPolicy(credential, AuthorizationHeader));
             this.endpoint = endpoint;
+            apiVersion = options.Version;
         }
 
         /// <summary>

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
@@ -106,6 +106,7 @@ namespace AutoRest.CSharp.Generation.Writers
         private const string PipelineField = "Pipeline";
         private const string KeyCredentialVariable = "credential";
         private const string OptionsVariable = "options";
+        private const string APIVersionField = "apiVersion";
         private const string AuthorizationHeaderConstant = "AuthorizationHeader";
         private const string ScopesConstant = "AuthorizationScopes";
 
@@ -137,6 +138,9 @@ namespace AutoRest.CSharp.Generation.Writers
             {
                 writer.Line($"private {clientParameter.Type} {clientParameter.Name};");
             }
+
+            writer.Line($"private readonly string {APIVersionField};");
+
             writer.Line();
         }
 
@@ -209,6 +213,7 @@ namespace AutoRest.CSharp.Generation.Writers
                 {
                     writer.Line($"this.{clientParameter.Name} = {clientParameter.Name};");
                 }
+                writer.Line($"this.{APIVersionField} = {OptionsVariable}.Version;");
             }
             writer.Line();
         }

--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClient.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClient.cs
@@ -28,7 +28,7 @@ namespace AutoRest.CSharp.Output.Models
             _context = context;
             _builder = new RestClientBuilder (operationGroup, context);
 
-            Parameters = _builder.GetOrderedParameters ();
+            Parameters = _builder.GetOrderedParameters ().Where (p => !p.IsApiVersionParameter).ToArray();
             ClientPrefix = GetClientPrefix(operationGroup.Language.Default.Name, context);
             DefaultName = ClientPrefix + ClientSuffix;
         }


### PR DESCRIPTION
- Store apiVersion from options as needed
- The checked in samples does not unfortunately use apiVersion but other clients would have:

```
public FooClient(string accountName, TokenCredential credential, string apiVersion = "STUFF",  FooClientOptions options = null)
{
...
}
```

```
            uri.AppendQuery("api-version", apiVersion, true);
```