### PR TITLE
Fix ConfigureAwait issue in Generator.Shared code

### DIFF
--- a/src/assets/Generator.Shared/OperationInternals.cs
+++ b/src/assets/Generator.Shared/OperationInternals.cs
@@ -122,7 +122,7 @@ namespace Azure.Core
                     case 201 when _requestMethod == RequestMethod.Put:
                     case 204 when !(_requestMethod == RequestMethod.Put || _requestMethod == RequestMethod.Patch):
                         {
-                            await SetValueAsync(async, finalResponse, cancellationToken);
+                            await SetValueAsync(async, finalResponse, cancellationToken).ConfigureAwait(false);
                             _rawResponse = finalResponse;
                             break;
                         }


### PR DESCRIPTION
packages\microsoft.azure.autorest.csharp\3.0.0-beta.20210503.1\content\Generator.Shared\OperationInternals.cs(125,29):
	error AZC0100: ConfigureAwait(false) must be used.

Only shows up when compiling in azure-sdk-for-net
