### PR TITLE
Use correct header for CodeGenSuppressTypeAttribute.cs

### DIFF
--- a/src/assets/Generator.Shared/CodeGenSuppressTypeAttribute.cs
+++ b/src/assets/Generator.Shared/CodeGenSuppressTypeAttribute.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT License.
+
+#nullable enable
 
 using System;
 


### PR DESCRIPTION
Lack of nullable enable broken azure-sdk-for-net build