### PR TITLE
Add ValidResourceType to [Resource]Container

### DIFF
--- a/samples/Azure.Management.Storage/Generated/BlobContainerContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobContainerContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of BlobContainer and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected BlobContainerContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/BlobContainerOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobContainerOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/BlobContainerOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/BlobContainerOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/BlobServiceContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobServiceContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of BlobService and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected BlobServiceContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/BlobServiceOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobServiceOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/BlobServiceOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/BlobServiceOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/EncryptionScopeContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/EncryptionScopeContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of EncryptionScope and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected EncryptionScopeContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/EncryptionScopeOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/EncryptionScopeOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/EncryptionScopeOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/EncryptionScopeOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/FileServiceContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/FileServiceContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of FileService and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected FileServiceContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/FileServiceOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/FileServiceOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/FileServiceOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/FileServiceOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/FileShareContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/FileShareContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of FileShare and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected FileShareContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/FileShareOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/FileShareOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/FileShareOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/FileShareOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/ManagementPolicyContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/ManagementPolicyContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of ManagementPolicy and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected ManagementPolicyContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/ManagementPolicyOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/ManagementPolicyOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/ManagementPolicyOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/ManagementPolicyOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of ObjectReplicationPolicy and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected ObjectReplicationPolicyContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/ObjectReplicationPolicyOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/ObjectReplicationPolicyOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/OperationContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/OperationContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of Operation and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected OperationContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "";
     }
 }

--- a/samples/Azure.Management.Storage/Generated/OperationContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/OperationContainer.cs
@@ -18,6 +18,6 @@ namespace Azure.Management.Storage
         }
 
         /// <summary> Gets the valid resource type for this object. </summary>
-        protected ResourceType ValidResourceType => "";
+        protected ResourceType ValidResourceType => ResourceIdentifier.RootResourceIdentifier.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/OperationOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/OperationOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/OperationOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/OperationOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of PrivateEndpointConnection and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected PrivateEndpointConnectionContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/PrivateEndpointConnectionOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/PrivateEndpointConnectionOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/PrivateLinkResourceContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateLinkResourceContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of PrivateLinkResource and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected PrivateLinkResourceContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => StorageAccountOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/PrivateLinkResourceOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateLinkResourceOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/PrivateLinkResourceOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/PrivateLinkResourceOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/SkuContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/SkuContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of Sku and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected SkuContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => SubscriptionOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/SkuOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/SkuOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/SkuOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/SkuOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/StorageAccountContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccountContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of StorageAccount and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected StorageAccountContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "any";
     }
 }

--- a/samples/Azure.Management.Storage/Generated/StorageAccountOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccountOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/StorageAccountOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/StorageAccountOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/UsageContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/UsageContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.Management.Storage
 {
     /// <summary> A class representing collection of Usage and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.Management.Storage
         protected UsageContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => SubscriptionOperations.ResourceType;
     }
 }

--- a/samples/Azure.Management.Storage/Generated/UsageOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/UsageOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.Management.Storage
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.Management.Storage/UsageOperations";
+        public static readonly ResourceType ResourceType = "Azure.Management.Storage/UsageOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of AvailabilitySet and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected AvailabilitySetContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/AvailabilitySetOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/AvailabilitySetOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of DedicatedHost and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected DedicatedHostContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => DedicatedHostGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of DedicatedHostGroup and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected DedicatedHostGroupContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/DedicatedHostGroupOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/DedicatedHostGroupOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/DedicatedHostOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/DedicatedHostOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/ImageContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImageContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of Image and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected ImageContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/ImageOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImageOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/ImageOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/ImageOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of ProximityPlacementGroup and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected ProximityPlacementGroupContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/ProximityPlacementGroupOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/ProximityPlacementGroupOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/RestApiContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestApiContainer.cs
@@ -18,6 +18,6 @@ namespace Azure.ResourceManager.Sample
         }
 
         /// <summary> Gets the valid resource type for this object. </summary>
-        protected ResourceType ValidResourceType => "";
+        protected ResourceType ValidResourceType => ResourceIdentifier.RootResourceIdentifier.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/RestApiContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestApiContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of RestApi and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected RestApiContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "";
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/RestApiOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestApiOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/RestApiOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/RestApiOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of SshPublicKey and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected SshPublicKeyContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/SshPublicKeyOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/SshPublicKeyOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachine and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineExtension and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineExtensionContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => VirtualMachineScaleSetOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineExtensionImage and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineExtensionImageContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "Microsoft.Compute/locations/publishers";
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineExtensionImageOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineExtensionImageOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineExtensionOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineExtensionOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineImageContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineImageContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineImage and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineImageContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "Microsoft.Compute/locations";
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineImageOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineImageOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineImageOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineImageOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineScaleSet and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineScaleSetContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineScaleSetExtension and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineScaleSetExtensionContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => VirtualMachineScaleSetOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetExtensionOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetExtensionOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineScaleSetRollingUpgrade and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineScaleSetRollingUpgradeContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => VirtualMachineScaleSetOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetRollingUpgradeOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetRollingUpgradeOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineScaleSetVM and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineScaleSetVMContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => VirtualMachineScaleSetOperations.ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetVMOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineScaleSetVMOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineSizeContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineSizeContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> A class representing collection of VirtualMachineSize and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace Azure.ResourceManager.Sample
         protected VirtualMachineSizeContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "Microsoft.Compute/locations";
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineSizeOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineSizeOperations.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
-        private static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineSizeOperations";
+        public static readonly ResourceType ResourceType = "Azure.ResourceManager.Sample/VirtualMachineSizeOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -50,6 +50,8 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
 
         public IEnumerable<ResourceOperation> ResourceOperations => EnsureResourceOperations().Values;
 
+        public ResourceOperation GetResourceOperation(OperationGroup operationGroup) => EnsureResourceOperations()[operationGroup];
+
         public IEnumerable<ResourceContainer> ResourceContainers => EnsureResourceContainers().Values;
 
         private static HashSet<string> ResourceTypes = new HashSet<string>

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -58,7 +58,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             foreach (var resourceContainer in context.Library.ResourceContainers)
             {
                 var codeWriter = new CodeWriter();
-                resourceContainerWriter.WriteClient(codeWriter, resourceContainer);
+                resourceContainerWriter.WriteContainer(codeWriter, resourceContainer);
 
                 project.AddGeneratedFile($"{resourceContainer.Type.Name}.cs", codeWriter.ToString());
             }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
@@ -15,7 +15,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
     {
         private static ConcurrentDictionary<OperationGroup, string> _valueCache = new ConcurrentDictionary<OperationGroup, string>();
 
-        public static string Parent(this OperationGroup operationGroup, MgmtConfiguration config)
+        public static string ParentResourceType(this OperationGroup operationGroup, MgmtConfiguration config)
         {
             string? result = null;
             if (_valueCache.TryGetValue(operationGroup, out result))
@@ -116,9 +116,9 @@ namespace AutoRest.CSharp.Mgmt.Decorator
         {
             foreach (var operationsGroup in operationGroups)
             {
-                if (operationsGroup.Parent(config) != null && !ResourceTypes.Contains(operationsGroup.Parent(config)))
+                if (operationsGroup.ParentResourceType(config) != null && !ResourceTypes.Contains(operationsGroup.ParentResourceType(config)))
                 {
-                    throw new ArgumentException($"Could not set parent for operations group {operationsGroup.Key} with parent {operationsGroup.Parent(config)}. key Please add to readme.md");
+                    throw new ArgumentException($"Could not set parent for operations group {operationsGroup.Key} with parent {operationsGroup.ParentResourceType(config)}. key Please add to readme.md");
                 }
             }
         }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ResourceTypeBuilder.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ResourceTypeBuilder.cs
@@ -13,6 +13,9 @@ namespace AutoRest.CSharp.Mgmt.Decorator
 {
     internal static class ResourceTypeBuilder
     {
+        public const string Subscriptions = "subscriptions";
+        public const string ResourceGroups = "resourceGroups";
+        public const string Tenant = "tenant";
         private static ConcurrentDictionary<OperationGroup, string> _valueCache = new ConcurrentDictionary<OperationGroup, string>();
 
         public static string ResourceType(this OperationGroup operationsGroup, MgmtConfiguration config)

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceContainerWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceContainerWriter.cs
@@ -2,7 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using AutoRest.CSharp.Generation.Writers;
+using AutoRest.CSharp.Input;
+using AutoRest.CSharp.Mgmt.AutoRest;
 using AutoRest.CSharp.Mgmt.Output;
+using AutoRest.CSharp.Output.Models.Types;
+using Azure.ResourceManager.Core;
+using AutoRest.CSharp.Mgmt.Decorator;
 
 namespace AutoRest.CSharp.Mgmt.Generation
 {
@@ -11,7 +16,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
         private const string ClientDiagnosticsVariable = "clientDiagnostics";
         private const string PipelineVariable = "pipeline";
 
-        public void WriteClient(CodeWriter writer, ResourceContainer resourceContainer)
+        public void WriteContainer(CodeWriter writer, ResourceContainer resourceContainer)
         {
             var cs = resourceContainer.Type;
             var @namespace = cs.Namespace;
@@ -20,17 +25,34 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 writer.WriteXmlDocumentationSummary(resourceContainer.Description);
                 using (writer.Scope($"{resourceContainer.Declaration.Accessibility} partial class {cs.Name}"))
                 {
-                    WriteClientCtors(writer, resourceContainer);
+                    WriteContainerCtors(writer, resourceContainer);
+
+                    WriteContainerProperties(writer, resourceContainer);
                 }
             }
         }
 
-        private void WriteClientCtors(CodeWriter writer, ResourceContainer resourceContainer)
+        private void WriteContainerCtors(CodeWriter writer, ResourceContainer resourceContainer)
         {
             writer.WriteXmlDocumentationSummary($"Initializes a new instance of {resourceContainer.Type.Name} for mocking.");
             using (writer.Scope($"protected {resourceContainer.Type.Name:D}()"))
             {
             }
+            writer.Line();
+        }
+
+        private void WriteContainerProperties(CodeWriter writer, ResourceContainer resourceContainer)
+        {
+            var resourceType = resourceContainer.GetValidResourceValue();
+
+            // TODO: Remove this if condition after https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/5800
+            if (!resourceType.Contains(".ResourceType"))
+            {
+                resourceType = $"\"{resourceType}\"";
+            }
+
+            writer.WriteXmlDocumentationSummary($"Gets the valid resource type for this object");
+            writer.Line($"protected {typeof(ResourceType)} ValidResourceType => {resourceType};");
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
@@ -44,7 +44,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
         private void WriteClientProperties(CodeWriter writer, ResourceOperation resourceOperation)
         {
             writer.Line();
-            writer.Line($"private static readonly {typeof(ResourceType)} ResourceType = \"{resourceOperation.Type.Namespace}/{resourceOperation.Type.Name}\";");
+            writer.Line($"public static readonly {typeof(ResourceType)} ResourceType = \"{resourceOperation.Type.Namespace}/{resourceOperation.Type.Name}\";");
             writer.Line($"protected override {typeof(ResourceType)} ValidResourceType => ResourceType;");
             }
 

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceContainer.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceContainer.cs
@@ -1,22 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Text;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
+using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Output.Builders;
 using AutoRest.CSharp.Output.Models.Types;
+using Azure.ResourceManager.Core;
 
 namespace AutoRest.CSharp.Mgmt.Output
 {
     internal class ResourceContainer : ResourceOperation
     {
         private const string _suffixValue = "Container";
+        private BuildContext<MgmtOutputLibrary> _context;
+        private const string ResourceGroupOperationsResourceType = "ResourceGroupOperations.ResourceType";
+        private const string SubscriptionOperationsResourceType = "SubscriptionOperations.ResourceType";
 
         public ResourceContainer(OperationGroup operationGroup, BuildContext<MgmtOutputLibrary> context)
             : base(operationGroup, context)
         {
+            OperationGroup = operationGroup;
+            _context = context;
         }
+
+        internal OperationGroup OperationGroup { get; }
 
         protected override string SuffixValue => _suffixValue;
 
@@ -26,6 +36,44 @@ namespace AutoRest.CSharp.Mgmt.Output
             return string.IsNullOrWhiteSpace(operationGroup.Language.Default.Description) ?
                 $"A class representing collection of {clientPrefix} and their operations over a [ParentResource]. " :
                 BuilderHelpers.EscapeXmlDescription(operationGroup.Language.Default.Description);
+        }
+
+        public string GetValidResourceValue()
+        {
+            var parentResourceType = OperationGroup.ParentResourceType(_context.Configuration.MgmtConfiguration);
+
+            switch (parentResourceType)
+            {
+                case ResourceTypeBuilder.ResourceGroups:
+                    return ResourceGroupOperationsResourceType;
+                case ResourceTypeBuilder.Subscriptions:
+                    return SubscriptionOperationsResourceType;
+                case ResourceTypeBuilder.Tenant:
+                    return ResourceIdentifier.RootResourceIdentifier;
+                default:
+                    return FindParentFromRp(parentResourceType);
+            }
+        }
+
+        private string FindParentFromRp(string parentResourceType)
+        {
+            OperationGroup? parentOperationGroup = null;
+            foreach (var operationGroup in _context.CodeModel.OperationGroups)
+            {
+                if (operationGroup.ResourceType(_context.Configuration.MgmtConfiguration).Equals(parentResourceType))
+                {
+                    parentOperationGroup = operationGroup;
+                    break;
+                }
+            }
+
+            if (parentOperationGroup is null)
+                return parentResourceType;
+            // TODO: Throw the below exception after https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/5800
+            // throw new Exception($"Could not find ResourceType for {parentResourceType}. Please update the swagger");
+
+            var parentOperations = _context.Library.GetResourceOperation(parentOperationGroup);
+            return $"{parentOperations.Declaration.Name}.ResourceType";
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceContainer.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceContainer.cs
@@ -18,6 +18,7 @@ namespace AutoRest.CSharp.Mgmt.Output
         private BuildContext<MgmtOutputLibrary> _context;
         private const string ResourceGroupOperationsResourceType = "ResourceGroupOperations.ResourceType";
         private const string SubscriptionOperationsResourceType = "SubscriptionOperations.ResourceType";
+        private const string TenantResourceType = "ResourceIdentifier.RootResourceIdentifier.ResourceType";
 
         public ResourceContainer(OperationGroup operationGroup, BuildContext<MgmtOutputLibrary> context)
             : base(operationGroup, context)
@@ -49,7 +50,7 @@ namespace AutoRest.CSharp.Mgmt.Output
                 case ResourceTypeBuilder.Subscriptions:
                     return SubscriptionOperationsResourceType;
                 case ResourceTypeBuilder.Tenant:
-                    return ResourceIdentifier.RootResourceIdentifier;
+                    return TenantResourceType;
                 default:
                     return FindParentFromRp(parentResourceType);
             }

--- a/src/AutoRest.CSharp/Properties/launchSettings.json
+++ b/src/AutoRest.CSharp/Properties/launchSettings.json
@@ -267,7 +267,7 @@
     "subscriptionId-apiVersion": {
       "commandName": "Project",
       "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestServerProjects\\subscriptionId-apiVersion\\Generated"
-    },    
+    },
     "SupersetInheritance": {
       "commandName": "Project",
       "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestProjects\\SupersetInheritance\\Generated"

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/MgmtParentTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/MgmtParentTests.cs
@@ -26,13 +26,13 @@ namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
             var context = result.Context;
             foreach (var operations in model.OperationGroups)
             {
-                Assert.IsNotNull(operations.Parent(context.Configuration.MgmtConfiguration));
+                Assert.IsNotNull(operations.ParentResourceType(context.Configuration.MgmtConfiguration));
                 if (operations.Key.Equals("VirtualMachineExtensionImages"))
-                    Assert.IsTrue(operations.Parent(context.Configuration.MgmtConfiguration).Equals("Microsoft.Compute/locations/publishers"));
+                    Assert.IsTrue(operations.ParentResourceType(context.Configuration.MgmtConfiguration).Equals("Microsoft.Compute/locations/publishers"));
                 else if (operations.Key.Equals("AvailabilitySets"))
-                    Assert.IsTrue(operations.Parent(context.Configuration.MgmtConfiguration).Equals("resourceGroups"));
+                    Assert.IsTrue(operations.ParentResourceType(context.Configuration.MgmtConfiguration).Equals("resourceGroups"));
                 else if (operations.Key.Equals("DedicatedHosts"))
-                    Assert.IsTrue(operations.Parent(context.Configuration.MgmtConfiguration).Equals("Microsoft.Compute/hostGroups"));
+                    Assert.IsTrue(operations.ParentResourceType(context.Configuration.MgmtConfiguration).Equals("Microsoft.Compute/hostGroups"));
             }
         }
     }

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/TenantOnlyTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/TenantOnlyTests.cs
@@ -20,13 +20,13 @@ namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
             var context = result.Context;
             foreach (var operations in model.OperationGroups)
             {
-                Assert.IsNotNull(operations.Parent(context.Configuration.MgmtConfiguration));
+                Assert.IsNotNull(operations.ParentResourceType(context.Configuration.MgmtConfiguration));
                 if (operations.Key.Equals("AvailableBalances") || operations.Key.Equals("Instructions"))
-                    Assert.IsTrue(operations.Parent(context.Configuration.MgmtConfiguration).Equals("Microsoft.Billing/billingAccounts/billingProfiles"));
+                    Assert.IsTrue(operations.ParentResourceType(context.Configuration.MgmtConfiguration).Equals("Microsoft.Billing/billingAccounts/billingProfiles"));
                 else if (operations.Key.Equals("Agreements"))
-                    Assert.IsTrue(operations.Parent(context.Configuration.MgmtConfiguration).Equals("Microsoft.Billing/billingAccounts"));
+                    Assert.IsTrue(operations.ParentResourceType(context.Configuration.MgmtConfiguration).Equals("Microsoft.Billing/billingAccounts"));
                 else
-                    Assert.IsTrue(operations.Parent(context.Configuration.MgmtConfiguration).Equals("tenant"));
+                    Assert.IsTrue(operations.ParentResourceType(context.Configuration.MgmtConfiguration).Equals("tenant"));
             }
         }
     }

--- a/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
@@ -66,5 +66,29 @@ namespace AutoRest.TestServer.Tests.Mgmt.TestProjects
                 }
             }
         }
+
+        [TestCase("ValidResourceType")]
+        public void ValidateContainerPropertyExists(string propertyName)
+        {
+            foreach (var type in FindAllContainers())
+            {
+                var propertyInfo = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(propertyInfo, $"Property '{type.Name}' is not found");
+                Assert.AreEqual(typeof(ResourceType), propertyInfo.PropertyType);
+            }
+        }
+
+        private IEnumerable<Type> FindAllContainers()
+        {
+            Type[] allTypes = Assembly.GetExecutingAssembly().GetTypes();
+
+            foreach (Type t in allTypes)
+            {
+                if (t.Name.Contains("Container") && !t.Name.Contains("Tests") && t.Namespace == _projectName)
+                {
+                    yield return t;
+                }
+            }
+        }
     }
 }

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace ExactMatchInheritance
 {
     /// <summary> A class representing collection of ExactMatchModel1 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace ExactMatchInheritance
         protected ExactMatchModel1Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Operations.cs
@@ -21,7 +21,7 @@ namespace ExactMatchInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel1Operations";
+        public static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel1Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel2Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel2Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace ExactMatchInheritance
 {
     /// <summary> A class representing collection of ExactMatchModel2 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace ExactMatchInheritance
         protected ExactMatchModel2Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel2Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel2Operations.cs
@@ -21,7 +21,7 @@ namespace ExactMatchInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel2Operations";
+        public static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel2Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace ExactMatchInheritance
 {
     /// <summary> A class representing collection of ExactMatchModel3 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace ExactMatchInheritance
         protected ExactMatchModel3Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Operations.cs
@@ -21,7 +21,7 @@ namespace ExactMatchInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel3Operations";
+        public static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel3Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel4Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel4Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace ExactMatchInheritance
 {
     /// <summary> A class representing collection of ExactMatchModel4 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace ExactMatchInheritance
         protected ExactMatchModel4Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel4Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel4Operations.cs
@@ -21,7 +21,7 @@ namespace ExactMatchInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel4Operations";
+        public static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel4Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace ExactMatchInheritance
 {
     /// <summary> A class representing collection of ExactMatchModel5 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace ExactMatchInheritance
         protected ExactMatchModel5Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Operations.cs
@@ -21,7 +21,7 @@ namespace ExactMatchInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel5Operations";
+        public static readonly ResourceType ResourceType = "ExactMatchInheritance/ExactMatchModel5Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/AvailabilitySetContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/AvailabilitySetContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace MgmtParent
 {
     /// <summary> A class representing collection of AvailabilitySet and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace MgmtParent
         protected AvailabilitySetContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/MgmtParent/Generated/AvailabilitySetOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/AvailabilitySetOperations.cs
@@ -21,7 +21,7 @@ namespace MgmtParent
         {
         }
 
-        private static readonly ResourceType ResourceType = "MgmtParent/AvailabilitySetOperations";
+        public static readonly ResourceType ResourceType = "MgmtParent/AvailabilitySetOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace MgmtParent
 {
     /// <summary> A class representing collection of DedicatedHost and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace MgmtParent
         protected DedicatedHostContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => DedicatedHostGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace MgmtParent
 {
     /// <summary> A class representing collection of DedicatedHostGroup and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace MgmtParent
         protected DedicatedHostGroupContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupOperations.cs
@@ -21,7 +21,7 @@ namespace MgmtParent
         {
         }
 
-        private static readonly ResourceType ResourceType = "MgmtParent/DedicatedHostGroupOperations";
+        public static readonly ResourceType ResourceType = "MgmtParent/DedicatedHostGroupOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostOperations.cs
@@ -21,7 +21,7 @@ namespace MgmtParent
         {
         }
 
-        private static readonly ResourceType ResourceType = "MgmtParent/DedicatedHostOperations";
+        public static readonly ResourceType ResourceType = "MgmtParent/DedicatedHostOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace MgmtParent
 {
     /// <summary> A class representing collection of VirtualMachineExtensionImage and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace MgmtParent
         protected VirtualMachineExtensionImageContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "Microsoft.Compute/locations/publishers";
     }
 }

--- a/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageOperations.cs
@@ -21,7 +21,7 @@ namespace MgmtParent
         {
         }
 
-        private static readonly ResourceType ResourceType = "MgmtParent/VirtualMachineExtensionImageOperations";
+        public static readonly ResourceType ResourceType = "MgmtParent/VirtualMachineExtensionImageOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetContainer.cs
+++ b/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace OperationGroupMappings
 {
     /// <summary> A class representing collection of AvailabilitySet and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace OperationGroupMappings
         protected AvailabilitySetContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetOperations.cs
+++ b/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetOperations.cs
@@ -21,7 +21,7 @@ namespace OperationGroupMappings
         {
         }
 
-        private static readonly ResourceType ResourceType = "OperationGroupMappings/AvailabilitySetOperations";
+        public static readonly ResourceType ResourceType = "OperationGroupMappings/AvailabilitySetOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceRename/Generated/SshPublicKeyInfoContainer.cs
+++ b/test/TestProjects/ResourceRename/Generated/SshPublicKeyInfoContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace ResourceRename
 {
     /// <summary> A class representing collection of SshPublicKeyInfo and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace ResourceRename
         protected SshPublicKeyInfoContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/ResourceRename/Generated/SshPublicKeyInfoOperations.cs
+++ b/test/TestProjects/ResourceRename/Generated/SshPublicKeyInfoOperations.cs
@@ -21,7 +21,7 @@ namespace ResourceRename
         {
         }
 
-        private static readonly ResourceType ResourceType = "ResourceRename/SshPublicKeyInfoOperations";
+        public static readonly ResourceType ResourceType = "ResourceRename/SshPublicKeyInfoOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Container.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace SupersetInheritance
 {
     /// <summary> A class representing collection of SupersetModel1 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace SupersetInheritance
         protected SupersetModel1Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Operations.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Operations.cs
@@ -21,7 +21,7 @@ namespace SupersetInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel1Operations";
+        public static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel1Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel2Container.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel2Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace SupersetInheritance
 {
     /// <summary> A class representing collection of SupersetModel2 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace SupersetInheritance
         protected SupersetModel2Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel2Operations.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel2Operations.cs
@@ -21,7 +21,7 @@ namespace SupersetInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel2Operations";
+        public static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel2Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel3Container.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel3Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace SupersetInheritance
 {
     /// <summary> A class representing collection of SupersetModel3 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace SupersetInheritance
         protected SupersetModel3Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel3Operations.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel3Operations.cs
@@ -21,7 +21,7 @@ namespace SupersetInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel3Operations";
+        public static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel3Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Container.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Container.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace SupersetInheritance
 {
     /// <summary> A class representing collection of SupersetModel4 and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace SupersetInheritance
         protected SupersetModel4Container()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => ResourceGroupOperations.ResourceType;
     }
 }

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Operations.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Operations.cs
@@ -21,7 +21,7 @@ namespace SupersetInheritance
         {
         }
 
-        private static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel4Operations";
+        public static readonly ResourceType ResourceType = "SupersetInheritance/SupersetModel4Operations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/TenantOnly/Generated/AgreementContainer.cs
+++ b/test/TestProjects/TenantOnly/Generated/AgreementContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace TenantOnly
 {
     /// <summary> A class representing collection of Agreement and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace TenantOnly
         protected AgreementContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => BillingAccountOperations.ResourceType;
     }
 }

--- a/test/TestProjects/TenantOnly/Generated/AgreementOperations.cs
+++ b/test/TestProjects/TenantOnly/Generated/AgreementOperations.cs
@@ -21,7 +21,7 @@ namespace TenantOnly
         {
         }
 
-        private static readonly ResourceType ResourceType = "TenantOnly/AgreementOperations";
+        public static readonly ResourceType ResourceType = "TenantOnly/AgreementOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/TenantOnly/Generated/BillingAccountContainer.cs
+++ b/test/TestProjects/TenantOnly/Generated/BillingAccountContainer.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace TenantOnly
 {
     /// <summary> A class representing collection of BillingAccount and their operations over a [ParentResource]. </summary>
@@ -14,5 +16,8 @@ namespace TenantOnly
         protected BillingAccountContainer()
         {
         }
+
+        /// <summary> Gets the valid resource type for this object. </summary>
+        protected ResourceType ValidResourceType => "";
     }
 }

--- a/test/TestProjects/TenantOnly/Generated/BillingAccountContainer.cs
+++ b/test/TestProjects/TenantOnly/Generated/BillingAccountContainer.cs
@@ -18,6 +18,6 @@ namespace TenantOnly
         }
 
         /// <summary> Gets the valid resource type for this object. </summary>
-        protected ResourceType ValidResourceType => "";
+        protected ResourceType ValidResourceType => ResourceIdentifier.RootResourceIdentifier.ResourceType;
     }
 }

--- a/test/TestProjects/TenantOnly/Generated/BillingAccountOperations.cs
+++ b/test/TestProjects/TenantOnly/Generated/BillingAccountOperations.cs
@@ -21,7 +21,7 @@ namespace TenantOnly
         {
         }
 
-        private static readonly ResourceType ResourceType = "TenantOnly/BillingAccountOperations";
+        public static readonly ResourceType ResourceType = "TenantOnly/BillingAccountOperations";
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />


### PR DESCRIPTION
Add valid resource property that points at resource parent.

Example: https://github.com/Azure/azure-sdk-for-net/blob/feature/mgmt-track2/sdk/resourcemanager/Proto.Client/compute/AvailabilitySetContainer.cs#L25

Resolves: https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/5414