### PR TITLE
Bump autorest core / m4 for hotifx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1055,7 +1055,7 @@ input-file: "swagger-document"
 
 ```yaml
 # autorest-core version
-version: 3.4.0
+version: 3.4.1
 save-inputs: true
 use: $(this-folder)/artifacts/bin/AutoRest.CSharp/Debug/netcoreapp3.1/
 clear-output-folder: true

--- a/src/AutoRest.CSharp/readme.md
+++ b/src/AutoRest.CSharp/readme.md
@@ -4,7 +4,7 @@
 ## Configuration
 ```yaml
 use-extension:
-  "@autorest/modelerfour": "4.19.0"
+  "@autorest/modelerfour": "4.19.1"
 modelerfour:
   always-create-content-type-parameter: true
   flatten-models: true


### PR DESCRIPTION
Pick up https://github.com/Azure/autorest/pull/4110 hotfix.

# autorest.csharp bump checklist
- [x] Bump autorest [Example](https://github.com/Azure/autorest.csharp/commit/6182984d59642e47ee12cb6b2bf54d4a9a0386c8)
   - [ ] package.json (autorest)
   - [x] readme.md (autorest.core)
   - [x] src/AutoRest.CSharp/readme.md (M4)
- [x] npm install
- [x] Regenerate CodeModel
   - [x] `cd .\src\AutoRest.CodeModel`
   - [x] `dotnet run`
- [x] `git commit` the bump files
- [x] `.\eng\Generate.ps1 -reset`
- [x] `git commit` any generated/yaml changes
- [x] `dotnet test`
- [x] Kick off bump PR in autorest.csharp
- [x] `dotnet pack`
- [x] Copy nuget to local feed

# azure-sdk-for-net
- [x] eng/Packages.Data.props
   - [x]  Update in `<PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="VERSION" PrivateAssets="All" />` 
   - [x] `dotnet restore eng/service.proj -s LOCAL_NUGET_DIR`
   - [ ] `dotnet build eng/service.proj /t:GenerateCode`
   - [ ] `dotnet build eng/service.proj`

# Landing
- [ ] Land autorest.csharp PR
- [ ] Wait for auto PR for azure-sdk-for-net and land after review
- [ ] Next day double check non-CI builds