### PR TITLE
[LLC] Expose Pipeline, Hide CreateXYZ methods

### DIFF
--- a/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
+++ b/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.DocumentTranslation
     public partial class DocumentTranslationClient
     {
         /// <summary> The HTTP pipeline for sending and receiving REST requests and responses. </summary>
-        public HttpPipeline Pipeline { get; }
+        public virtual HttpPipeline Pipeline { get; }
         private const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
         private string endpoint;
         private readonly string apiVersion;

--- a/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
+++ b/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.DocumentTranslation
     public partial class DocumentTranslationClient
     {
         /// <summary> The HTTP pipeline for sending and receiving REST requests and responses. </summary>
-        protected HttpPipeline Pipeline { get; }
+        public HttpPipeline Pipeline { get; }
         private const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
         private string endpoint;
         private readonly string apiVersion;
@@ -108,7 +108,7 @@ namespace Azure.AI.DocumentTranslation
 
         /// <summary> Create Request for <see cref="SubmitBatchRequest"/> and <see cref="SubmitBatchRequestAsync"/> operations. </summary>
         /// <param name="requestBody"> The request body. </param>
-        protected Request CreateSubmitBatchRequestRequest(RequestContent requestBody)
+        private Request CreateSubmitBatchRequestRequest(RequestContent requestBody)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -347,7 +347,7 @@ namespace Azure.AI.DocumentTranslation
         /// <param name="createdDateTimeUtcStart"> the start datetime to get items after. </param>
         /// <param name="createdDateTimeUtcEnd"> the end datetime to get items before. </param>
         /// <param name="orderBy"> the sorting query for the collection (ex: &apos;CreatedDateTimeUtc asc&apos;, &apos;CreatedDateTimeUtc desc&apos;). </param>
-        protected Request CreateGetOperationsRequest(int? top = null, int? skip = null, int? maxpagesize = null, IEnumerable<Guid> ids = null, IEnumerable<string> statuses = null, DateTimeOffset? createdDateTimeUtcStart = null, DateTimeOffset? createdDateTimeUtcEnd = null, IEnumerable<string> orderBy = null)
+        private Request CreateGetOperationsRequest(int? top = null, int? skip = null, int? maxpagesize = null, IEnumerable<Guid> ids = null, IEnumerable<string> statuses = null, DateTimeOffset? createdDateTimeUtcStart = null, DateTimeOffset? createdDateTimeUtcEnd = null, IEnumerable<string> orderBy = null)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -416,7 +416,7 @@ namespace Azure.AI.DocumentTranslation
         /// <summary> Create Request for <see cref="GetDocumentStatus"/> and <see cref="GetDocumentStatusAsync"/> operations. </summary>
         /// <param name="id"> Format - uuid.  The batch id. </param>
         /// <param name="documentId"> Format - uuid.  The document id. </param>
-        protected Request CreateGetDocumentStatusRequest(Guid id, Guid documentId)
+        private Request CreateGetDocumentStatusRequest(Guid id, Guid documentId)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -461,7 +461,7 @@ namespace Azure.AI.DocumentTranslation
 
         /// <summary> Create Request for <see cref="GetOperationStatus"/> and <see cref="GetOperationStatusAsync"/> operations. </summary>
         /// <param name="id"> Format - uuid.  The operation id. </param>
-        protected Request CreateGetOperationStatusRequest(Guid id)
+        private Request CreateGetOperationStatusRequest(Guid id)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -516,7 +516,7 @@ namespace Azure.AI.DocumentTranslation
 
         /// <summary> Create Request for <see cref="CancelOperation"/> and <see cref="CancelOperationAsync"/> operations. </summary>
         /// <param name="id"> Format - uuid.  The operation-id. </param>
-        protected Request CreateCancelOperationRequest(Guid id)
+        private Request CreateCancelOperationRequest(Guid id)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -745,7 +745,7 @@ namespace Azure.AI.DocumentTranslation
         /// <param name="createdDateTimeUtcStart"> the start datetime to get items after. </param>
         /// <param name="createdDateTimeUtcEnd"> the end datetime to get items before. </param>
         /// <param name="orderBy"> the sorting query for the collection (ex: &apos;CreatedDateTimeUtc asc&apos;, &apos;CreatedDateTimeUtc desc&apos;). </param>
-        protected Request CreateGetOperationDocumentsStatusRequest(Guid id, int? top = null, int? skip = null, int? maxpagesize = null, IEnumerable<Guid> ids = null, IEnumerable<string> statuses = null, DateTimeOffset? createdDateTimeUtcStart = null, DateTimeOffset? createdDateTimeUtcEnd = null, IEnumerable<string> orderBy = null)
+        private Request CreateGetOperationDocumentsStatusRequest(Guid id, int? top = null, int? skip = null, int? maxpagesize = null, IEnumerable<Guid> ids = null, IEnumerable<string> statuses = null, DateTimeOffset? createdDateTimeUtcStart = null, DateTimeOffset? createdDateTimeUtcEnd = null, IEnumerable<string> orderBy = null)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -818,7 +818,7 @@ namespace Azure.AI.DocumentTranslation
         }
 
         /// <summary> Create Request for <see cref="GetDocumentFormats"/> and <see cref="GetDocumentFormatsAsync"/> operations. </summary>
-        protected Request CreateGetDocumentFormatsRequest()
+        private Request CreateGetDocumentFormatsRequest()
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -857,7 +857,7 @@ namespace Azure.AI.DocumentTranslation
         }
 
         /// <summary> Create Request for <see cref="GetGlossaryFormats"/> and <see cref="GetGlossaryFormatsAsync"/> operations. </summary>
-        protected Request CreateGetGlossaryFormatsRequest()
+        private Request CreateGetGlossaryFormatsRequest()
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -888,7 +888,7 @@ namespace Azure.AI.DocumentTranslation
         }
 
         /// <summary> Create Request for <see cref="GetDocumentStorageSource"/> and <see cref="GetDocumentStorageSourceAsync"/> operations. </summary>
-        protected Request CreateGetDocumentStorageSourceRequest()
+        private Request CreateGetDocumentStorageSourceRequest()
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;

--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -26,7 +26,7 @@ namespace AutoRest.CSharp.Generation.Writers
 
             var methodName = CreateRequestMethodName(clientMethod.Name);
             var returnType = lowLevel ? typeof(Azure.Core.Request) : typeof(HttpMessage);
-            var visibility = clientMethod.IsVisible ? "protected" : "internal";
+            var visibility = lowLevel ? "private" : (clientMethod.IsVisible ? "protected" : "internal");
             writer.Append($"{visibility} {returnType} {methodName}(");
             foreach (Parameter clientParameter in parameters)
             {

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
@@ -116,7 +116,7 @@ namespace AutoRest.CSharp.Generation.Writers
         private void WriteClientFields(CodeWriter writer, LowLevelRestClient client, BuildContext context)
         {
             writer.WriteXmlDocumentationSummary("The HTTP pipeline for sending and receiving REST requests and responses.");
-            writer.Append($"public {typeof(HttpPipeline)} {PipelineField}");
+            writer.Append($"public virtual {typeof(HttpPipeline)} {PipelineField}");
             writer.AppendRaw("{ get; }\n");
 
             if (HasKeyAuth (context))

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
@@ -116,7 +116,7 @@ namespace AutoRest.CSharp.Generation.Writers
         private void WriteClientFields(CodeWriter writer, LowLevelRestClient client, BuildContext context)
         {
             writer.WriteXmlDocumentationSummary("The HTTP pipeline for sending and receiving REST requests and responses.");
-            writer.Append($"protected {typeof(HttpPipeline)} {PipelineField}");
+            writer.Append($"public {typeof(HttpPipeline)} {PipelineField}");
             writer.AppendRaw("{ get; }\n");
 
             if (HasKeyAuth (context))


### PR DESCRIPTION
For Low Level Clients, expose the HttpPipeline via a public read-only
property. Previously, this was `protected` and so a customer who
wished to send arbitrary requests would need to inherit from the
client to access this property. In addition, we make our `CreateXYZ`
methods private for now. We do believe we will want to expose these
somehow at some point, but we aren't exactly sure how (perhaps via
some nested `RequestBuilders` static class or something else).