### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Description
+<i>Add your description here!</i>
+
+# Checklist
+
+To ensure a quick review and merge, please ensure:
+- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
+- [ ] The PR is opened in draft if not ready for review yet.
+   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
+- [ ] The branch is recent enough to not have merge conflicts upon creation.
+
+# Ready to Land?
+- [ ] Build is completely green
+   - Submissions with test failures require tracking issue and approval of a CODEOWNER
+- [ ] At least one +1 review by a CODEOWNER
+- [ ] All -1 reviews are confirmed resolved by the reviewer 
+   - Override/Marking reviews stale must be discussed with CODEOWNERS first


### PR DESCRIPTION
As autorest.csharp gains increased traffic with more developers, laying out expectations for review and submission with a PR template (like azure-rest-api-specs does) seemed reasonable.

Consider the text draft and not set in stone - I just wrote up the most common PR mistakes I've seen in the past. 

Thoughts?