### PR TITLE
Improve bug repro by write code-model & config out

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
@@ -106,8 +106,8 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 try
                 {
                     // We are unsuspectingly crashing, so output anything that might help us reproduce the issue
-                    await autoRest.WriteFile("Configuration-Crash.json", StandaloneGeneratorRunner.SaveConfiguration(configuration), "source-file-csharp");
-                    await autoRest.WriteFile("CodeModel-Crash.yaml", codeModelYaml, "source-file-csharp");
+                    await autoRest.WriteFile("Configuration.json", StandaloneGeneratorRunner.SaveConfiguration(configuration), "source-file-csharp");
+                    await autoRest.WriteFile("CodeModel.yaml", codeModelYaml, "source-file-csharp");
                 }
                 catch
                 {

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
@@ -103,7 +103,17 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             }
             catch (Exception e)
             {
-                await autoRest.Fatal($"Internal error in AutoRest.CSharp - {ErrorHelpers.FileIssueText}\nException: {e.Message}\n{e.StackTrace}");
+                try
+                {
+                    // We are unsuspectingly crashing, so output anything that might help us reproduce the issue
+                    await autoRest.WriteFile("Configuration-Crash.json", StandaloneGeneratorRunner.SaveConfiguration(configuration), "source-file-csharp");
+                    await autoRest.WriteFile("CodeModel-Crash.yaml", codeModelYaml, "source-file-csharp");
+                }
+                catch
+                {
+                    // Ignore any errors while trying to output crash information
+                }
+                await autoRest.Fatal($"Internal error in AutoRest.CSharp{ErrorHelpers.FileIssueText}\nException: {e.Message}\n{e.StackTrace}");
                 return false;
             }
 

--- a/src/AutoRest.CSharp/Common/Utilities/ErrorHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Utilities/ErrorHelpers.cs
@@ -6,7 +6,7 @@ namespace AutoRest.CSharp.Utilities
 {
     internal static class ErrorHelpers
     {
-        internal static string FileIssueText = "\n   Please file an issue at https://github.com/Azure/autorest.csharp/issues/new. \n   Attach the written 'Configuration-Crash.json' and 'CodeModel-Crash.yaml' or the original swagger so we can reproduce your error.\n";
+        internal static string FileIssueText = "\n   Please file an issue at https://github.com/Azure/autorest.csharp/issues/new. \n   Attach the written 'Configuration.json' and 'CodeModel.yaml' or the original swagger so we can reproduce your error.\n";
         internal static string UpdateSwaggerOrFile = "\n\nPlease review your swagger and make necessary corrections.\n\nIf the definition is correct file an issue at https://github.com/Azure/autorest.csharp/issues/new with details to reproduce.\n";
 
         // We wrap all 'reported' errors in a custom exception type so CSharpGen can recognize them as not internal errors and not show 'Internal error in AutoRest.CSharp'

--- a/src/AutoRest.CSharp/Common/Utilities/ErrorHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Utilities/ErrorHelpers.cs
@@ -6,7 +6,7 @@ namespace AutoRest.CSharp.Utilities
 {
     internal static class ErrorHelpers
     {
-        internal static string FileIssueText = "Please file an issue at https://github.com/Azure/autorest.csharp/issues/new with a swagger that reproduces the issue.";
+        internal static string FileIssueText = "\n   Please file an issue at https://github.com/Azure/autorest.csharp/issues/new. \n   Attach the written 'Configuration-Crash.json' and 'CodeModel-Crash.yaml' or the original swagger so we can reproduce your error.\n";
         internal static string UpdateSwaggerOrFile = "\n\nPlease review your swagger and make necessary corrections.\n\nIf the definition is correct file an issue at https://github.com/Azure/autorest.csharp/issues/new with details to reproduce.\n";
 
         // We wrap all 'reported' errors in a custom exception type so CSharpGen can recognize them as not internal errors and not show 'Internal error in AutoRest.CSharp'


### PR DESCRIPTION
- While crashing, writing out Configuration-Crash.json and
  CodeModel-Crash.yaml if possible, to make reproducing crashes a lot
  easier in some cases.
- No need to setup arbitrary swagger with configuration we if aren't
  crashing there.