### PR TITLE
Improve CSharpType.Implementation exception to include more information

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -59,7 +59,7 @@ namespace AutoRest.CSharp.Generation.Types
         public CSharpType[] Arguments { get; } = Array.Empty<CSharpType>();
         public bool IsFrameworkType => _type != null;
         public Type FrameworkType => _type ?? throw new InvalidOperationException("Not a framework type");
-        public TypeProvider Implementation => _implementation ?? throw new InvalidOperationException("Not implemented type");
+        public TypeProvider Implementation => _implementation ?? throw new InvalidOperationException($"Not implemented type: '{Namespace}.{Name}'");
         public bool IsNullable { get; }
 
         protected bool Equals(CSharpType other)


### PR DESCRIPTION
From:

```
FATAL: Internal error in AutoRest.CSharp
   Please file an issue at https://github.com/Azure/autorest.csharp/issues/new.
   Attach the written 'Configuration.json' and 'CodeModel.yaml' or the original swagger so we can reproduce your error.

Exception: Not implemented type
   at AutoRest.CSharp.Generation.Types.CSharpType.get_Implementation() in C:\Users\chhamo\Programming\autorest.csharp\src\AutoRest.CSharp\Common\Generation\Types\CSharpType.cs:line 62
```

To:

```
FATAL: Internal error in AutoRest.CSharp
   Please file an issue at https://github.com/Azure/autorest.csharp/issues/new.
   Attach the written 'Configuration.json' and 'CodeModel.yaml' or the original swagger so we can reproduce your error.

Exception: Not implemented type: 'System.Object'
   at AutoRest.CSharp.Generation.Types.CSharpType.get_Implementation() in C:\Users\chhamo\Programming\autorest.csharp\src\AutoRest.CSharp\Common\Generation\Types\CSharpType.cs:line 62
```