### PR TITLE
Fix index out of range in GetProviderSegments

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
@@ -84,6 +84,10 @@ namespace AutoRest.CSharp.Mgmt.Decorator
 
         private static ProviderSegment? GetFullProvider(List<ProviderSegment> providerSegments)
         {
+            if (providerSegments.Count == 0)
+            {
+                return null;
+            }
             return providerSegments.Last().IsFullProvider ? providerSegments.Last() : null;
         }
 

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ProviderSegmentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ProviderSegmentDetection.cs
@@ -32,6 +32,10 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                 return new List<ProviderSegment>();
             }
             var offset = path.IndexOf(ProviderSegment.Providers);
+            if (offset == -1)
+            {
+                return new List<ProviderSegment>();
+            }
             ProviderSegment currentToken;
             var tokens = new List<ProviderSegment>();
             int pathLen = path.Length;

--- a/test/AutoRest.TestServer.Tests/Mgmt/ProviderSegmentDetectionTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/ProviderSegmentDetectionTests.cs
@@ -68,5 +68,13 @@ namespace AutoRest.TestServer.Tests.Mgmt
             Assert.AreEqual(string.Empty, segments[1].TokenValue);
             Assert.IsFalse(segments[1].IsFullProvider);
         }
+
+        [Test]
+        public void ValidateNoProvider()
+        {
+            string path = "/{linkId}";
+            var segments = ProviderSegmentDetection.GetProviderSegments(path);
+            Assert.AreEqual(0, segments.Count);
+        }
     }
 }


### PR DESCRIPTION
# Description

Resolve ADO Item [5885](https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_workitems/edit/5885).

With paths do not contain `/providers/`, `GetProviderSegments` method may cause index out of range error, such as ["/{linkId}"](https://github.com/Azure/azure-rest-api-specs/blob/b02a0b6106cccf5479b832268f32687b128615c3/specification/resources/resource-manager/Microsoft.Resources/stable/2016-09-01/links.json#L62).
This PR adds a check on `offset` of `/providers` in path and returns an empty list if it is `-1`.

This PR also adds a check on whether the `providerSegments` list is empty to avoid `InvalidOperationException` in `List.Last()` method.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first