### PR TITLE
Add System.Text.Json support to Utf8JsonWriterExtensions

### DIFF
--- a/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
+++ b/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
@@ -65,6 +65,9 @@ namespace Azure.Core
                 case BinaryData bytes:
                     writer.WriteBase64StringValue(bytes);
                     break;
+                case System.Text.Json.JsonElement json:
+                    json.WriteTo(writer);
+                    break;
                 case int i:
                     writer.WriteNumberValue(i);
                     break;

--- a/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
+++ b/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Core.Tests
             new object[] { new Guid ("c6125705-61d7-4cd6-8d6c-f7f247a7a5fa"), @"""c6125705-61d7-4cd6-8d6c-f7f247a7a5fa""" },
             new object[] { new BinaryData (new byte[] { 1, 2, 3, 4}), @"""AQIDBA==""" },
             new object[] { new DateTimeOffset (2001, 1, 1, 1, 1, 1, 1, new TimeSpan ()), @"""2001-01-01T01:01:01.0010000Z""" },
-            new object[] { new DateTime (2001, 1, 1), @"""2001-01-01T00:00:00.0000000-06:00""" },
+            //new object[] { new DateTime (2001, 1, 1), @"""2001-01-01T00:00:00.0000000-06:00""" }, https://github.com/Azure/autorest.csharp/issues/1205
             new object[] { (IEnumerable<object>)new List<object>() { 1, 2, 3, 4 }, "[1,2,3,4]" },
             new object[] { (IEnumerable<KeyValuePair<string, object>>)new List<KeyValuePair<string, object>>() {
                 KeyValuePair.Create<string, object> ("a", (object)1),

--- a/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
+++ b/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class WriterExtensionTests
+    {
+        private static object[] ObjectCases =
+        {
+            new object[] { null },
+            new object[] { new byte[] { 1, 2, 3, 4} },
+            new object[] { 42 },
+            new object[] { 42.0m, },
+            new object[] { 42.0d },
+            new object[] { 42.0f },
+            new object[] { 42L },
+            new object[] { "asdf" },
+            new object[] { false },
+            new object[] { Guid.NewGuid() },
+            new object[] { new BinaryData (new byte[] { 1, 2, 3, 4}) },
+            new object[] { new DateTimeOffset (2001, 1, 1, 1, 1, 1, 1, new TimeSpan ()) },
+            new object[] { DateTime.Now },
+            new object[] { (IEnumerable<object>)new List<object>() { 1, 2, 3, 4 } },
+            new object[] { (IEnumerable<KeyValuePair<string, object>>)new List<KeyValuePair<string, object>>() {
+                KeyValuePair.Create<string, object> ("a", (object)1),
+                KeyValuePair.Create<string, object> ("b", (object)2),
+                KeyValuePair.Create<string, object> ("c", (object)3),
+                KeyValuePair.Create<string, object> ("d", (object)4),
+            }},
+        };
+
+        [Test, TestCaseSource("ObjectCases")]
+        public static void WriteObjectValue (object value)
+        {
+            using MemoryStream stream = new MemoryStream ();
+            using Utf8JsonWriter writer = new Utf8JsonWriter (stream);
+            writer.WriteObjectValue (value);
+        }
+
+        [Test]
+        public static void WriteObjectValueJsonElement ()
+        {
+            using MemoryStream stream = new MemoryStream ();
+            using Utf8JsonWriter writer = new Utf8JsonWriter (stream);
+
+            string json = @"{""TablesToMove"": [{""TableName"":""TestTable""}]}";
+            Dictionary<string, object> content = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+            JsonElement element = (JsonElement)content["TablesToMove"];
+            writer.WriteObjectValue (element);
+        }
+
+        [Test]
+        public static void WriteObjectValueIUtf8JsonSerializable ()
+        {
+            using MemoryStream stream = new MemoryStream ();
+            using Utf8JsonWriter writer = new Utf8JsonWriter (stream);
+
+            var content = new TestSerialize ();
+            writer.WriteObjectValue (content);
+            Assert.True (content.didWrite);
+        }
+
+        internal class TestSerialize : IUtf8JsonSerializable
+        {
+            internal bool didWrite = false;
+
+            public void Write(Utf8JsonWriter writer)
+            {
+                didWrite = true;
+            }
+        }
+    }
+}

--- a/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
+++ b/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
@@ -13,34 +13,39 @@ namespace Azure.Core.Tests
     {
         private static object[] ObjectCases =
         {
-            new object[] { null },
-            new object[] { new byte[] { 1, 2, 3, 4} },
-            new object[] { 42 },
-            new object[] { 42.0m, },
-            new object[] { 42.0d },
-            new object[] { 42.0f },
-            new object[] { 42L },
-            new object[] { "asdf" },
-            new object[] { false },
-            new object[] { Guid.NewGuid() },
-            new object[] { new BinaryData (new byte[] { 1, 2, 3, 4}) },
-            new object[] { new DateTimeOffset (2001, 1, 1, 1, 1, 1, 1, new TimeSpan ()) },
-            new object[] { DateTime.Now },
-            new object[] { (IEnumerable<object>)new List<object>() { 1, 2, 3, 4 } },
+            new object[] { null, "null" },
+            new object[] { new byte[] { 1, 2, 3, 4}, @"""AQIDBA==""" },
+            new object[] { 42, "42" },
+            new object[] { 42.0m, "42.0" },
+            new object[] { 42.0d, "42" },
+            new object[] { 42.0f, "42" },
+            new object[] { 42L, "42" },
+            new object[] { "asdf", @"""asdf""" },
+            new object[] { false, "false" },
+            new object[] { new Guid ("c6125705-61d7-4cd6-8d6c-f7f247a7a5fa"), @"""c6125705-61d7-4cd6-8d6c-f7f247a7a5fa""" },
+            new object[] { new BinaryData (new byte[] { 1, 2, 3, 4}), @"""AQIDBA==""" },
+            new object[] { new DateTimeOffset (2001, 1, 1, 1, 1, 1, 1, new TimeSpan ()), @"""2001-01-01T01:01:01.0010000Z""" },
+            new object[] { new DateTime (2001, 1, 1), @"""2001-01-01T00:00:00.0000000-06:00""" },
+            new object[] { (IEnumerable<object>)new List<object>() { 1, 2, 3, 4 }, "[1,2,3,4]" },
             new object[] { (IEnumerable<KeyValuePair<string, object>>)new List<KeyValuePair<string, object>>() {
                 KeyValuePair.Create<string, object> ("a", (object)1),
                 KeyValuePair.Create<string, object> ("b", (object)2),
                 KeyValuePair.Create<string, object> ("c", (object)3),
                 KeyValuePair.Create<string, object> ("d", (object)4),
-            }},
+            },
+            @"{""a"":1,""b"":2,""c"":3,""d"":4}"
+            },
         };
 
         [Test, TestCaseSource("ObjectCases")]
-        public static void WriteObjectValue (object value)
+        public static void WriteObjectValue (object value, string expectedJson)
         {
             using MemoryStream stream = new MemoryStream ();
             using Utf8JsonWriter writer = new Utf8JsonWriter (stream);
             writer.WriteObjectValue (value);
+
+            writer.Flush ();
+            Assert.AreEqual (expectedJson, System.Text.Encoding.UTF8.GetString(stream.ToArray()));
         }
 
         [Test]
@@ -53,6 +58,9 @@ namespace Azure.Core.Tests
             Dictionary<string, object> content = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
             JsonElement element = (JsonElement)content["TablesToMove"];
             writer.WriteObjectValue (element);
+            writer.Flush ();
+
+            Assert.AreEqual (@"[{""TableName"":""TestTable""}]", System.Text.Encoding.UTF8.GetString(stream.ToArray()));
         }
 
         [Test]


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-sdk-for-net/issues/20051

This fails today:

```
            string parameterAsJson = @"{""TablesToMove"": [{""TableName"":""TestTable""}]}";
            Dictionary<string, object> parameters = ReadParametersFromJson(parameterAsJson);
            CreateRunResponse runResponse = await pipelineClient.CreatePipelineRunAsync(pipeline.Name, parameters: parameters);
```

As the Dictionary<string, object> gets a JsonElement for the subtree, and we don't know how to write those out. 

Adding support to Utf8JsonWriterExtensions  seemed straightforward enough, let me know if you have any concerns. 