### PR TITLE
Add ref to azure-sdk-build-tools in preparation of rename

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -26,6 +26,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
+      ref: refs/tags/azure-sdk-build-tools_20210602.1
 
 stages:
   - stage: 'Build_and_Test'


### PR DESCRIPTION
# Description
- `net-release-blobfeed.yml` will soon be renamed to `net-release-to-feed.yml` because packages published from that pipeline will now go to the `azure-sdk-for-net devOps feed` rather than the blob feed.
-  The ref added here prevents this pipeline from breaking while the change is made.
# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first