### PR TITLE
Remove AdditionalProperties dictionary interface 

### DIFF
--- a/samples/CognitiveSearch/Generated/Models/FacetResult.cs
+++ b/samples/CognitiveSearch/Generated/Models/FacetResult.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace CognitiveSearch.Models
 {
     /// <summary> A single bucket of a facet query result. Reports the number of documents with a field value falling within a particular range or having a particular value or interval. </summary>
-    public partial class FacetResult : IReadOnlyDictionary<string, object>
+    public partial class FacetResult
     {
         /// <summary> Initializes a new instance of FacetResult. </summary>
         internal FacetResult()
@@ -31,25 +30,6 @@ namespace CognitiveSearch.Models
 
         /// <summary> The approximate count of documents falling within the bucket described by this facet. </summary>
         public long? Count { get; }
-        internal IReadOnlyDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public IEnumerable<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
-        int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-        }
+        public IReadOnlyDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/samples/CognitiveSearch/Generated/Models/IndexAction.cs
+++ b/samples/CognitiveSearch/Generated/Models/IndexAction.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace CognitiveSearch.Models
 {
     /// <summary> Represents an index action that operates on a document. </summary>
-    public partial class IndexAction : IDictionary<string, object>
+    public partial class IndexAction
     {
         /// <summary> Initializes a new instance of IndexAction. </summary>
         public IndexAction()
@@ -22,42 +21,6 @@ namespace CognitiveSearch.Models
 
         /// <summary> The operation to perform on a document in an indexing batch. </summary>
         public IndexActionType? ActionType { get; set; }
-        internal IDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, object value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/samples/CognitiveSearch/Generated/Models/SearchResult.cs
+++ b/samples/CognitiveSearch/Generated/Models/SearchResult.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace CognitiveSearch.Models
 {
     /// <summary> Contains a document found by a search query, plus associated metadata. </summary>
-    public partial class SearchResult : IReadOnlyDictionary<string, object>
+    public partial class SearchResult
     {
         /// <summary> Initializes a new instance of SearchResult. </summary>
         /// <param name="score"> The relevance score of the document compared to other documents returned by the query. </param>
@@ -38,25 +37,6 @@ namespace CognitiveSearch.Models
         public double Score { get; }
         /// <summary> Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query. </summary>
         public IReadOnlyDictionary<string, IList<string>> Highlights { get; }
-        internal IReadOnlyDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public IEnumerable<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
-        int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-        }
+        public IReadOnlyDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/samples/CognitiveSearch/Generated/Models/SuggestResult.cs
+++ b/samples/CognitiveSearch/Generated/Models/SuggestResult.cs
@@ -6,14 +6,13 @@
 #nullable disable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace CognitiveSearch.Models
 {
     /// <summary> A result containing a document found by a suggestion query, plus associated metadata. </summary>
-    public partial class SuggestResult : IReadOnlyDictionary<string, object>
+    public partial class SuggestResult
     {
         /// <summary> Initializes a new instance of SuggestResult. </summary>
         /// <param name="text"> The text of the suggestion result. </param>
@@ -40,25 +39,6 @@ namespace CognitiveSearch.Models
 
         /// <summary> The text of the suggestion result. </summary>
         public string Text { get; }
-        internal IReadOnlyDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public IEnumerable<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public IEnumerable<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
-        int IReadOnlyCollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-        }
+        public IReadOnlyDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -75,6 +75,9 @@ namespace AutoRest.CSharp.Output.Models.Types
                     return _additionalPropertiesProperty;
                 }
 
+                // We use a $ prefix here as AdditionalProperties comes from a swagger concept
+                // and not a swagger model/operation name to disambiguate from a possible property with
+                // the same name.
                 SourceMemberMapping? memberMapping = _sourceTypeMapping?.GetForMember("$AdditionalProperties");
 
                 _additionalPropertiesProperty = new ObjectTypeProperty(

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -78,7 +78,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                 SourceMemberMapping? memberMapping = _sourceTypeMapping?.GetForMember("$AdditionalProperties");
 
                 _additionalPropertiesProperty = new ObjectTypeProperty(
-                    BuilderHelpers.CreateMemberDeclaration("AdditionalProperties", ImplementsDictionaryType, "internal", memberMapping?.ExistingMember, _typeFactory),
+                    BuilderHelpers.CreateMemberDeclaration("AdditionalProperties", ImplementsDictionaryType, "public", memberMapping?.ExistingMember, _typeFactory),
                     string.Empty,
                     true,
                     null

--- a/test/AutoRest.TestServer.Tests/AdditionalPropertiesExTest.cs
+++ b/test/AutoRest.TestServer.Tests/AdditionalPropertiesExTest.cs
@@ -15,34 +15,6 @@ namespace AutoRest.TestServer.Tests
 {
     public class AdditionalPropertiesExTest
     {
-        [Theory]
-        [TestCase(typeof(InputAdditionalPropertiesModel))]
-        [TestCase(typeof(InputAdditionalPropertiesModelStruct))]
-        public void InputModelsImplementIDictionary(Type type)
-        {
-            var iface = type
-                .GetInterfaces()
-                .SingleOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
-
-            Assert.NotNull(iface);
-            Assert.AreEqual(typeof(string), iface.GenericTypeArguments[0]);
-            Assert.AreEqual(typeof(object), iface.GenericTypeArguments[1]);
-        }
-
-        [Theory]
-        [TestCase(typeof(OutputAdditionalPropertiesModel))]
-        [TestCase(typeof(OutputAdditionalPropertiesModelStruct))]
-        public void OutputModelsImplementIReadOnlyDictionary(Type type)
-        {
-            var iface = type
-                .GetInterfaces()
-                .SingleOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
-
-            Assert.NotNull(iface);
-            Assert.AreEqual(typeof(string), iface.GenericTypeArguments[0]);
-            Assert.AreEqual(typeof(string), iface.GenericTypeArguments[1]);
-        }
-
         [Test]
         public void CanCreateStructWithAdditionalProperties()
         {
@@ -53,8 +25,8 @@ namespace AutoRest.TestServer.Tests
             });
 
             Assert.AreEqual(123, s.Id);
-            Assert.AreEqual("b", s["a"]);
-            Assert.AreEqual(2, s["c"]);
+            Assert.AreEqual("b", s.AdditionalProperties["a"]);
+            Assert.AreEqual(2, s.AdditionalProperties["c"]);
         }
     }
 }

--- a/test/AutoRest.TestServer.Tests/additionalProperties.cs
+++ b/test/AutoRest.TestServer.Tests/additionalProperties.cs
@@ -51,9 +51,9 @@ namespace AutoRest.TestServer.Tests
                 },
             };
 
-            parameter["color"] = "red";
-            parameter["city"] = "Seattle";
-            parameter["food"] = "tikka masala";
+            parameter.MoreAdditionalProperties["color"] = "red";
+            parameter.MoreAdditionalProperties["city"] = "Seattle";
+            parameter.MoreAdditionalProperties["food"] = "tikka masala";
 
             var response = await new PetsClient(ClientDiagnostics, pipeline, host).CreateAPInPropertiesWithAPStringAsync(parameter);
 
@@ -65,9 +65,9 @@ namespace AutoRest.TestServer.Tests
             Assert.AreEqual(599f, value.AdditionalProperties["weight"]);
             Assert.AreEqual(11.5f, value.AdditionalProperties["footsize"]);
 
-            Assert.AreEqual("red", value["color"]);
-            Assert.AreEqual("Seattle", value["city"]);
-            Assert.AreEqual("tikka masala", value["food"]);
+            Assert.AreEqual("red", value.MoreAdditionalProperties["color"]);
+            Assert.AreEqual("Seattle", value.MoreAdditionalProperties["city"]);
+            Assert.AreEqual("tikka masala", value.MoreAdditionalProperties["food"]);
         });
 
         [Test]
@@ -79,8 +79,8 @@ namespace AutoRest.TestServer.Tests
                 Friendly = true,
             };
 
-            catAPTrue["birthdate"] = DateTimeOffset.Parse("2017-12-13T02:29:51Z");
-            catAPTrue["complexProperty"] = new Dictionary<string, object>()
+            catAPTrue.AdditionalProperties["birthdate"] = DateTimeOffset.Parse("2017-12-13T02:29:51Z");
+            catAPTrue.AdditionalProperties["complexProperty"] = new Dictionary<string, object>()
             {
                 {"color", "Red"}
             };
@@ -92,8 +92,8 @@ namespace AutoRest.TestServer.Tests
             Assert.AreEqual("Lisa", value.Name);
             Assert.AreEqual(true, value.Status);
             Assert.AreEqual(true, value.Friendly);
-            Assert.AreEqual("2017-12-13T02:29:51Z", value["birthdate"]);
-            Assert.AreEqual("Red", ((Dictionary<string, object>)value["complexProperty"])["color"]);
+            Assert.AreEqual("2017-12-13T02:29:51Z", value.AdditionalProperties["birthdate"]);
+            Assert.AreEqual("Red", ((Dictionary<string, object>)value.AdditionalProperties["complexProperty"])["color"]);
         });
 
         [Test]
@@ -104,8 +104,8 @@ namespace AutoRest.TestServer.Tests
                 Name = "Puppy",
             };
 
-            catAPTrue["birthdate"] = DateTimeOffset.Parse("2017-12-13T02:29:51Z");
-            catAPTrue["complexProperty"] = new Dictionary<string, object>()
+            catAPTrue.AdditionalProperties["birthdate"] = DateTimeOffset.Parse("2017-12-13T02:29:51Z");
+            catAPTrue.AdditionalProperties["complexProperty"] = new Dictionary<string, object>()
             {
                 {"color", "Red"}
             };
@@ -116,8 +116,8 @@ namespace AutoRest.TestServer.Tests
             Assert.AreEqual(1, value.Id);
             Assert.AreEqual("Puppy", value.Name);
             Assert.AreEqual(true, value.Status);
-            Assert.AreEqual("2017-12-13T02:29:51Z", value["birthdate"]);
-            Assert.AreEqual("Red", ((Dictionary<string, object>)value["complexProperty"])["color"]);
+            Assert.AreEqual("2017-12-13T02:29:51Z", value.AdditionalProperties["birthdate"]);
+            Assert.AreEqual("Red", ((Dictionary<string, object>)value.AdditionalProperties["complexProperty"])["color"]);
         });
 
         [Test]
@@ -128,8 +128,8 @@ namespace AutoRest.TestServer.Tests
                 Name = "Puppy",
             };
 
-            petAPObject["birthdate"] = DateTimeOffset.Parse("2017-12-13T02:29:51Z");
-            petAPObject["complexProperty"] = new Dictionary<string, object>()
+            petAPObject.AdditionalProperties["birthdate"] = DateTimeOffset.Parse("2017-12-13T02:29:51Z");
+            petAPObject.AdditionalProperties["complexProperty"] = new Dictionary<string, object>()
             {
                 {"color", "Red"}
             };
@@ -138,11 +138,11 @@ namespace AutoRest.TestServer.Tests
             {
                 Name = "Hira"
             };
-            outerAPObject["siblings"] = new object[]
+            outerAPObject.AdditionalProperties["siblings"] = new object[]
             {
                 petAPObject
             };
-            outerAPObject["picture"] = new byte[] { 255, 255, 255, 255, 254 };
+            outerAPObject.AdditionalProperties["picture"] = new byte[] { 255, 255, 255, 255, 254 };
 
             var response = await new PetsClient(ClientDiagnostics, pipeline, host).CreateAPObjectAsync(outerAPObject);
 
@@ -152,7 +152,7 @@ namespace AutoRest.TestServer.Tests
             Assert.AreEqual("Hira", value.Name);
             Assert.AreEqual(true, value.Status);
 
-            var siblings = (IEnumerable<object>)value["siblings"];
+            var siblings = (IEnumerable<object>)value.AdditionalProperties["siblings"];
             var sibling = (IDictionary<string, object>)siblings.Single();
 
             Assert.AreEqual(1, sibling["id"]);
@@ -169,18 +169,18 @@ namespace AutoRest.TestServer.Tests
                 Name = "Tommy"
             };
 
-            petAPObject["weight"] = "10 kg";
-            petAPObject["color"] = "red";
-            petAPObject["city"] = "Bombay";
+            petAPObject.AdditionalProperties["weight"] = "10 kg";
+            petAPObject.AdditionalProperties["color"] = "red";
+            petAPObject.AdditionalProperties["city"] = "Bombay";
 
             var response = await new PetsClient(ClientDiagnostics, pipeline, host).CreateAPStringAsync(petAPObject);
             var value = response.Value;
             Assert.AreEqual(3, value.Id);
             Assert.AreEqual("Tommy", value.Name);
             Assert.AreEqual(true, value.Status);
-            Assert.AreEqual("red", value["color"]);
-            Assert.AreEqual("10 kg", value["weight"]);
-            Assert.AreEqual("Bombay", value["city"]);
+            Assert.AreEqual("red", value.AdditionalProperties["color"]);
+            Assert.AreEqual("10 kg", value.AdditionalProperties["weight"]);
+            Assert.AreEqual("Bombay", value.AdditionalProperties["city"]);
         });
 
         [Test]

--- a/test/AutoRest.TestServer.Tests/body-complex.cs
+++ b/test/AutoRest.TestServer.Tests/body-complex.cs
@@ -607,16 +607,16 @@ namespace AutoRest.TestServer.Tests
             Assert.AreEqual(5, goblin.Jawsize);
             Assert.AreEqual("pinkish-gray", goblin.Color.ToString());
 
-            Assert.AreEqual(1, value["additionalProperty1"]);
-            Assert.AreEqual(false, value["additionalProperty2"]);
-            Assert.AreEqual("hello", value["additionalProperty3"]);
+            Assert.AreEqual(1, value.AdditionalProperties["additionalProperty1"]);
+            Assert.AreEqual(false, value.AdditionalProperties["additionalProperty2"]);
+            Assert.AreEqual("hello", value.AdditionalProperties["additionalProperty3"]);
             Assert.AreEqual(new Dictionary<string, object>()
             {
                 {"a", 1},
                 {"b", 2 }
-            }, value["additionalProperty4"]);
+            }, value.AdditionalProperties["additionalProperty4"]);
 
-            Assert.AreEqual(new object[] { 1, 3 }, value["additionalProperty5"]);
+            Assert.AreEqual(new object[] { 1, 3 }, value.AdditionalProperties["additionalProperty5"]);
         });
 
         [Test]
@@ -649,11 +649,11 @@ namespace AutoRest.TestServer.Tests
                     }
                 }
             };
-            value["additionalProperty1"] = 1;
-            value["additionalProperty2"] = false;
-            value["additionalProperty3"] = "hello";
-            value["additionalProperty4"] = new Dictionary<string, object>() {{"a", 1}, {"b", 2}};
-            value["additionalProperty5"] = new object[] {1, 3};
+            value.AdditionalProperties["additionalProperty1"] = 1;
+            value.AdditionalProperties["additionalProperty2"] = false;
+            value.AdditionalProperties["additionalProperty3"] = "hello";
+            value.AdditionalProperties["additionalProperty4"] = new Dictionary<string, object>() {{"a", 1}, {"b", 2}};
+            value.AdditionalProperties["additionalProperty5"] = new object[] {1, 3};
 
             return await new PolymorphismClient(ClientDiagnostics, pipeline, host).PutComplicatedAsync( value);
         });

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace AdditionalPropertiesEx.Models
 {
     /// <summary> The InputAdditionalPropertiesModel. </summary>
-    public partial class InputAdditionalPropertiesModel : IDictionary<string, object>
+    public partial class InputAdditionalPropertiesModel
     {
         /// <summary> Initializes a new instance of InputAdditionalPropertiesModel. </summary>
         /// <param name="id"> . </param>
@@ -23,42 +22,6 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
-        internal IDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, object value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModelStruct.cs
@@ -6,13 +6,12 @@
 #nullable disable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace AdditionalPropertiesEx.Models
 {
     /// <summary> The InputAdditionalPropertiesModelStruct. </summary>
-    public readonly partial struct InputAdditionalPropertiesModelStruct : IDictionary<string, object>
+    public readonly partial struct InputAdditionalPropertiesModelStruct
     {
         /// <summary> Initializes a new instance of InputAdditionalPropertiesModelStruct. </summary>
         /// <param name="id"> . </param>
@@ -30,42 +29,6 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
-        internal IDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, object value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace AdditionalPropertiesEx.Models
 {
     /// <summary> The OutputAdditionalPropertiesModel. </summary>
-    public partial class OutputAdditionalPropertiesModel : IReadOnlyDictionary<string, string>
+    public partial class OutputAdditionalPropertiesModel
     {
         /// <summary> Initializes a new instance of OutputAdditionalPropertiesModel. </summary>
         /// <param name="id"> . </param>
@@ -32,25 +31,6 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
-        internal IReadOnlyDictionary<string, string> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out string value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public IEnumerable<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public IEnumerable<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
-        int IReadOnlyCollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public string this[string key]
-        {
-            get => AdditionalProperties[key];
-        }
+        public IReadOnlyDictionary<string, string> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
@@ -6,13 +6,12 @@
 #nullable disable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace AdditionalPropertiesEx.Models
 {
     /// <summary> The OutputAdditionalPropertiesModelStruct. </summary>
-    public readonly partial struct OutputAdditionalPropertiesModelStruct : IReadOnlyDictionary<string, string>
+    public readonly partial struct OutputAdditionalPropertiesModelStruct
     {
         /// <summary> Initializes a new instance of OutputAdditionalPropertiesModelStruct. </summary>
         /// <param name="id"> . </param>
@@ -30,25 +29,6 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
-        internal IReadOnlyDictionary<string, string> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out string value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public IEnumerable<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public IEnumerable<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
-        int IReadOnlyCollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public string this[string key]
-        {
-            get => AdditionalProperties[key];
-        }
+        public IReadOnlyDictionary<string, string> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPInPropertiesWithAPString.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPInPropertiesWithAPString.cs
@@ -6,14 +6,13 @@
 #nullable disable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace additionalProperties.Models
 {
     /// <summary> The PetAPInPropertiesWithAPString. </summary>
-    public partial class PetAPInPropertiesWithAPString : IDictionary<string, string>
+    public partial class PetAPInPropertiesWithAPString
     {
         /// <summary> Initializes a new instance of PetAPInPropertiesWithAPString. </summary>
         /// <param name="id"> . </param>
@@ -55,41 +54,5 @@ namespace additionalProperties.Models
         public string OdataLocation { get; set; }
         /// <summary> Dictionary of &lt;number&gt;. </summary>
         public IDictionary<string, float> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => MoreAdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => MoreAdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out string value) => MoreAdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => MoreAdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => MoreAdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<string> Values => MoreAdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, string>>.Count => MoreAdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, string value) => MoreAdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => MoreAdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, string>>.IsReadOnly => MoreAdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> value) => MoreAdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> value) => MoreAdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> value) => MoreAdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] destination, int offset) => MoreAdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, string>>.Clear() => MoreAdditionalProperties.Clear();
-        /// <inheritdoc />
-        public string this[string key]
-        {
-            get => MoreAdditionalProperties[key];
-            set => MoreAdditionalProperties[key] = value;
-        }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPObject.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPObject.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace additionalProperties.Models
 {
     /// <summary> The PetAPObject. </summary>
-    public partial class PetAPObject : IDictionary<string, object>
+    public partial class PetAPObject
     {
         /// <summary> Initializes a new instance of PetAPObject. </summary>
         /// <param name="id"> . </param>
@@ -38,42 +37,6 @@ namespace additionalProperties.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public bool? Status { get; }
-        internal IDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, object value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPString.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPString.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace additionalProperties.Models
 {
     /// <summary> The PetAPString. </summary>
-    public partial class PetAPString : IDictionary<string, string>
+    public partial class PetAPString
     {
         /// <summary> Initializes a new instance of PetAPString. </summary>
         /// <param name="id"> . </param>
@@ -38,42 +37,6 @@ namespace additionalProperties.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public bool? Status { get; }
-        internal IDictionary<string, string> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out string value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<string> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, string>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, string value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, string>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, string>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public string this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, string> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPTrue.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPTrue.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace additionalProperties.Models
 {
     /// <summary> The PetAPTrue. </summary>
-    public partial class PetAPTrue : IDictionary<string, object>
+    public partial class PetAPTrue
     {
         /// <summary> Initializes a new instance of PetAPTrue. </summary>
         /// <param name="id"> . </param>
@@ -38,42 +37,6 @@ namespace additionalProperties.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public bool? Status { get; }
-        internal IDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, object value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/body-complex/Generated/Models/SmartSalmon.cs
+++ b/test/TestServerProjects/body-complex/Generated/Models/SmartSalmon.cs
@@ -5,14 +5,13 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Generic;
 using Azure.Core;
 
 namespace body_complex.Models
 {
     /// <summary> The SmartSalmon. </summary>
-    public partial class SmartSalmon : Salmon, IDictionary<string, object>
+    public partial class SmartSalmon : Salmon
     {
         /// <summary> Initializes a new instance of SmartSalmon. </summary>
         /// <param name="length"> . </param>
@@ -39,42 +38,6 @@ namespace body_complex.Models
         }
 
         public string CollegeDegree { get; set; }
-        internal IDictionary<string, object> AdditionalProperties { get; }
-        /// <inheritdoc />
-        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => AdditionalProperties.GetEnumerator();
-        /// <inheritdoc />
-        public bool TryGetValue(string key, out object value) => AdditionalProperties.TryGetValue(key, out value);
-        /// <inheritdoc />
-        public bool ContainsKey(string key) => AdditionalProperties.ContainsKey(key);
-        /// <inheritdoc />
-        public ICollection<string> Keys => AdditionalProperties.Keys;
-        /// <inheritdoc />
-        public ICollection<object> Values => AdditionalProperties.Values;
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        int ICollection<KeyValuePair<string, object>>.Count => AdditionalProperties.Count;
-        /// <inheritdoc />
-        public void Add(string key, object value) => AdditionalProperties.Add(key, value);
-        /// <inheritdoc />
-        public bool Remove(string key) => AdditionalProperties.Remove(key);
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => AdditionalProperties.IsReadOnly;
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> value) => AdditionalProperties.Add(value);
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> value) => AdditionalProperties.Remove(value);
-        /// <inheritdoc cref="ICollection{T}.Contains"/>
-        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> value) => AdditionalProperties.Contains(value);
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] destination, int offset) => AdditionalProperties.CopyTo(destination, offset);
-        /// <inheritdoc cref="ICollection{T}.Clear"/>
-        void ICollection<KeyValuePair<string, object>>.Clear() => AdditionalProperties.Clear();
-        /// <inheritdoc />
-        public object this[string key]
-        {
-            get => AdditionalProperties[key];
-            set => AdditionalProperties[key] = value;
-        }
+        public IDictionary<string, object> AdditionalProperties { get; }
     }
 }


### PR DESCRIPTION
# Description
- Fixes the parts of https://github.com/Azure/autorest.csharp/issues/1232 that we are hashing out now.
- Remove AdditionalProperties's IDictionary interface and make the field public

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first