### PR TITLE
Add comment to generated 'Additional Properties' property

### DIFF
--- a/samples/CognitiveSearch/Generated/CognitiveServicesModelFactory.cs
+++ b/samples/CognitiveSearch/Generated/CognitiveServicesModelFactory.cs
@@ -31,7 +31,7 @@ namespace CognitiveSearch
 
         /// <summary> Initializes new instance of FacetResult class. </summary>
         /// <param name="count"> The approximate count of documents falling within the bucket described by this facet. </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.FacetResult"/> instance for mocking. </returns>
         public static FacetResult FacetResult(long? count = default, IReadOnlyDictionary<string, object> additionalProperties = default)
         {
@@ -42,7 +42,7 @@ namespace CognitiveSearch
         /// <summary> Initializes new instance of SearchResult class. </summary>
         /// <param name="score"> The relevance score of the document compared to other documents returned by the query. </param>
         /// <param name="highlights"> Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query. </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.SearchResult"/> instance for mocking. </returns>
         public static SearchResult SearchResult(double score = default, IReadOnlyDictionary<string, IList<string>> highlights = default, IReadOnlyDictionary<string, object> additionalProperties = default)
         {
@@ -63,7 +63,7 @@ namespace CognitiveSearch
 
         /// <summary> Initializes new instance of SuggestResult class. </summary>
         /// <param name="text"> The text of the suggestion result. </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.SuggestResult"/> instance for mocking. </returns>
         public static SuggestResult SuggestResult(string text = default, IReadOnlyDictionary<string, object> additionalProperties = default)
         {

--- a/samples/CognitiveSearch/Generated/Models/FacetResult.cs
+++ b/samples/CognitiveSearch/Generated/Models/FacetResult.cs
@@ -21,7 +21,7 @@ namespace CognitiveSearch.Models
 
         /// <summary> Initializes a new instance of FacetResult. </summary>
         /// <param name="count"> The approximate count of documents falling within the bucket described by this facet. </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal FacetResult(long? count, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Count = count;
@@ -30,6 +30,7 @@ namespace CognitiveSearch.Models
 
         /// <summary> The approximate count of documents falling within the bucket described by this facet. </summary>
         public long? Count { get; }
+        /// <summary> Additional Properties. </summary>
         public IReadOnlyDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/samples/CognitiveSearch/Generated/Models/IndexAction.cs
+++ b/samples/CognitiveSearch/Generated/Models/IndexAction.cs
@@ -21,6 +21,7 @@ namespace CognitiveSearch.Models
 
         /// <summary> The operation to perform on a document in an indexing batch. </summary>
         public IndexActionType? ActionType { get; set; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/samples/CognitiveSearch/Generated/Models/SearchResult.cs
+++ b/samples/CognitiveSearch/Generated/Models/SearchResult.cs
@@ -25,7 +25,7 @@ namespace CognitiveSearch.Models
         /// <summary> Initializes a new instance of SearchResult. </summary>
         /// <param name="score"> The relevance score of the document compared to other documents returned by the query. </param>
         /// <param name="highlights"> Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query. </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal SearchResult(double score, IReadOnlyDictionary<string, IList<string>> highlights, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Score = score;
@@ -37,6 +37,7 @@ namespace CognitiveSearch.Models
         public double Score { get; }
         /// <summary> Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query. </summary>
         public IReadOnlyDictionary<string, IList<string>> Highlights { get; }
+        /// <summary> Additional Properties. </summary>
         public IReadOnlyDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/samples/CognitiveSearch/Generated/Models/SuggestResult.cs
+++ b/samples/CognitiveSearch/Generated/Models/SuggestResult.cs
@@ -30,7 +30,7 @@ namespace CognitiveSearch.Models
 
         /// <summary> Initializes a new instance of SuggestResult. </summary>
         /// <param name="text"> The text of the suggestion result. </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal SuggestResult(string text, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Text = text;
@@ -39,6 +39,7 @@ namespace CognitiveSearch.Models
 
         /// <summary> The text of the suggestion result. </summary>
         public string Text { get; }
+        /// <summary> Additional Properties. </summary>
         public IReadOnlyDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -82,7 +82,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
                 _additionalPropertiesProperty = new ObjectTypeProperty(
                     BuilderHelpers.CreateMemberDeclaration("AdditionalProperties", ImplementsDictionaryType, "public", memberMapping?.ExistingMember, _typeFactory),
-                    string.Empty,
+                    "Additional Properties",
                     true,
                     null
                     );

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/AdditionalPropertiesModelFactory.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/AdditionalPropertiesModelFactory.cs
@@ -15,7 +15,7 @@ namespace AdditionalPropertiesEx
     {
         /// <summary> Initializes new instance of OutputAdditionalPropertiesModel class. </summary>
         /// <param name="id"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.OutputAdditionalPropertiesModel"/> instance for mocking. </returns>
         public static OutputAdditionalPropertiesModel OutputAdditionalPropertiesModel(int id = default, IReadOnlyDictionary<string, string> additionalProperties = default)
         {
@@ -25,7 +25,7 @@ namespace AdditionalPropertiesEx
 
         /// <summary> Initializes new instance of OutputAdditionalPropertiesModelStruct structure. </summary>
         /// <param name="id"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.OutputAdditionalPropertiesModelStruct"/> instance for mocking. </returns>
         public static OutputAdditionalPropertiesModelStruct OutputAdditionalPropertiesModelStruct(int id = default, IReadOnlyDictionary<string, string> additionalProperties = default)
         {

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
@@ -22,6 +22,7 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModelStruct.cs
@@ -15,7 +15,7 @@ namespace AdditionalPropertiesEx.Models
     {
         /// <summary> Initializes a new instance of InputAdditionalPropertiesModelStruct. </summary>
         /// <param name="id"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="additionalProperties"/> is null. </exception>
         public InputAdditionalPropertiesModelStruct(int id, IDictionary<string, object> additionalProperties)
         {
@@ -29,6 +29,7 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModel.cs
@@ -23,7 +23,7 @@ namespace AdditionalPropertiesEx.Models
 
         /// <summary> Initializes a new instance of OutputAdditionalPropertiesModel. </summary>
         /// <param name="id"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal OutputAdditionalPropertiesModel(int id, IReadOnlyDictionary<string, string> additionalProperties)
         {
             Id = id;
@@ -31,6 +31,7 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
+        /// <summary> Additional Properties. </summary>
         public IReadOnlyDictionary<string, string> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/OutputAdditionalPropertiesModelStruct.cs
@@ -15,7 +15,7 @@ namespace AdditionalPropertiesEx.Models
     {
         /// <summary> Initializes a new instance of OutputAdditionalPropertiesModelStruct. </summary>
         /// <param name="id"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="additionalProperties"/> is null. </exception>
         internal OutputAdditionalPropertiesModelStruct(int id, IReadOnlyDictionary<string, string> additionalProperties)
         {
@@ -29,6 +29,7 @@ namespace AdditionalPropertiesEx.Models
         }
 
         public int Id { get; }
+        /// <summary> Additional Properties. </summary>
         public IReadOnlyDictionary<string, string> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/AdditionalPropertiesModelFactory.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/AdditionalPropertiesModelFactory.cs
@@ -17,7 +17,7 @@ namespace additionalProperties
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.PetAPTrue"/> instance for mocking. </returns>
         public static PetAPTrue PetAPTrue(int id = default, string name = default, bool? status = default, IDictionary<string, object> additionalProperties = default)
         {
@@ -29,7 +29,7 @@ namespace additionalProperties
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.PetAPObject"/> instance for mocking. </returns>
         public static PetAPObject PetAPObject(int id = default, string name = default, bool? status = default, IDictionary<string, object> additionalProperties = default)
         {
@@ -41,7 +41,7 @@ namespace additionalProperties
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.PetAPString"/> instance for mocking. </returns>
         public static PetAPString PetAPString(int id = default, string name = default, bool? status = default, IDictionary<string, string> additionalProperties = default)
         {
@@ -67,7 +67,7 @@ namespace additionalProperties
         /// <param name="status"> . </param>
         /// <param name="odataLocation"> . </param>
         /// <param name="additionalProperties"> Dictionary of &lt;number&gt;. </param>
-        /// <param name="moreAdditionalProperties"> . </param>
+        /// <param name="moreAdditionalProperties"> Additional Properties. </param>
         /// <returns> A new <see cref="Models.PetAPInPropertiesWithAPString"/> instance for mocking. </returns>
         public static PetAPInPropertiesWithAPString PetAPInPropertiesWithAPString(int id = default, string name = default, bool? status = default, string odataLocation = default, IDictionary<string, float> additionalProperties = default, IDictionary<string, string> moreAdditionalProperties = default)
         {

--- a/test/TestServerProjects/additionalProperties/Generated/Models/CatAPTrue.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/CatAPTrue.cs
@@ -22,7 +22,7 @@ namespace additionalProperties.Models
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         /// <param name="friendly"> . </param>
         internal CatAPTrue(int id, string name, bool? status, IDictionary<string, object> additionalProperties, bool? friendly) : base(id, name, status, additionalProperties)
         {

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPInPropertiesWithAPString.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPInPropertiesWithAPString.cs
@@ -37,7 +37,7 @@ namespace additionalProperties.Models
         /// <param name="status"> . </param>
         /// <param name="odataLocation"> . </param>
         /// <param name="additionalProperties"> Dictionary of &lt;number&gt;. </param>
-        /// <param name="moreAdditionalProperties"> . </param>
+        /// <param name="moreAdditionalProperties"> Additional Properties. </param>
         internal PetAPInPropertiesWithAPString(int id, string name, bool? status, string odataLocation, IDictionary<string, float> additionalProperties, IDictionary<string, string> moreAdditionalProperties)
         {
             Id = id;

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPObject.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPObject.cs
@@ -25,7 +25,7 @@ namespace additionalProperties.Models
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal PetAPObject(int id, string name, bool? status, IDictionary<string, object> additionalProperties)
         {
             Id = id;
@@ -37,6 +37,7 @@ namespace additionalProperties.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public bool? Status { get; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPString.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPString.cs
@@ -25,7 +25,7 @@ namespace additionalProperties.Models
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal PetAPString(int id, string name, bool? status, IDictionary<string, string> additionalProperties)
         {
             Id = id;
@@ -37,6 +37,7 @@ namespace additionalProperties.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public bool? Status { get; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, string> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/additionalProperties/Generated/Models/PetAPTrue.cs
+++ b/test/TestServerProjects/additionalProperties/Generated/Models/PetAPTrue.cs
@@ -25,7 +25,7 @@ namespace additionalProperties.Models
         /// <param name="id"> . </param>
         /// <param name="name"> . </param>
         /// <param name="status"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal PetAPTrue(int id, string name, bool? status, IDictionary<string, object> additionalProperties)
         {
             Id = id;
@@ -37,6 +37,7 @@ namespace additionalProperties.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public bool? Status { get; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
     }
 }

--- a/test/TestServerProjects/body-complex/Generated/Models/SmartSalmon.cs
+++ b/test/TestServerProjects/body-complex/Generated/Models/SmartSalmon.cs
@@ -29,7 +29,7 @@ namespace body_complex.Models
         /// <param name="location"> . </param>
         /// <param name="iswild"> . </param>
         /// <param name="collegeDegree"> . </param>
-        /// <param name="additionalProperties"> . </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
         internal SmartSalmon(string fishtype, string species, float length, IList<Fish> siblings, string location, bool? iswild, string collegeDegree, IDictionary<string, object> additionalProperties) : base(fishtype, species, length, siblings, location, iswild)
         {
             CollegeDegree = collegeDegree;
@@ -38,6 +38,7 @@ namespace body_complex.Models
         }
 
         public string CollegeDegree { get; set; }
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
     }
 }


### PR DESCRIPTION
We weren't commenting it before, because it wasn't public:

```
+        /// <summary> Additional Properties. </summary>
         public IDictionary<string, object> AdditionalProperties { get; }
```

Comments welcome on a better comment string.