### PR TITLE
Add unit test to validate cardinality of the 4 resource class types

### DIFF
--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/ExactMatchInheritanceTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/ExactMatchInheritanceTests.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
+{
+    internal class ExactMatchInheritanceTests : OutputLibraryTestBase
+    {
+        public ExactMatchInheritanceTests() : base("ExactMatchInheritance") { }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/MgmtParentTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/MgmtParentTests.cs
@@ -1,23 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
-using System.Threading.Tasks;
 using NUnit.Framework;
-using AutoRest.CSharp.AutoRest.Communication;
-using AutoRest.CSharp.Input;
-using AutoRest.CSharp.AutoRest.Plugins;
-using AutoRest.CSharp.Input.Source;
-using AutoRest.CSharp.Output.Models.Types;
-using System.Reflection;
-using System.Text;
-using System.Text.Json;
 using AutoRest.CSharp.Mgmt.Decorator;
 
 namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
 {
     internal class MgmtParentTests : OutputLibraryTestBase
     {
+        public MgmtParentTests() : base("MgmtParent") { }
+
         [Test]
         public void TestParentComputer()
         {

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OperationGroupMappingsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OperationGroupMappingsTests.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
+{
+    internal class OperationGroupMappingsTests : OutputLibraryTestBase
+    {
+        public OperationGroupMappingsTests() : base("OperationGroupMappings") { }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OutputLibraryTestBase.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OutputLibraryTestBase.cs
@@ -50,7 +50,6 @@ namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
             Assert.AreEqual(count, context.Library.ResourceContainers.Count());
             Assert.AreEqual(count, context.Library.ResourceData.Count());
             Assert.AreEqual(count, context.Library.ArmResource.Count());
-            Assert.AreEqual(count, context.Library.RestClients.Count());
         }
     }
 }

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OutputLibraryTestBase.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OutputLibraryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using AutoRest.CSharp.AutoRest.Communication;
@@ -9,7 +10,6 @@ using AutoRest.CSharp.AutoRest.Plugins;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Input.Source;
 using AutoRest.CSharp.Mgmt.AutoRest;
-using AutoRest.CSharp.Mgmt.Output;
 using AutoRest.CSharp.Output.Models.Types;
 using NUnit.Framework;
 
@@ -17,6 +17,13 @@ namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
 {
     internal abstract class OutputLibraryTestBase
     {
+        private string _projectName;
+
+        public OutputLibraryTestBase(string projectName)
+        {
+            _projectName = projectName;
+        }
+
         protected static async Task<(CodeModel Model, BuildContext<MgmtOutputLibrary> Context)> Generate(string testProject)
         {
             var basePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -30,6 +37,20 @@ namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
             var context = new BuildContext<MgmtOutputLibrary>(model, configuration, sourceInputModel);
             _ = context.Library; // gen lib
             return (model, context);
+        }
+
+        [Test]
+        public void ValidateResourceClassTypesCount()
+        {
+            var result = Generate(_projectName).Result;
+            var context = result.Context;
+
+            var count = context.Library.ResourceSchemaMap.Count;
+            Assert.AreEqual(count, context.Library.ResourceOperations.Count());
+            Assert.AreEqual(count, context.Library.ResourceContainers.Count());
+            Assert.AreEqual(count, context.Library.ResourceData.Count());
+            Assert.AreEqual(count, context.Library.ArmResource.Count());
+            Assert.AreEqual(count, context.Library.RestClients.Count());
         }
     }
 }

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/ResourceRenameTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/ResourceRenameTests.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
+{
+    internal class ResourceRenameTests : OutputLibraryTestBase
+    {
+        public ResourceRenameTests() : base("ResourceRename") { }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/SubscriptionExtensionsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/SubscriptionExtensionsTests.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
+{
+    internal class SubscriptionExtensionsTests : OutputLibraryTestBase
+    {
+        public SubscriptionExtensionsTests() : base("SubscriptionExtensions") { }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/SupersetInheritanceTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/SupersetInheritanceTests.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
+{
+    internal class SupersetInheritanceTests : OutputLibraryTestBase
+    {
+        public SupersetInheritanceTests() : base("SupersetInheritance") { }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/TenantOnlyTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/TenantOnlyTests.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.Decorator;
 using NUnit.Framework;
 
@@ -12,6 +8,8 @@ namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
 {
     internal class TenantOnlyTests : OutputLibraryTestBase
     {
+        public TenantOnlyTests() : base("TenantOnly") { }
+
         [Test]
         public void TestTenant()
         {


### PR DESCRIPTION
# Description
Adding unit tests for OutputLibrary to verify that the count of the below properties are equals or not

* count of ResourceSchemaMap
* count of ResourceOperations
* count of ResourceContainers
* count of ResourceData
* count of ArmResource

# Issue
https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/5710