### PR TITLE
[LLC] Add Documentaion for Input Scheama Shapes

### DIFF
--- a/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
+++ b/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClient.cs
@@ -71,6 +71,196 @@ namespace Azure.AI.DocumentTranslation
         /// 
         /// If a file with the same name already exists at the destination, it will be overwritten. The targetUrl for each target language must be unique.
         /// </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>inputs</term>
+        ///     <term>BatchRequest[]</term>
+        ///     <term>Yes</term>
+        ///     <term> The input list of documents or folders containing documents. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>BatchRequest</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>source</term>
+        ///     <term>SourceInput</term>
+        ///     <term>Yes</term>
+        ///     <term> Source of the input documents. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>targets</term>
+        ///     <term>TargetInput[]</term>
+        ///     <term>Yes</term>
+        ///     <term> Location of the destination for the output. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageType</term>
+        ///     <term>&quot;Folder&quot; | &quot;File&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage type of the input documents source string. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>SourceInput</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>sourceUrl</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Location of the folder / container or single file with your documents. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>filter</term>
+        ///     <term>DocumentFilter</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>language</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term>
+        /// Language code
+        /// 
+        /// If none is specified, we will perform auto detect on the document.
+        /// </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageSource</term>
+        ///     <term>&quot;AzureBlob&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage Source. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>DocumentFilter</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>prefix</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term>
+        /// A case-sensitive prefix string to filter documents in the source path for translation.
+        /// 
+        /// For example, when using a Azure storage blob Uri, use the prefix to restrict sub folders for translation.
+        /// </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>suffix</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term>
+        /// A case-sensitive suffix string to filter documents in the source path for translation.
+        /// 
+        /// This is most often use for file extensions.
+        /// </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>TargetInput</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>targetUrl</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Location of the folder / container with your documents. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>category</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Category / custom system for translation request. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>language</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Target Language. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>glossaries</term>
+        ///     <term>Glossary[]</term>
+        ///     <term></term>
+        ///     <term> List of Glossary. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageSource</term>
+        ///     <term>&quot;AzureBlob&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage Source. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Glossary</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>glossaryUrl</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term>
+        /// Location of the glossary.
+        /// 
+        /// We will use the file extension to extract the formatting if the format parameter is not supplied.
+        /// 
+        /// 
+        /// 
+        /// If the translation language pair is not present in the glossary, it will not be applied.
+        /// </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>format</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Format. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>version</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Optional Version.  If not specified, default is used. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageSource</term>
+        ///     <term>&quot;AzureBlob&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage Source. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> StartTranslationAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -98,6 +288,196 @@ namespace Azure.AI.DocumentTranslation
         /// 
         /// If a file with the same name already exists at the destination, it will be overwritten. The targetUrl for each target language must be unique.
         /// </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>inputs</term>
+        ///     <term>BatchRequest[]</term>
+        ///     <term>Yes</term>
+        ///     <term> The input list of documents or folders containing documents. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>BatchRequest</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>source</term>
+        ///     <term>SourceInput</term>
+        ///     <term>Yes</term>
+        ///     <term> Source of the input documents. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>targets</term>
+        ///     <term>TargetInput[]</term>
+        ///     <term>Yes</term>
+        ///     <term> Location of the destination for the output. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageType</term>
+        ///     <term>&quot;Folder&quot; | &quot;File&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage type of the input documents source string. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>SourceInput</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>sourceUrl</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Location of the folder / container or single file with your documents. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>filter</term>
+        ///     <term>DocumentFilter</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>language</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term>
+        /// Language code
+        /// 
+        /// If none is specified, we will perform auto detect on the document.
+        /// </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageSource</term>
+        ///     <term>&quot;AzureBlob&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage Source. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>DocumentFilter</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>prefix</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term>
+        /// A case-sensitive prefix string to filter documents in the source path for translation.
+        /// 
+        /// For example, when using a Azure storage blob Uri, use the prefix to restrict sub folders for translation.
+        /// </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>suffix</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term>
+        /// A case-sensitive suffix string to filter documents in the source path for translation.
+        /// 
+        /// This is most often use for file extensions.
+        /// </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>TargetInput</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>targetUrl</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Location of the folder / container with your documents. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>category</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Category / custom system for translation request. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>language</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Target Language. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>glossaries</term>
+        ///     <term>Glossary[]</term>
+        ///     <term></term>
+        ///     <term> List of Glossary. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageSource</term>
+        ///     <term>&quot;AzureBlob&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage Source. </term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Glossary</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>glossaryUrl</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term>
+        /// Location of the glossary.
+        /// 
+        /// We will use the file extension to extract the formatting if the format parameter is not supplied.
+        /// 
+        /// 
+        /// 
+        /// If the translation language pair is not present in the glossary, it will not be applied.
+        /// </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>format</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///     <term> Format. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>version</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Optional Version.  If not specified, default is used. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>storageSource</term>
+        ///     <term>&quot;AzureBlob&quot;</term>
+        ///     <term></term>
+        ///     <term> Storage Source. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response StartTranslation(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/src/AutoRest.CSharp/Common/Generation/Writers/DocumentationWriterExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/DocumentationWriterExtensions.cs
@@ -83,7 +83,7 @@ namespace AutoRest.CSharp.Generation.Writers
             return writer;
         }
 
-        private static CodeWriter WriteDocumentationLines(this CodeWriter writer, string prefix, string suffix, string? text, bool skipWhenEmpty = true)
+        public static CodeWriter WriteDocumentationLines(this CodeWriter writer, string prefix, string suffix, string? text, bool skipWhenEmpty = true)
         {
             if (string.IsNullOrEmpty(text))
             {

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelClientWriter.cs
@@ -53,13 +53,50 @@ namespace AutoRest.CSharp.Generation.Writers
             RequestWriterHelpers.WriteRequestCreation(writer, clientMethod, lowLevel: true, "private");
         }
 
-        private void WriteClientMethod(CodeWriter writer, RestClientMethod clientMethod, bool async)
+        private void WriteClientMethod(CodeWriter writer, LowLevelRestClientMethod clientMethod, bool async)
         {
             var parameters = clientMethod.Parameters;
 
             var responseType = async ? new CSharpType(typeof(Task<Response>)) : new CSharpType(typeof(Response));
 
             writer.WriteXmlDocumentationSummary(clientMethod.Description);
+
+            if (clientMethod.SchemaDocumentations != null)
+            {
+                writer.LineRaw("/// <remarks>");
+
+                foreach (var schemaDoc in clientMethod.SchemaDocumentations)
+                {
+                    writer.Line($"/// Schema for <c>{schemaDoc.SchemaName}</c>:");
+                    writer.LineRaw("/// <list type=\"table\">");
+                    writer.LineRaw("///   <listeader>");
+                    writer.LineRaw("///     <term>Name</term>");
+                    writer.LineRaw("///     <term>Type</term>");
+                    writer.LineRaw("///     <term>Required</term>");
+                    writer.LineRaw("///     <term>Description</term>");
+                    writer.LineRaw("///   </listeader>");
+                    foreach (var row in schemaDoc.DocumentationRows)
+                    {
+                        writer.LineRaw("///   <item>");
+                        writer.Line($"///     <term>{row.Name}</term>");
+                        writer.Line($"///     <term>{row.Type}</term>");
+                        writer.Line($"///     <term>{(row.Required ? "Yes" : "")}</term>");
+                        if (string.IsNullOrEmpty(row.Description))
+                        {
+                            writer.Line($"///    <term></term>");
+                        }
+                        else
+                        {
+                            writer.WriteDocumentationLines("    <term>", "</term>", row.Description);
+                        }
+                        writer.LineRaw("///   </item>");
+                    }
+                    writer.LineRaw("/// </list>");
+                }
+
+                writer.LineRaw("/// </remarks>");
+            }
+
             foreach (var parameter in parameters)
             {
                 writer.WriteXmlDocumentationParameter(parameter.Name, parameter.Description);

--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClient.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using AutoRest.CSharp.Common.Output.Builders;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
@@ -20,7 +21,7 @@ namespace AutoRest.CSharp.Output.Models
         private readonly BuildContext<LowLevelOutputLibrary> _context;
         private RestClientBuilder _builder;
 
-        private RestClientMethod[]? _allMethods;
+        private LowLevelRestClientMethod[]? _allMethods;
 
         protected override string DefaultAccessibility { get; } = "public";
 
@@ -37,13 +38,13 @@ namespace AutoRest.CSharp.Output.Models
 
         public Parameter[] Parameters { get; }
         public string Description => BuilderHelpers.EscapeXmlDescription(ClientBuilder.CreateDescription(_operationGroup, ClientBuilder.GetClientPrefix(Declaration.Name, _context)));
-        public RestClientMethod[] Methods => _allMethods ??= BuildAllMethods().ToArray();
+        public LowLevelRestClientMethod[] Methods => _allMethods ??= BuildAllMethods().ToArray();
         public string ClientPrefix { get; }
         protected override string DefaultName { get; }
 
-        private IEnumerable<RestClientMethod> BuildAllMethods()
+        private IEnumerable<LowLevelRestClientMethod> BuildAllMethods()
         {
-            var requestMethods = new Dictionary<ServiceRequest, RestClientMethod>();
+            var requestMethods = new Dictionary<ServiceRequest, LowLevelRestClientMethod>();
 
             foreach (var operation in _operationGroup.Operations)
             {
@@ -60,9 +61,12 @@ namespace AutoRest.CSharp.Output.Models
                     RestClientMethod method = _builder.BuildMethod(operation, (HttpRequest)serviceRequest.Protocol.Http!, requestParameters, null, accessibility);
                     List<Parameter> parameters = method.Parameters.ToList();
                     RequestBody? body = null;
+                    LowLevelRestClientMethod.SchemaDocumentation[]? schemaDocumentation = null;
 
                     if (serviceRequest.Parameters.Any(p => p.In == ParameterLocation.Body))
                     {
+                        RequestParameter bodyParameter = serviceRequest.Parameters.First(p => p.In == ParameterLocation.Body);
+
                         // The service request had some parameters for the body, so create a parameter for the body and inject it into the list of parameters,
                         // right before the first optional parameter.
                         Parameter bodyParam = new Parameter("requestBody", "The request body", typeof(Azure.Core.RequestContent), null, true);
@@ -73,11 +77,110 @@ namespace AutoRest.CSharp.Output.Models
                         }
                         parameters.Insert(firstOptionalParameterIndex, bodyParam);
                         body = new RequestContentRequestBody(bodyParam);
+                        schemaDocumentation = GetSchemaDocumentationsForParameter(bodyParameter);
                     }
 
                     Request request = new Request (method.Request.HttpMethod, method.Request.PathSegments, method.Request.Query, method.Request.Headers, body);
-                    yield return new RestClientMethod (method.Name, method.Description, method.ReturnType, request, parameters.ToArray(), method.Responses, method.HeaderModel, method.BufferResponse, method.Accessibility);
+                    yield return new LowLevelRestClientMethod (method.Name, method.Description, method.ReturnType, request, parameters.ToArray(), method.Responses, method.HeaderModel, method.BufferResponse, method.Accessibility, schemaDocumentation);
                 }
+            }
+        }
+
+        private LowLevelRestClientMethod.SchemaDocumentation[]? GetSchemaDocumentationsForParameter(RequestParameter parameter)
+        {
+            // Visit each schema in the graph and for object schemas, collect information about all the properties.
+            HashSet<string> visitedSchema = new HashSet<string>();
+            Queue<Schema> schemasToExplore = new Queue<Schema>(new Schema[] { parameter.Schema });
+            List<(string SchemaName, List<LowLevelRestClientMethod.SchemaDocumentation.DocumentationRow> Rows)> documentationObjects = new ();
+
+            while (schemasToExplore.Any())
+            {
+                Schema toExplore = schemasToExplore.Dequeue();
+
+                if (visitedSchema.Contains(toExplore.Name))
+                {
+                    continue;
+                }
+
+                switch (toExplore)
+                {
+                    case OrSchema o:
+                        foreach (Schema s in o.AnyOf)
+                        {
+                            schemasToExplore.Enqueue(s);
+                        }
+                        break;
+                    case DictionarySchema d:
+                        schemasToExplore.Enqueue(d.ElementType);
+                        break;
+                    case ArraySchema a:
+                        schemasToExplore.Enqueue(a.ElementType);
+                        break;
+                    case ObjectSchema o:
+                        List<LowLevelRestClientMethod.SchemaDocumentation.DocumentationRow> propertyDocumentation = new ();
+
+                        // We must also include any properties introduced by our parent chain.
+                        foreach (ObjectSchema s in (o.Parents?.All ?? Array.Empty<ComplexSchema>()).Concat(new ComplexSchema[] { o }).OfType<ObjectSchema>())
+                        {
+                            foreach (Property prop in s.Properties)
+                            {
+                                propertyDocumentation.Add(new LowLevelRestClientMethod.SchemaDocumentation.DocumentationRow(
+                                    prop.SerializedName,
+                                    BuilderHelpers.EscapeXmlDescription(StringifyTypeForTable(prop.Schema)),
+                                    prop.Required ?? false,
+                                    BuilderHelpers.EscapeXmlDescription(prop.Language.Default.Description)));
+
+                                schemasToExplore.Enqueue(prop.Schema);
+                            }
+                        }
+
+                        documentationObjects.Add(new (parameter.Schema == o ? "Request Body" : StringifyTypeForTable(o), propertyDocumentation));
+                        break;
+                }
+
+                visitedSchema.Add(toExplore.Name);
+            }
+
+            if (!documentationObjects.Any())
+            {
+                return null;
+            }
+
+            return documentationObjects.Select(o => new LowLevelRestClientMethod.SchemaDocumentation(o.SchemaName, o.Rows.ToArray())).ToArray();
+        }
+
+        private string StringifyTypeForTable(Schema s)
+        {
+            string RemovePrefix(string s, string prefix)
+            {
+                if (s.StartsWith(prefix))
+                {
+                    return s.Substring(prefix.Length);
+                }
+
+                return s;
+            }
+
+            switch (s)
+            {
+                case BooleanSchema:
+                    return "boolean";
+                case StringSchema:
+                    return "string";
+                case NumberSchema:
+                    return "number";
+                case AnySchema:
+                    return "object";
+                case DateTimeSchema:
+                    return "string (ISO 8601 Format)";
+                case ChoiceSchema c:
+                    return string.Join(" | ", c.Choices.Select(c => $"\"{c.Value}\""));
+                case DictionarySchema d:
+                    return $"Dictionary<string, {StringifyTypeForTable(d.ElementType)}>";
+                case ArraySchema a:
+                    return $"{StringifyTypeForTable(a.ElementType)}[]";
+                default:
+                    return $"{RemovePrefix(s.Name, "Json")}";
             }
         }
 

--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClientMethod.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClientMethod.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AutoRest.CSharp.Generation.Types;
+using AutoRest.CSharp.Output.Models.Requests;
+using AutoRest.CSharp.Output.Models.Responses;
+using AutoRest.CSharp.Output.Models.Shared;
+
+namespace AutoRest.CSharp.Output.Models
+{
+    internal class LowLevelRestClientMethod : RestClientMethod
+    {
+        internal class SchemaDocumentation
+        {
+            internal record DocumentationRow(string Name, string Type, bool Required, string Description) { }
+
+            public string SchemaName { get; }
+            public DocumentationRow[] DocumentationRows { get;  }
+
+            public SchemaDocumentation(string schemaName, DocumentationRow[] documentationRows)
+            {
+                SchemaName = schemaName;
+                DocumentationRows = documentationRows;
+            }
+        }
+
+        public SchemaDocumentation[]? SchemaDocumentations { get; }
+
+        public LowLevelRestClientMethod(string name, string? description, CSharpType? returnType, Request request, Parameter[] parameters, Response[] responses, DataPlaneResponseHeaderGroupType? headerModel, bool bufferResponse, string accessibility, SchemaDocumentation[]? schemaDocumentations) : base (name, description, returnType, request, parameters, responses, headerModel, bufferResponse, accessibility)
+        {
+            SchemaDocumentations = schemaDocumentations;
+        }
+    }
+}

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/ArrayClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/ArrayClient.cs
@@ -79,6 +79,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with array property. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>array</term>
+        ///     <term>string[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +105,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with array property. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>array</term>
+        ///     <term>string[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -144,6 +178,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with array property which is empty. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>array</term>
+        ///     <term>string[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutEmptyAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -153,6 +204,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with array property which is empty. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>array</term>
+        ///     <term>string[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutEmpty(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/BasicClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/BasicClient.cs
@@ -79,6 +79,35 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Please put {id: 2, name: &apos;abc&apos;, color: &apos;Magenta&apos;}. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///     <term> Basic Id. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>name</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Name property with a very long description that does not fit on a single line and a line break. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>color</term>
+        ///     <term>&quot;cyan&quot; | &quot;Magenta&quot; | &quot;YELLOW&quot; | &quot;blacK&quot;</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +117,35 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Please put {id: 2, name: &apos;abc&apos;, color: &apos;Magenta&apos;}. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///     <term> Basic Id. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>name</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Name property with a very long description that does not fit on a single line and a line break. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>color</term>
+        ///     <term>&quot;cyan&quot; | &quot;Magenta&quot; | &quot;YELLOW&quot; | &quot;blacK&quot;</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/DictionaryClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/DictionaryClient.cs
@@ -79,6 +79,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with dictionary property. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>defaultProgram</term>
+        ///     <term>Dictionary&lt;string, string&gt;</term>
+        ///     <term></term>
+        ///     <term> Dictionary of &lt;string&gt;. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +105,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with dictionary property. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>defaultProgram</term>
+        ///     <term>Dictionary&lt;string, string&gt;</term>
+        ///     <term></term>
+        ///     <term> Dictionary of &lt;string&gt;. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -144,6 +178,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with dictionary property which is empty. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>defaultProgram</term>
+        ///     <term>Dictionary&lt;string, string&gt;</term>
+        ///     <term></term>
+        ///     <term> Dictionary of &lt;string&gt;. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutEmptyAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -153,6 +204,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with dictionary property which is empty. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>defaultProgram</term>
+        ///     <term>Dictionary&lt;string, string&gt;</term>
+        ///     <term></term>
+        ///     <term> Dictionary of &lt;string&gt;. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutEmpty(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/InheritanceClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/InheritanceClient.cs
@@ -79,6 +79,74 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that extend others. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>color</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>hates</term>
+        ///     <term>Dog[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>name</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>breed</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Dog</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>name</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>food</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +156,74 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that extend others. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>color</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>hates</term>
+        ///     <term>Dog[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>name</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>breed</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Dog</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>name</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>food</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/PolymorphicrecursiveClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/PolymorphicrecursiveClient.cs
@@ -79,6 +79,41 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic and have recursive references. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +123,41 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic and have recursive references. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/PolymorphismClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/PolymorphismClient.cs
@@ -79,6 +79,41 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +123,41 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -234,6 +304,86 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>location</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>iswild</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Fish</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutComplicatedAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -243,6 +393,86 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>location</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>iswild</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Fish</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutComplicated(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -269,6 +499,86 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic, omitting the discriminator. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>location</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>iswild</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Fish</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutMissingDiscriminatorAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -278,6 +588,86 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic, omitting the discriminator. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>location</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>iswild</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// Schema for <c>Fish</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutMissingDiscriminator(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -304,6 +694,41 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic, attempting to omit required &apos;birthday&apos; field - the request should not be allowed from the client. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidMissingRequiredAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -313,6 +738,41 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that are polymorphic, attempting to omit required &apos;birthday&apos; field - the request should not be allowed from the client. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>fishtype</term>
+        ///     <term>string</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>species</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>length</term>
+        ///     <term>number</term>
+        ///     <term>Yes</term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>siblings</term>
+        ///     <term>Fish[]</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValidMissingRequired(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/PrimitiveClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/PrimitiveClient.cs
@@ -79,6 +79,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with integer properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field2</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutIntAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +111,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with integer properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field2</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutInt(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -144,6 +190,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with long properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field2</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutLongAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -153,6 +222,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with long properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field2</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutLong(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -209,6 +301,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with float properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field2</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutFloatAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -218,6 +333,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with float properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field2</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutFloat(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -274,6 +412,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with double properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutDoubleAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -283,6 +444,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with double properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutDouble(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -339,6 +523,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with bool properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field_true</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field_false</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutBoolAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -348,6 +555,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with bool properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field_true</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field_false</term>
+        ///     <term>boolean</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutBool(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -404,6 +634,35 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with string properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>empty</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>null</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutStringAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -413,6 +672,35 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with string properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>empty</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>null</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutString(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -469,6 +757,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with date properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>DateWrapperField</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>leap</term>
+        ///     <term>DateWrapperLeap</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutDateAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -478,6 +789,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with date properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>DateWrapperField</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>leap</term>
+        ///     <term>DateWrapperLeap</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutDate(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -534,6 +868,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with datetime properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>now</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutDateTimeAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -543,6 +900,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with datetime properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>now</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutDateTime(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -599,6 +979,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with datetimeRfc1123 properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>now</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutDateTimeRfc1123Async(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -608,6 +1011,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with datetimeRfc1123 properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>now</term>
+        ///     <term>string (ISO 8601 Format)</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutDateTimeRfc1123(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -664,6 +1090,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with duration properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>DurationWrapperField</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutDurationAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -673,6 +1116,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with duration properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>DurationWrapperField</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutDuration(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -729,6 +1189,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with byte properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>ByteWrapperField</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutByteAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -738,6 +1215,23 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types with byte properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>field</term>
+        ///     <term>ByteWrapperField</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutByte(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/ReadonlypropertyClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/ReadonlypropertyClient.cs
@@ -79,6 +79,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that have readonly properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>size</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutValidAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -88,6 +111,29 @@ namespace body_complex_LowLevel
         }
 
         /// <summary> Put complex types that have readonly properties. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>id</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        ///   <item>
+        ///     <term>size</term>
+        ///     <term>number</term>
+        ///     <term></term>
+        ///    <term></term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutValid(RequestContent requestBody, CancellationToken cancellationToken = default)

--- a/test/TestServerProjectsLowLevel/body-string/Generated/EnumClient.cs
+++ b/test/TestServerProjectsLowLevel/body-string/Generated/EnumClient.cs
@@ -209,6 +209,29 @@ namespace body_string_LowLevel
         }
 
         /// <summary> Sends value &apos;green-color&apos; from a constant. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>ColorConstant</term>
+        ///     <term>ColorConstant</term>
+        ///     <term>Yes</term>
+        ///     <term> Referenced Color Constant Description. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Sample string. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response> PutReferencedConstantAsync(RequestContent requestBody, CancellationToken cancellationToken = default)
@@ -218,6 +241,29 @@ namespace body_string_LowLevel
         }
 
         /// <summary> Sends value &apos;green-color&apos; from a constant. </summary>
+        /// <remarks>
+        /// Schema for <c>Request Body</c>:
+        /// <list type="table">
+        ///   <listeader>
+        ///     <term>Name</term>
+        ///     <term>Type</term>
+        ///     <term>Required</term>
+        ///     <term>Description</term>
+        ///   </listeader>
+        ///   <item>
+        ///     <term>ColorConstant</term>
+        ///     <term>ColorConstant</term>
+        ///     <term>Yes</term>
+        ///     <term> Referenced Color Constant Description. </term>
+        ///   </item>
+        ///   <item>
+        ///     <term>field1</term>
+        ///     <term>string</term>
+        ///     <term></term>
+        ///     <term> Sample string. </term>
+        ///   </item>
+        /// </list>
+        /// </remarks>
         /// <param name="requestBody"> The request body. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response PutReferencedConstant(RequestContent requestBody, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This change adds logic to include a table in the `<remarks>` section
of a method documentation with information about about the input shape
of the method and gives information about the properties every object
has, if they are required or not, their types, and a description.
