### PR TITLE
[Mgmt LRO] wrap result type of PATCH LRO

### DIFF
--- a/samples/Azure.Management.Storage/Generated/BlobContainersUpdateOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobContainersUpdateOperation.cs
@@ -11,29 +11,30 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Management.Storage.Models;
+using Azure.ResourceManager.Core;
 
 namespace Azure.Management.Storage
 {
     /// <summary> Updates container properties as specified in request body. Properties not mentioned in the request will be unchanged. Update fails if the specified container doesn&apos;t already exist. </summary>
-    public partial class BlobContainersUpdateOperation : Operation<BlobContainerData>
+    public partial class BlobContainersUpdateOperation : Operation<BlobContainer>
     {
-        private readonly OperationOrResponseInternals<BlobContainerData> _operation;
+        private readonly OperationOrResponseInternals<BlobContainer> _operation;
 
         /// <summary> Initializes a new instance of BlobContainersUpdateOperation for mocking. </summary>
         protected BlobContainersUpdateOperation()
         {
         }
 
-        internal BlobContainersUpdateOperation(Response<BlobContainerData> response)
+        internal BlobContainersUpdateOperation(ResourceOperationsBase operationsBase, Response<BlobContainerData> response)
         {
-            _operation = new OperationOrResponseInternals<BlobContainerData>(response);
+            _operation = new OperationOrResponseInternals<BlobContainer>(Response.FromValue(new BlobContainer(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override BlobContainerData Value => _operation.Value;
+        public override BlobContainer Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -51,9 +52,9 @@ namespace Azure.Management.Storage
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<BlobContainerData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<BlobContainer>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<BlobContainerData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<BlobContainer>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.Management.Storage/Generated/EncryptionScopesPatchOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/EncryptionScopesPatchOperation.cs
@@ -11,29 +11,30 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Management.Storage.Models;
+using Azure.ResourceManager.Core;
 
 namespace Azure.Management.Storage
 {
     /// <summary> Update encryption scope properties as specified in the request body. Update fails if the specified encryption scope does not already exist. </summary>
-    public partial class EncryptionScopesPatchOperation : Operation<EncryptionScopeData>
+    public partial class EncryptionScopesPatchOperation : Operation<EncryptionScope>
     {
-        private readonly OperationOrResponseInternals<EncryptionScopeData> _operation;
+        private readonly OperationOrResponseInternals<EncryptionScope> _operation;
 
         /// <summary> Initializes a new instance of EncryptionScopesPatchOperation for mocking. </summary>
         protected EncryptionScopesPatchOperation()
         {
         }
 
-        internal EncryptionScopesPatchOperation(Response<EncryptionScopeData> response)
+        internal EncryptionScopesPatchOperation(ResourceOperationsBase operationsBase, Response<EncryptionScopeData> response)
         {
-            _operation = new OperationOrResponseInternals<EncryptionScopeData>(response);
+            _operation = new OperationOrResponseInternals<EncryptionScope>(Response.FromValue(new EncryptionScope(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override EncryptionScopeData Value => _operation.Value;
+        public override EncryptionScope Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -51,9 +52,9 @@ namespace Azure.Management.Storage
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<EncryptionScopeData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<EncryptionScope>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<EncryptionScopeData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<EncryptionScope>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.Management.Storage/Generated/FileSharesUpdateOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/FileSharesUpdateOperation.cs
@@ -11,29 +11,30 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Management.Storage.Models;
+using Azure.ResourceManager.Core;
 
 namespace Azure.Management.Storage
 {
     /// <summary> Updates share properties as specified in request body. Properties not mentioned in the request will not be changed. Update fails if the specified share does not already exist. </summary>
-    public partial class FileSharesUpdateOperation : Operation<FileShareData>
+    public partial class FileSharesUpdateOperation : Operation<FileShare>
     {
-        private readonly OperationOrResponseInternals<FileShareData> _operation;
+        private readonly OperationOrResponseInternals<FileShare> _operation;
 
         /// <summary> Initializes a new instance of FileSharesUpdateOperation for mocking. </summary>
         protected FileSharesUpdateOperation()
         {
         }
 
-        internal FileSharesUpdateOperation(Response<FileShareData> response)
+        internal FileSharesUpdateOperation(ResourceOperationsBase operationsBase, Response<FileShareData> response)
         {
-            _operation = new OperationOrResponseInternals<FileShareData>(response);
+            _operation = new OperationOrResponseInternals<FileShare>(Response.FromValue(new FileShare(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override FileShareData Value => _operation.Value;
+        public override FileShare Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -51,9 +52,9 @@ namespace Azure.Management.Storage
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<FileShareData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<FileShare>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<FileShareData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<FileShare>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.Management.Storage/Generated/StorageAccountsUpdateOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccountsUpdateOperation.cs
@@ -11,29 +11,30 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Management.Storage.Models;
+using Azure.ResourceManager.Core;
 
 namespace Azure.Management.Storage
 {
     /// <summary> The update operation can be used to update the SKU, encryption, access tier, or tags for a storage account. It can also be used to map the account to a custom domain. Only one custom domain is supported per storage account; the replacement/change of custom domain is not supported. In order to replace an old custom domain, the old value must be cleared/unregistered before a new value can be set. The update of multiple properties is supported. This call does not change the storage keys for the account. If you want to change the storage account keys, use the regenerate keys operation. The location and name of the storage account cannot be changed after creation. </summary>
-    public partial class StorageAccountsUpdateOperation : Operation<StorageAccountData>
+    public partial class StorageAccountsUpdateOperation : Operation<StorageAccount>
     {
-        private readonly OperationOrResponseInternals<StorageAccountData> _operation;
+        private readonly OperationOrResponseInternals<StorageAccount> _operation;
 
         /// <summary> Initializes a new instance of StorageAccountsUpdateOperation for mocking. </summary>
         protected StorageAccountsUpdateOperation()
         {
         }
 
-        internal StorageAccountsUpdateOperation(Response<StorageAccountData> response)
+        internal StorageAccountsUpdateOperation(ResourceOperationsBase operationsBase, Response<StorageAccountData> response)
         {
-            _operation = new OperationOrResponseInternals<StorageAccountData>(response);
+            _operation = new OperationOrResponseInternals<StorageAccount>(Response.FromValue(new StorageAccount(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override StorageAccountData Value => _operation.Value;
+        public override StorageAccount Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -51,9 +52,9 @@ namespace Azure.Management.Storage
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<StorageAccountData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<StorageAccount>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<StorageAccountData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<StorageAccount>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetsUpdateOperation.cs
@@ -10,29 +10,30 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Update an availability set. </summary>
-    public partial class AvailabilitySetsUpdateOperation : Operation<AvailabilitySetData>
+    public partial class AvailabilitySetsUpdateOperation : Operation<AvailabilitySet>
     {
-        private readonly OperationOrResponseInternals<AvailabilitySetData> _operation;
+        private readonly OperationOrResponseInternals<AvailabilitySet> _operation;
 
         /// <summary> Initializes a new instance of AvailabilitySetsUpdateOperation for mocking. </summary>
         protected AvailabilitySetsUpdateOperation()
         {
         }
 
-        internal AvailabilitySetsUpdateOperation(Response<AvailabilitySetData> response)
+        internal AvailabilitySetsUpdateOperation(ResourceOperationsBase operationsBase, Response<AvailabilitySetData> response)
         {
-            _operation = new OperationOrResponseInternals<AvailabilitySetData>(response);
+            _operation = new OperationOrResponseInternals<AvailabilitySet>(Response.FromValue(new AvailabilitySet(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override AvailabilitySetData Value => _operation.Value;
+        public override AvailabilitySet Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -50,9 +51,9 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<AvailabilitySetData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<AvailabilitySet>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<AvailabilitySetData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<AvailabilitySet>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupsUpdateOperation.cs
@@ -10,29 +10,30 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Update an dedicated host group. </summary>
-    public partial class DedicatedHostGroupsUpdateOperation : Operation<DedicatedHostGroupData>
+    public partial class DedicatedHostGroupsUpdateOperation : Operation<DedicatedHostGroup>
     {
-        private readonly OperationOrResponseInternals<DedicatedHostGroupData> _operation;
+        private readonly OperationOrResponseInternals<DedicatedHostGroup> _operation;
 
         /// <summary> Initializes a new instance of DedicatedHostGroupsUpdateOperation for mocking. </summary>
         protected DedicatedHostGroupsUpdateOperation()
         {
         }
 
-        internal DedicatedHostGroupsUpdateOperation(Response<DedicatedHostGroupData> response)
+        internal DedicatedHostGroupsUpdateOperation(ResourceOperationsBase operationsBase, Response<DedicatedHostGroupData> response)
         {
-            _operation = new OperationOrResponseInternals<DedicatedHostGroupData>(response);
+            _operation = new OperationOrResponseInternals<DedicatedHostGroup>(Response.FromValue(new DedicatedHostGroup(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override DedicatedHostGroupData Value => _operation.Value;
+        public override DedicatedHostGroup Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -50,9 +51,9 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<DedicatedHostGroupData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<DedicatedHostGroup>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<DedicatedHostGroupData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<DedicatedHostGroup>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Update an dedicated host . </summary>
-    public partial class DedicatedHostsUpdateOperation : Operation<DedicatedHostData>, IOperationSource<DedicatedHostData>
+    public partial class DedicatedHostsUpdateOperation : Operation<DedicatedHost>, IOperationSource<DedicatedHost>
     {
-        private readonly OperationInternals<DedicatedHostData> _operation;
+        private readonly OperationInternals<DedicatedHost> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of DedicatedHostsUpdateOperation for mocking. </summary>
         protected DedicatedHostsUpdateOperation()
         {
         }
 
-        internal DedicatedHostsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal DedicatedHostsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<DedicatedHostData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "DedicatedHostsUpdateOperation");
+            _operation = new OperationInternals<DedicatedHost>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "DedicatedHostsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override DedicatedHostData Value => _operation.Value;
+        public override DedicatedHost Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<DedicatedHostData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<DedicatedHost>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<DedicatedHostData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<DedicatedHost>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        DedicatedHostData IOperationSource<DedicatedHostData>.CreateResult(Response response, CancellationToken cancellationToken)
+        DedicatedHost IOperationSource<DedicatedHost>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+            return new DedicatedHost(_operationBase, DedicatedHostData.DeserializeDedicatedHostData(document.RootElement));
         }
 
-        async ValueTask<DedicatedHostData> IOperationSource<DedicatedHostData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<DedicatedHost> IOperationSource<DedicatedHost>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+            return new DedicatedHost(_operationBase, DedicatedHostData.DeserializeDedicatedHostData(document.RootElement));
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/ImagesUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImagesUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Update an image. </summary>
-    public partial class ImagesUpdateOperation : Operation<ImageData>, IOperationSource<ImageData>
+    public partial class ImagesUpdateOperation : Operation<Image>, IOperationSource<Image>
     {
-        private readonly OperationInternals<ImageData> _operation;
+        private readonly OperationInternals<Image> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of ImagesUpdateOperation for mocking. </summary>
         protected ImagesUpdateOperation()
         {
         }
 
-        internal ImagesUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal ImagesUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<ImageData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ImagesUpdateOperation");
+            _operation = new OperationInternals<Image>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ImagesUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override ImageData Value => _operation.Value;
+        public override Image Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<ImageData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<Image>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<ImageData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<Image>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        ImageData IOperationSource<ImageData>.CreateResult(Response response, CancellationToken cancellationToken)
+        Image IOperationSource<Image>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return ImageData.DeserializeImageData(document.RootElement);
+            return new Image(_operationBase, ImageData.DeserializeImageData(document.RootElement));
         }
 
-        async ValueTask<ImageData> IOperationSource<ImageData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<Image> IOperationSource<Image>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return ImageData.DeserializeImageData(document.RootElement);
+            return new Image(_operationBase, ImageData.DeserializeImageData(document.RootElement));
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupsUpdateOperation.cs
@@ -10,29 +10,30 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Update a proximity placement group. </summary>
-    public partial class ProximityPlacementGroupsUpdateOperation : Operation<ProximityPlacementGroupData>
+    public partial class ProximityPlacementGroupsUpdateOperation : Operation<ProximityPlacementGroup>
     {
-        private readonly OperationOrResponseInternals<ProximityPlacementGroupData> _operation;
+        private readonly OperationOrResponseInternals<ProximityPlacementGroup> _operation;
 
         /// <summary> Initializes a new instance of ProximityPlacementGroupsUpdateOperation for mocking. </summary>
         protected ProximityPlacementGroupsUpdateOperation()
         {
         }
 
-        internal ProximityPlacementGroupsUpdateOperation(Response<ProximityPlacementGroupData> response)
+        internal ProximityPlacementGroupsUpdateOperation(ResourceOperationsBase operationsBase, Response<ProximityPlacementGroupData> response)
         {
-            _operation = new OperationOrResponseInternals<ProximityPlacementGroupData>(response);
+            _operation = new OperationOrResponseInternals<ProximityPlacementGroup>(Response.FromValue(new ProximityPlacementGroup(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override ProximityPlacementGroupData Value => _operation.Value;
+        public override ProximityPlacementGroup Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -50,9 +51,9 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<ProximityPlacementGroupData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<ProximityPlacementGroup>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<ProximityPlacementGroupData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<ProximityPlacementGroup>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeysUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeysUpdateOperation.cs
@@ -10,29 +10,30 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Updates a new SSH public key resource. </summary>
-    public partial class SshPublicKeysUpdateOperation : Operation<SshPublicKeyData>
+    public partial class SshPublicKeysUpdateOperation : Operation<SshPublicKey>
     {
-        private readonly OperationOrResponseInternals<SshPublicKeyData> _operation;
+        private readonly OperationOrResponseInternals<SshPublicKey> _operation;
 
         /// <summary> Initializes a new instance of SshPublicKeysUpdateOperation for mocking. </summary>
         protected SshPublicKeysUpdateOperation()
         {
         }
 
-        internal SshPublicKeysUpdateOperation(Response<SshPublicKeyData> response)
+        internal SshPublicKeysUpdateOperation(ResourceOperationsBase operationsBase, Response<SshPublicKeyData> response)
         {
-            _operation = new OperationOrResponseInternals<SshPublicKeyData>(response);
+            _operation = new OperationOrResponseInternals<SshPublicKey>(Response.FromValue(new SshPublicKey(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override SshPublicKeyData Value => _operation.Value;
+        public override SshPublicKey Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -50,9 +51,9 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<SshPublicKeyData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<SshPublicKey>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<SshPublicKeyData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<SshPublicKey>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> The operation to update the extension. </summary>
-    public partial class VirtualMachineExtensionsUpdateOperation : Operation<VirtualMachineExtensionData>, IOperationSource<VirtualMachineExtensionData>
+    public partial class VirtualMachineExtensionsUpdateOperation : Operation<VirtualMachineExtension>, IOperationSource<VirtualMachineExtension>
     {
-        private readonly OperationInternals<VirtualMachineExtensionData> _operation;
+        private readonly OperationInternals<VirtualMachineExtension> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of VirtualMachineExtensionsUpdateOperation for mocking. </summary>
         protected VirtualMachineExtensionsUpdateOperation()
         {
         }
 
-        internal VirtualMachineExtensionsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal VirtualMachineExtensionsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<VirtualMachineExtensionData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineExtensionsUpdateOperation");
+            _operation = new OperationInternals<VirtualMachineExtension>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineExtensionsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override VirtualMachineExtensionData Value => _operation.Value;
+        public override VirtualMachineExtension Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineExtensionData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<VirtualMachineExtension>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineExtensionData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<VirtualMachineExtension>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        VirtualMachineExtensionData IOperationSource<VirtualMachineExtensionData>.CreateResult(Response response, CancellationToken cancellationToken)
+        VirtualMachineExtension IOperationSource<VirtualMachineExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+            return new VirtualMachineExtension(_operationBase, VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement));
         }
 
-        async ValueTask<VirtualMachineExtensionData> IOperationSource<VirtualMachineExtensionData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<VirtualMachineExtension> IOperationSource<VirtualMachineExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+            return new VirtualMachineExtension(_operationBase, VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement));
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> The operation to update an extension. </summary>
-    public partial class VirtualMachineScaleSetExtensionsUpdateOperation : Operation<VirtualMachineScaleSetExtensionData>, IOperationSource<VirtualMachineScaleSetExtensionData>
+    public partial class VirtualMachineScaleSetExtensionsUpdateOperation : Operation<VirtualMachineScaleSetExtension>, IOperationSource<VirtualMachineScaleSetExtension>
     {
-        private readonly OperationInternals<VirtualMachineScaleSetExtensionData> _operation;
+        private readonly OperationInternals<VirtualMachineScaleSetExtension> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of VirtualMachineScaleSetExtensionsUpdateOperation for mocking. </summary>
         protected VirtualMachineScaleSetExtensionsUpdateOperation()
         {
         }
 
-        internal VirtualMachineScaleSetExtensionsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal VirtualMachineScaleSetExtensionsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<VirtualMachineScaleSetExtensionData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineScaleSetExtensionsUpdateOperation");
+            _operation = new OperationInternals<VirtualMachineScaleSetExtension>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineScaleSetExtensionsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override VirtualMachineScaleSetExtensionData Value => _operation.Value;
+        public override VirtualMachineScaleSetExtension Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineScaleSetExtensionData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<VirtualMachineScaleSetExtension>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineScaleSetExtensionData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<VirtualMachineScaleSetExtension>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        VirtualMachineScaleSetExtensionData IOperationSource<VirtualMachineScaleSetExtensionData>.CreateResult(Response response, CancellationToken cancellationToken)
+        VirtualMachineScaleSetExtension IOperationSource<VirtualMachineScaleSetExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
+            return new VirtualMachineScaleSetExtension(_operationBase, VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement));
         }
 
-        async ValueTask<VirtualMachineScaleSetExtensionData> IOperationSource<VirtualMachineScaleSetExtensionData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<VirtualMachineScaleSetExtension> IOperationSource<VirtualMachineScaleSetExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
+            return new VirtualMachineScaleSetExtension(_operationBase, VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement));
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMExtensionsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMExtensionsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> The operation to update the VMSS VM extension. </summary>
-    public partial class VirtualMachineScaleSetVMExtensionsUpdateOperation : Operation<VirtualMachineExtensionData>, IOperationSource<VirtualMachineExtensionData>
+    public partial class VirtualMachineScaleSetVMExtensionsUpdateOperation : Operation<VirtualMachineExtension>, IOperationSource<VirtualMachineExtension>
     {
-        private readonly OperationInternals<VirtualMachineExtensionData> _operation;
+        private readonly OperationInternals<VirtualMachineExtension> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of VirtualMachineScaleSetVMExtensionsUpdateOperation for mocking. </summary>
         protected VirtualMachineScaleSetVMExtensionsUpdateOperation()
         {
         }
 
-        internal VirtualMachineScaleSetVMExtensionsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal VirtualMachineScaleSetVMExtensionsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<VirtualMachineExtensionData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineScaleSetVMExtensionsUpdateOperation");
+            _operation = new OperationInternals<VirtualMachineExtension>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineScaleSetVMExtensionsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override VirtualMachineExtensionData Value => _operation.Value;
+        public override VirtualMachineExtension Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineExtensionData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<VirtualMachineExtension>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineExtensionData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<VirtualMachineExtension>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        VirtualMachineExtensionData IOperationSource<VirtualMachineExtensionData>.CreateResult(Response response, CancellationToken cancellationToken)
+        VirtualMachineExtension IOperationSource<VirtualMachineExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+            return new VirtualMachineExtension(_operationBase, VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement));
         }
 
-        async ValueTask<VirtualMachineExtensionData> IOperationSource<VirtualMachineExtensionData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<VirtualMachineExtension> IOperationSource<VirtualMachineExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+            return new VirtualMachineExtension(_operationBase, VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement));
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetsUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> Update a VM scale set. </summary>
-    public partial class VirtualMachineScaleSetsUpdateOperation : Operation<VirtualMachineScaleSetData>, IOperationSource<VirtualMachineScaleSetData>
+    public partial class VirtualMachineScaleSetsUpdateOperation : Operation<VirtualMachineScaleSet>, IOperationSource<VirtualMachineScaleSet>
     {
-        private readonly OperationInternals<VirtualMachineScaleSetData> _operation;
+        private readonly OperationInternals<VirtualMachineScaleSet> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of VirtualMachineScaleSetsUpdateOperation for mocking. </summary>
         protected VirtualMachineScaleSetsUpdateOperation()
         {
         }
 
-        internal VirtualMachineScaleSetsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal VirtualMachineScaleSetsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<VirtualMachineScaleSetData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineScaleSetsUpdateOperation");
+            _operation = new OperationInternals<VirtualMachineScaleSet>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachineScaleSetsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override VirtualMachineScaleSetData Value => _operation.Value;
+        public override VirtualMachineScaleSet Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineScaleSetData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<VirtualMachineScaleSet>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineScaleSetData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<VirtualMachineScaleSet>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        VirtualMachineScaleSetData IOperationSource<VirtualMachineScaleSetData>.CreateResult(Response response, CancellationToken cancellationToken)
+        VirtualMachineScaleSet IOperationSource<VirtualMachineScaleSet>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+            return new VirtualMachineScaleSet(_operationBase, VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement));
         }
 
-        async ValueTask<VirtualMachineScaleSetData> IOperationSource<VirtualMachineScaleSetData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<VirtualMachineScaleSet> IOperationSource<VirtualMachineScaleSet>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+            return new VirtualMachineScaleSet(_operationBase, VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement));
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachinesUpdateOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachinesUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
 {
     /// <summary> The operation to update a virtual machine. </summary>
-    public partial class VirtualMachinesUpdateOperation : Operation<VirtualMachineData>, IOperationSource<VirtualMachineData>
+    public partial class VirtualMachinesUpdateOperation : Operation<VirtualMachine>, IOperationSource<VirtualMachine>
     {
-        private readonly OperationInternals<VirtualMachineData> _operation;
+        private readonly OperationInternals<VirtualMachine> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of VirtualMachinesUpdateOperation for mocking. </summary>
         protected VirtualMachinesUpdateOperation()
         {
         }
 
-        internal VirtualMachinesUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal VirtualMachinesUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<VirtualMachineData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachinesUpdateOperation");
+            _operation = new OperationInternals<VirtualMachine>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "VirtualMachinesUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override VirtualMachineData Value => _operation.Value;
+        public override VirtualMachine Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace Azure.ResourceManager.Sample
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<VirtualMachine>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<VirtualMachineData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<VirtualMachine>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        VirtualMachineData IOperationSource<VirtualMachineData>.CreateResult(Response response, CancellationToken cancellationToken)
+        VirtualMachine IOperationSource<VirtualMachine>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+            return new VirtualMachine(_operationBase, VirtualMachineData.DeserializeVirtualMachineData(document.RootElement));
         }
 
-        async ValueTask<VirtualMachineData> IOperationSource<VirtualMachineData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<VirtualMachine> IOperationSource<VirtualMachine>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+            return new VirtualMachine(_operationBase, VirtualMachineData.DeserializeVirtualMachineData(document.RootElement));
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationHelper.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationHelper.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Linq;
+using AutoRest.CSharp.Common.Output.Models;
+using AutoRest.CSharp.Generation.Types;
+using AutoRest.CSharp.Input;
+using AutoRest.CSharp.Mgmt.AutoRest;
+using AutoRest.CSharp.Output.Builders;
+using AutoRest.CSharp.Output.Models.Types;
+
+namespace AutoRest.CSharp.Mgmt.Decorator
+{
+    internal static class LongRunningOperationHelper
+    {
+        /// <summary>
+        /// Decides if we want to wrap the LRO result type with a [Resource] type.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="operationGroup"></param>
+        /// <param name="operation"></param>
+        /// <param name="resultType">Result type of the LRO.</param>
+        /// <returns></returns>
+        public static bool ShouldWrapResultType(BuildContext<MgmtOutputLibrary> context, OperationGroup operationGroup, Input.Operation operation, CSharpType? resultType)
+        {
+            if (resultType != null
+                && operation.Requests.FirstOrDefault().Protocol.Http is HttpRequest httpRequest
+                && (httpRequest.Method == HttpMethod.Put || httpRequest.Method == HttpMethod.Patch))
+            {
+                // need to check result type is [Resource]Data because
+                // some PUT operation returns differently and we don't want to wrap that with [Resource]
+                var resourceDataType = context.Library.GetResourceData(operationGroup).Type;
+                if (resultType.Name.Equals(resourceDataType.Name))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtLongRunningOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtLongRunningOperation.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Linq;
 using AutoRest.CSharp.Common.Output.Models;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
+using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Output.Models.Requests;
 using AutoRest.CSharp.Output.Models.Types;
 
@@ -18,9 +18,7 @@ namespace AutoRest.CSharp.Mgmt.Output
     {
         public MgmtLongRunningOperation(OperationGroup operationGroup, Input.Operation operation, BuildContext<MgmtOutputLibrary> context, LongRunningOperationInfo lroInfo) : base(operationGroup, operation, context, lroInfo)
         {
-            if (ResultType != null
-                && operation.Requests.FirstOrDefault().Protocol.Http is HttpRequest httpRequest
-                && httpRequest.Method == HttpMethod.Put)
+            if (LongRunningOperationHelper.ShouldWrapResultType(context, operationGroup, operation, ResultType))
             {
                 WrapperType = context.Library.GetArmResource(operationGroup).Type;
             }

--- a/src/AutoRest.CSharp/Mgmt/Output/NonLongRunningOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/NonLongRunningOperation.cs
@@ -7,6 +7,7 @@ using AutoRest.CSharp.Common.Output.Models;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
+using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Output.Builders;
 using AutoRest.CSharp.Output.Models.Types;
 
@@ -30,7 +31,7 @@ namespace AutoRest.CSharp.Mgmt.Output
                 ResultType = TypeFactory.GetOutputType(context.TypeFactory.CreateType(responseSchema, false));
             }
 
-            if (ShouldWrapResultType(context, operationGroup, operation))
+            if (LongRunningOperationHelper.ShouldWrapResultType(context, operationGroup, operation, ResultType))
             {
                 ResultType = context.Library.GetArmResource(operationGroup).Type;
                 ResultDataType = context.Library.GetResourceData(operationGroup).Type;
@@ -59,22 +60,6 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         protected override string DefaultAccessibility { get; }
 
-        private bool ShouldWrapResultType(BuildContext<MgmtOutputLibrary> context, OperationGroup operationGroup, Input.Operation operation)
-        {
-            if (ResultType != null
-                && operation.Requests.FirstOrDefault().Protocol.Http is HttpRequest httpRequest
-                && httpRequest.Method == HttpMethod.Put)
-            {
-                // need to check result type is [Resource]Data because
-                // some PUT operation returns differently and we don't want to wrap that with [Resource]
-                var resourceDataType = context.Library.GetResourceData(operationGroup).Type;
-                if (ResultType.Name.Equals(resourceDataType.Name))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
         private ServiceResponse GetOperationResponse(Input.Operation operation)
         {
             foreach (var operationResponse in operation.Responses)

--- a/test/TestProjects/MgmtParent/Generated/AvailabilitySetsUpdateOperation.cs
+++ b/test/TestProjects/MgmtParent/Generated/AvailabilitySetsUpdateOperation.cs
@@ -10,29 +10,30 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
+using Azure.ResourceManager.Core;
 
 namespace MgmtParent
 {
     /// <summary> Update an availability set. </summary>
-    public partial class AvailabilitySetsUpdateOperation : Operation<AvailabilitySetData>
+    public partial class AvailabilitySetsUpdateOperation : Operation<AvailabilitySet>
     {
-        private readonly OperationOrResponseInternals<AvailabilitySetData> _operation;
+        private readonly OperationOrResponseInternals<AvailabilitySet> _operation;
 
         /// <summary> Initializes a new instance of AvailabilitySetsUpdateOperation for mocking. </summary>
         protected AvailabilitySetsUpdateOperation()
         {
         }
 
-        internal AvailabilitySetsUpdateOperation(Response<AvailabilitySetData> response)
+        internal AvailabilitySetsUpdateOperation(ResourceOperationsBase operationsBase, Response<AvailabilitySetData> response)
         {
-            _operation = new OperationOrResponseInternals<AvailabilitySetData>(response);
+            _operation = new OperationOrResponseInternals<AvailabilitySet>(Response.FromValue(new AvailabilitySet(operationsBase, response.Value), response.GetRawResponse()));
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override AvailabilitySetData Value => _operation.Value;
+        public override AvailabilitySet Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -50,9 +51,9 @@ namespace MgmtParent
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<AvailabilitySetData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<AvailabilitySet>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<AvailabilitySetData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<AvailabilitySet>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
     }
 }

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostsUpdateOperation.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace MgmtParent
 {
     /// <summary> Update an dedicated host . </summary>
-    public partial class DedicatedHostsUpdateOperation : Operation<DedicatedHostData>, IOperationSource<DedicatedHostData>
+    public partial class DedicatedHostsUpdateOperation : Operation<DedicatedHost>, IOperationSource<DedicatedHost>
     {
-        private readonly OperationInternals<DedicatedHostData> _operation;
+        private readonly OperationInternals<DedicatedHost> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of DedicatedHostsUpdateOperation for mocking. </summary>
         protected DedicatedHostsUpdateOperation()
         {
         }
 
-        internal DedicatedHostsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal DedicatedHostsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<DedicatedHostData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "DedicatedHostsUpdateOperation");
+            _operation = new OperationInternals<DedicatedHost>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "DedicatedHostsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override DedicatedHostData Value => _operation.Value;
+        public override DedicatedHost Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace MgmtParent
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<DedicatedHostData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<DedicatedHost>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<DedicatedHostData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<DedicatedHost>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        DedicatedHostData IOperationSource<DedicatedHostData>.CreateResult(Response response, CancellationToken cancellationToken)
+        DedicatedHost IOperationSource<DedicatedHost>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+            return new DedicatedHost(_operationBase, DedicatedHostData.DeserializeDedicatedHostData(document.RootElement));
         }
 
-        async ValueTask<DedicatedHostData> IOperationSource<DedicatedHostData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<DedicatedHost> IOperationSource<DedicatedHost>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+            return new DedicatedHost(_operationBase, DedicatedHostData.DeserializeDedicatedHostData(document.RootElement));
         }
     }
 }

--- a/test/TestProjects/TenantOnly/Generated/BillingAccountsUpdateOperation.cs
+++ b/test/TestProjects/TenantOnly/Generated/BillingAccountsUpdateOperation.cs
@@ -12,29 +12,33 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.ResourceManager.Core;
 
 namespace TenantOnly
 {
     /// <summary> Updates the properties of a billing account. Currently, displayName and address can be updated. The operation is supported only for billing accounts with agreement type Microsoft Customer Agreement. </summary>
-    public partial class BillingAccountsUpdateOperation : Operation<BillingAccountData>, IOperationSource<BillingAccountData>
+    public partial class BillingAccountsUpdateOperation : Operation<BillingAccount>, IOperationSource<BillingAccount>
     {
-        private readonly OperationInternals<BillingAccountData> _operation;
+        private readonly OperationInternals<BillingAccount> _operation;
+
+        private readonly ResourceOperationsBase _operationBase;
 
         /// <summary> Initializes a new instance of BillingAccountsUpdateOperation for mocking. </summary>
         protected BillingAccountsUpdateOperation()
         {
         }
 
-        internal BillingAccountsUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
+        internal BillingAccountsUpdateOperation(ResourceOperationsBase operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<BillingAccountData>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "BillingAccountsUpdateOperation");
+            _operation = new OperationInternals<BillingAccount>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "BillingAccountsUpdateOperation");
+            _operationBase = operationsBase;
         }
 
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
         /// <inheritdoc />
-        public override BillingAccountData Value => _operation.Value;
+        public override BillingAccount Value => _operation.Value;
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
@@ -52,21 +56,21 @@ namespace TenantOnly
         public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) => _operation.UpdateStatusAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<BillingAccountData>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
+        public override ValueTask<Response<BillingAccount>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc />
-        public override ValueTask<Response<BillingAccountData>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override ValueTask<Response<BillingAccount>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) => _operation.WaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        BillingAccountData IOperationSource<BillingAccountData>.CreateResult(Response response, CancellationToken cancellationToken)
+        BillingAccount IOperationSource<BillingAccount>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream);
-            return BillingAccountData.DeserializeBillingAccountData(document.RootElement);
+            return new BillingAccount(_operationBase, BillingAccountData.DeserializeBillingAccountData(document.RootElement));
         }
 
-        async ValueTask<BillingAccountData> IOperationSource<BillingAccountData>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<BillingAccount> IOperationSource<BillingAccount>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return BillingAccountData.DeserializeBillingAccountData(document.RootElement);
+            return new BillingAccount(_operationBase, BillingAccountData.DeserializeBillingAccountData(document.RootElement));
         }
     }
 }


### PR DESCRIPTION
# Description
When generating management plane LROs and non-LROs, we tend to wrap the result type **only** when it's a PUT request.
But that's just not enough, we want to do it for PATCH as well.

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first