### PR TITLE
Fix null ref issue in ResourceContainerWriter

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Decorator/TypeExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/TypeExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+
+using AutoRest.CSharp.Output.Models.Types;
+
+namespace AutoRest.CSharp.Mgmt.Decorator
+{
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// Is the type a string or an Enum that is modeled as string.
+        /// </summary>
+        /// <param name="type">Type to check.</param>
+        /// <returns>Is the type a string or an Enum that is modeled as string.</returns>
+        public static bool IsStringLike(this CSharp.Generation.Types.CSharpType type)
+        {
+            if (type.IsFrameworkType)
+            {
+                return type.Equals(typeof(string));
+            }
+            else
+            {
+                return type.Implementation is EnumType enumType && enumType.BaseType.Equals(typeof(string));
+            };
+        }
+    }
+}

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceContainerWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceContainerWriter.cs
@@ -403,7 +403,14 @@ namespace AutoRest.CSharp.Mgmt.Generation
         /// <returns>Is the input type string or an Enum that is modeled as string.</returns>
         private bool IsStringLike(CSharp.Generation.Types.CSharpType type)
         {
-            return type.Equals(typeof(string)) || type.Implementation is EnumType enumType && enumType.BaseType.Equals(typeof(string));
+            if (type.IsFrameworkType)
+            {
+                return type.Equals(typeof(string));
+            }
+            else
+            {
+                return type.Implementation is EnumType enumType && enumType.BaseType.Equals(typeof(string));
+            };
         }
 
         private void WriteContainerProperties()

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceContainerWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceContainerWriter.cs
@@ -16,10 +16,10 @@ using Azure.ResourceManager.Core;
 using Azure.Core.Pipeline;
 using System.Threading.Tasks;
 using AutoRest.CSharp.Common.Generation.Writers;
-using AutoRest.CSharp.Output.Models.Types;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Mgmt.AutoRest;
 using System.Diagnostics;
+using AutoRest.CSharp.Mgmt.Decorator;
 
 namespace AutoRest.CSharp.Mgmt.Generation
 {
@@ -322,7 +322,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 {
                     continue;
                 }
-                else if (IsStringLike(parameter.Type) && IsMandatory(parameter))
+                else if (parameter.Type.IsStringLike() && IsMandatory(parameter))
                 {
                     passThru = false;
                     if (string.Equals(parameter.Name, "resourceGroupName", StringComparison.InvariantCultureIgnoreCase))
@@ -348,7 +348,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
             // 2. ignoring optional parameters such as `expand`
             if (!method.Name.StartsWith("List", StringComparison.InvariantCultureIgnoreCase))
             {
-                var lastString = parameterMapping.LastOrDefault(parameter => IsStringLike(parameter.Parameter.Type) && IsMandatory(parameter.Parameter));
+                var lastString = parameterMapping.LastOrDefault(parameter => parameter.Parameter.Type.IsStringLike() && IsMandatory(parameter.Parameter));
                 if (lastString?.Parameter != null && !lastString.Parameter.Name.Equals("resourceGroupName", StringComparison.InvariantCultureIgnoreCase))
                 {
                     lastString.IsPassThru = true;
@@ -396,23 +396,6 @@ namespace AutoRest.CSharp.Mgmt.Generation
             }
         }
 
-        /// <summary>
-        /// Is the input type string or an Enum that is modeled as string.
-        /// </summary>
-        /// <param name="type">Type to check.</param>
-        /// <returns>Is the input type string or an Enum that is modeled as string.</returns>
-        private bool IsStringLike(CSharp.Generation.Types.CSharpType type)
-        {
-            if (type.IsFrameworkType)
-            {
-                return type.Equals(typeof(string));
-            }
-            else
-            {
-                return type.Implementation is EnumType enumType && enumType.BaseType.Equals(typeof(string));
-            };
-        }
-
         private void WriteContainerProperties()
         {
             var resourceType = _resourceContainer.GetValidResourceValue();
@@ -441,7 +424,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
             IEnumerable<Parameter> passThruParameters = parameterMapping.Where(p => p.IsPassThru).Select(parameter =>
             {
-                if (IsStringLike(parameter.Parameter.Type))
+                if (parameter.Parameter.Type.IsStringLike())
                 {
                     // for string-like parameters, we shall write them as string as base class
                     return new Parameter(


### PR DESCRIPTION
# Description
Fixed a null reference issue when detecting if a CSharpType is a string or enum which is modeled as string.
I also changed in into a extension of `CSharpType` for cleanness.

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first