### PR TITLE
Update ResourceManager core version and remove PhWrappingPageable

### DIFF
--- a/samples/Azure.Management.Storage/Azure.Management.Storage.csproj
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Azure.ResourceManager.Sample/Azure.ResourceManager.Sample.csproj
+++ b/samples/Azure.ResourceManager.Sample/Azure.ResourceManager.Sample.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.15.0" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.12" />
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0-1.final" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpProj.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpProj.cs
@@ -37,7 +37,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Azure.ResourceManager.Core"" Version=""1.0.0-alpha.20210610.1"" />
+    <PackageReference Include=""Azure.ResourceManager.Core"" Version=""1.0.0-alpha.20210615.1"" />
   </ItemGroup>
 ";
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/ClientWriter.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/ClientWriter.cs
@@ -36,64 +36,6 @@ namespace AutoRest.CSharp.Common.Generation.Writers
             writer.Append($"internal {client.Type} RestClient").LineRaw(" { get; }");
         }
 
-        protected void WritePagingOperationDefinition(CodeWriter writer, PagingMethod pagingMethod, bool async, string restClientParam, string clientDiagnosticsParam)
-        {
-            // Paging method definition
-            var pageType = pagingMethod.PagingResponse.ItemType;
-            var parameters = pagingMethod.Method.Parameters;
-            using (writer.Scope())
-            {
-                writer.WriteParameterNullChecks(parameters);
-
-                var pageWrappedType = new CSharpType(typeof(Page<>), pageType);
-                var funcType = async ? new CSharpType(typeof(Task<>), pageWrappedType) : pageWrappedType;
-
-                var nextLinkName = pagingMethod.PagingResponse.NextLinkProperty?.Declaration.Name;
-                var itemName = pagingMethod.PagingResponse.ItemProperty.Declaration.Name;
-
-                var continuationTokenText = nextLinkName != null ? $"response.Value.{nextLinkName}" : "null";
-                var asyncText = async ? "async" : string.Empty;
-                var awaitText = async ? "await" : string.Empty;
-                var configureAwaitText = async ? ".ConfigureAwait(false)" : string.Empty;
-                using (writer.Scope($"{asyncText} {funcType} FirstPageFunc({typeof(int?)} pageSizeHint)"))
-                {
-                    WriteDiagnosticScope(writer, pagingMethod.Diagnostics, clientDiagnosticsParam, writer =>
-                    {
-                        writer.Append($"var response = {awaitText} {restClientParam}.{CreateMethodName(pagingMethod.Method.Name, async)}(");
-                        foreach (Parameter parameter in parameters)
-                        {
-                            writer.Append($"{parameter.Name}, ");
-                        }
-
-                        writer.Line($"cancellationToken){configureAwaitText};");
-                        writer.Line($"return {typeof(Page)}.FromValues(response.Value.{itemName}, {continuationTokenText}, response.GetRawResponse());");
-                    });
-                }
-
-                var nextPageFunctionName = "null";
-                if (pagingMethod.NextPageMethod != null)
-                {
-                    nextPageFunctionName = "NextPageFunc";
-                    var nextPageParameters = pagingMethod.NextPageMethod.Parameters;
-                    using (writer.Scope($"{asyncText} {funcType} {nextPageFunctionName}({typeof(string)} nextLink, {typeof(int?)} pageSizeHint)"))
-                    {
-                        WriteDiagnosticScope(writer, pagingMethod.Diagnostics, clientDiagnosticsParam, writer =>
-                        {
-                            writer.Append($"var response = {awaitText} {restClientParam}.{CreateMethodName(pagingMethod.NextPageMethod.Name, async)}(");
-                            foreach (Parameter parameter in nextPageParameters)
-                            {
-                                writer.Append($"{parameter.Name}, ");
-                            }
-                            writer.Line($"cancellationToken){configureAwaitText};");
-                            writer.Line($"return {typeof(Page)}.FromValues(response.Value.{itemName}, {continuationTokenText}, response.GetRawResponse());");
-                        });
-                    }
-                }
-                writer.Line($"return {typeof(PageableHelpers)}.Create{(async ? "Async" : string.Empty)}Enumerable(FirstPageFunc, {nextPageFunctionName});");
-            }
-            writer.Line();
-        }
-
         protected void WriteDiagnosticScope(CodeWriter writer, Diagnostic diagnostic, string clientDiagnosticsParam, CodeWriterDelegate inner)
         {
             var scopeVariable = new CodeWriterDeclaration("scope");

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -103,7 +103,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
             using (writer.Scope())
             {
-                WriteContainerPagingOperation(writer, listMethod, async, resourceType, converter);
+                WritePagingOperationBody(writer, listMethod, async, resourceType, RestClientField, ClientDiagnosticsField, converter);
             }
         }
 
@@ -115,7 +115,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
         /// <param name="async">Should the method be written sync or async.</param>
         /// <param name="resourceType">The reource type that is being written.</param>
         /// <param name="converter">Optional convertor for modifying the result of the rest client call.</param>
-        private void WriteContainerPagingOperation(CodeWriter writer, PagingMethod pagingMethod, bool async, CSharpType resourceType, FormattableString converter)
+        protected void WritePagingOperationBody(CodeWriter writer, PagingMethod pagingMethod, bool async, CSharpType resourceType, string restClientName, string clientDiagnosticsName, FormattableString converter)
         {
             var parameters = pagingMethod.Method.Parameters;
 
@@ -132,14 +132,13 @@ namespace AutoRest.CSharp.Mgmt.Generation
             using (writer.Scope($"{asyncText} {returnType} FirstPageFunc({typeof(int?)} pageSizeHint)"))
             {
                 // no null-checks because all are optional
-                WriteDiagnosticScope(writer, pagingMethod.Diagnostics, ClientDiagnosticsField, writer =>
+                WriteDiagnosticScope(writer, pagingMethod.Diagnostics, clientDiagnosticsName, writer =>
                 {
-                    writer.Append($"var response = {awaitText} {RestClientField}.{CreateMethodName(pagingMethod.Method.Name, async)}(");
+                    writer.Append($"var response = {awaitText} {restClientName}.{CreateMethodName(pagingMethod.Method.Name, async)}(");
                     foreach (var parameter in BuildParameterMapping(pagingMethod.Method).Where(p => IsMandatory(p.Parameter)))
                     {
                         writer.Append($"{parameter.ValueExpression}, ");
                     }
-
                     writer.Line($"cancellationToken: cancellationToken){configureAwaitText};");
 
                     writer.UseNamespace("System.Linq");
@@ -157,17 +156,17 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 var nextPageParameters = pagingMethod.NextPageMethod.Parameters;
                 using (writer.Scope($"{asyncText} {returnType} {nextPageFunctionName}({typeof(string)} nextLink, {typeof(int?)} pageSizeHint)"))
                 {
-                    WriteDiagnosticScope(writer, pagingMethod.Diagnostics, ClientDiagnosticsField, writer =>
+                    WriteDiagnosticScope(writer, pagingMethod.Diagnostics, clientDiagnosticsName, writer =>
                     {
-                        writer.Append($"var response = {awaitText} {RestClientField}.{CreateMethodName(pagingMethod.NextPageMethod.Name, async)}(nextLink, ");
+                        writer.Append($"var response = {awaitText} {restClientName}.{CreateMethodName(pagingMethod.NextPageMethod.Name, async)}(nextLink, ");
                         foreach (var parameter in BuildParameterMapping(pagingMethod.NextPageMethod).Where(p => IsMandatory(p.Parameter)))
                         {
                             writer.Append($"{parameter.ValueExpression}, ");
                         }
                         writer.Line($"cancellationToken: cancellationToken){configureAwaitText};");
-                    writer.Append($"return {typeof(Page)}.FromValues(response.Value.{itemName}");
-                    writer.Append($"{converter}");
-                    writer.Line($", {continuationTokenText}, response.GetRawResponse());");
+                        writer.Append($"return {typeof(Page)}.FromValues(response.Value.{itemName}");
+                        writer.Append($"{converter}");
+                        writer.Line($", {continuationTokenText}, response.GetRawResponse());");
                     });
                 }
             }

--- a/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
+++ b/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
+++ b/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Azure.Core" Version="1.15" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.12" />
     <PackageReference Include="Azure.Identity" Version="1.0.0" />
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
@@ -363,7 +363,7 @@ namespace AutoRest.TestServer.Tests.Mgmt.TestProjects
                 {
                     var listMethodInfo = subscriptionExtension.GetMethod($"List{resourceName}", BindingFlags.Static | BindingFlags.Public);
                     Assert.NotNull(listMethodInfo);
-                    Assert.AreEqual(2, listMethodInfo.GetParameters().Length);
+                    Assert.True(listMethodInfo.GetParameters().Length >= 2);
                     var listParam1 = TypeAsserts.HasParameter(listMethodInfo, "subscription");
                     Assert.AreEqual(typeof(SubscriptionOperations), listParam1.ParameterType);
                     var listParam2 = TypeAsserts.HasParameter(listMethodInfo, "cancellationToken");
@@ -371,7 +371,7 @@ namespace AutoRest.TestServer.Tests.Mgmt.TestProjects
 
                     var listAsyncMethodInfo = subscriptionExtension.GetMethod($"List{resourceName}Async", BindingFlags.Static | BindingFlags.Public);
                     Assert.NotNull(listAsyncMethodInfo);
-                    Assert.AreEqual(2, listAsyncMethodInfo.GetParameters().Length);
+                    Assert.True(listMethodInfo.GetParameters().Length >= 2);
                     var listAsyncParam1 = TypeAsserts.HasParameter(listAsyncMethodInfo, "subscription");
                     Assert.AreEqual(typeof(SubscriptionOperations), listAsyncParam1.ParameterType);
                     var listAsyncParam2 = TypeAsserts.HasParameter(listAsyncMethodInfo, "cancellationToken");

--- a/test/TestProjects/ExactMatchFlattenInheritance/ExactMatchFlattenInheritance.csproj
+++ b/test/TestProjects/ExactMatchFlattenInheritance/ExactMatchFlattenInheritance.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/ExactMatchInheritance/ExactMatchInheritance.csproj
+++ b/test/TestProjects/ExactMatchInheritance/ExactMatchInheritance.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/MgmtOperations/MgmtOperations.csproj
+++ b/test/TestProjects/MgmtOperations/MgmtOperations.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/MgmtParent/MgmtParent.csproj
+++ b/test/TestProjects/MgmtParent/MgmtParent.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/MgmtSingleton/MgmtSingleton.csproj
+++ b/test/TestProjects/MgmtSingleton/MgmtSingleton.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/OperationGroupMappings/OperationGroupMappings.csproj
+++ b/test/TestProjects/OperationGroupMappings/OperationGroupMappings.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/ResourceIdentifierChooser/ResourceIdentifierChooser.csproj
+++ b/test/TestProjects/ResourceIdentifierChooser/ResourceIdentifierChooser.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/ResourceRename/ResourceRename.csproj
+++ b/test/TestProjects/ResourceRename/ResourceRename.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/SubscriptionExtensions/Generated/Extensions/SubscriptionExtensions.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/Extensions/SubscriptionExtensions.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -13,7 +14,6 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.ResourceManager.Core;
 using Azure.ResourceManager.Core.Resources;
-using SubscriptionExtensions.Models;
 
 namespace SubscriptionExtensions
 {
@@ -37,118 +37,94 @@ namespace SubscriptionExtensions
 
         /// <summary> Lists the Ovens for this Azure.ResourceManager.Core.SubscriptionOperations. </summary>
         /// <param name="subscription"> The <see cref="SubscriptionOperations" /> instance the method will execute against. </param>
+        /// <param name="statusOnly"> statusOnly=true enables fetching run time status of all Virtual Machines in the subscription. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <return> A collection of resource operations that may take multiple service requests to iterate over. </return>
-        public static AsyncPageable<Oven> ListOvenAsync(this SubscriptionOperations subscription, CancellationToken cancellationToken = default)
+        public static AsyncPageable<Oven> ListOvenAsync(this SubscriptionOperations subscription, string statusOnly = null, CancellationToken cancellationToken = default)
         {
             return subscription.UseClientContext((baseUri, credential, options, pipeline) =>
             {
                 var clientDiagnostics = new ClientDiagnostics(options);
                 var restOperations = GetOvensRestOperations(clientDiagnostics, credential, options, pipeline, subscription.Id.SubscriptionId, baseUri);
-                var result = ListAllAsync(clientDiagnostics, restOperations);
-                return new PhWrappingAsyncPageable<OvenData, Oven>(
-                result,
-                s => new Oven(subscription, s));
+                async Task<Page<Oven>> FirstPageFunc(int? pageSizeHint)
+                {
+                    using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
+                    scope.Start();
+                    try
+                    {
+                        var response = await restOperations.ListAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                        return Page.FromValues(response.Value.Value.Select(value => new Oven(subscription, value)), response.Value.NextLink, response.GetRawResponse());
+                    }
+                    catch (Exception e)
+                    {
+                        scope.Failed(e);
+                        throw;
+                    }
+                }
+                async Task<Page<Oven>> NextPageFunc(string nextLink, int? pageSizeHint)
+                {
+                    using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
+                    scope.Start();
+                    try
+                    {
+                        var response = await restOperations.ListAllNextPageAsync(nextLink, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        return Page.FromValues(response.Value.Value.Select(value => new Oven(subscription, value)), response.Value.NextLink, response.GetRawResponse());
+                    }
+                    catch (Exception e)
+                    {
+                        scope.Failed(e);
+                        throw;
+                    }
+                }
+                return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc);
             }
             );
-        }
-
-        /// <summary> Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response to get the next page of virtual machines. </summary>
-        /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
-        /// <param name="restOperations"> Resource client operations. </param>
-        /// <param name="statusOnly"> statusOnly=true enables fetching run time status of all Virtual Machines in the subscription. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        private static AsyncPageable<OvenData> ListAllAsync(ClientDiagnostics clientDiagnostics, OvensRestOperations restOperations, string statusOnly = null, CancellationToken cancellationToken = default)
-        {
-            async Task<Page<OvenData>> FirstPageFunc(int? pageSizeHint)
-            {
-                using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
-                scope.Start();
-                try
-                {
-                    var response = await restOperations.ListAllAsync(statusOnly, cancellationToken).ConfigureAwait(false);
-                    return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
-                }
-                catch (Exception e)
-                {
-                    scope.Failed(e);
-                    throw;
-                }
-            }
-            async Task<Page<OvenData>> NextPageFunc(string nextLink, int? pageSizeHint)
-            {
-                using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
-                scope.Start();
-                try
-                {
-                    var response = await restOperations.ListAllNextPageAsync(nextLink, statusOnly, cancellationToken).ConfigureAwait(false);
-                    return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
-                }
-                catch (Exception e)
-                {
-                    scope.Failed(e);
-                    throw;
-                }
-            }
-            return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc);
         }
 
         /// <summary> Lists the Ovens for this Azure.ResourceManager.Core.SubscriptionOperations. </summary>
         /// <param name="subscription"> The <see cref="SubscriptionOperations" /> instance the method will execute against. </param>
+        /// <param name="statusOnly"> statusOnly=true enables fetching run time status of all Virtual Machines in the subscription. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <return> A collection of resource operations that may take multiple service requests to iterate over. </return>
-        public static Pageable<Oven> ListOven(this SubscriptionOperations subscription, CancellationToken cancellationToken = default)
+        public static Pageable<Oven> ListOven(this SubscriptionOperations subscription, string statusOnly = null, CancellationToken cancellationToken = default)
         {
             return subscription.UseClientContext((baseUri, credential, options, pipeline) =>
             {
                 var clientDiagnostics = new ClientDiagnostics(options);
                 var restOperations = GetOvensRestOperations(clientDiagnostics, credential, options, pipeline, subscription.Id.SubscriptionId, baseUri);
-                var result = ListAll(clientDiagnostics, restOperations);
-                return new PhWrappingPageable<OvenData, Oven>(
-                result,
-                s => new Oven(subscription, s));
+                Page<Oven> FirstPageFunc(int? pageSizeHint)
+                {
+                    using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
+                    scope.Start();
+                    try
+                    {
+                        var response = restOperations.ListAll(cancellationToken: cancellationToken);
+                        return Page.FromValues(response.Value.Value.Select(value => new Oven(subscription, value)), response.Value.NextLink, response.GetRawResponse());
+                    }
+                    catch (Exception e)
+                    {
+                        scope.Failed(e);
+                        throw;
+                    }
+                }
+                Page<Oven> NextPageFunc(string nextLink, int? pageSizeHint)
+                {
+                    using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
+                    scope.Start();
+                    try
+                    {
+                        var response = restOperations.ListAllNextPage(nextLink, cancellationToken: cancellationToken);
+                        return Page.FromValues(response.Value.Value.Select(value => new Oven(subscription, value)), response.Value.NextLink, response.GetRawResponse());
+                    }
+                    catch (Exception e)
+                    {
+                        scope.Failed(e);
+                        throw;
+                    }
+                }
+                return PageableHelpers.CreateEnumerable(FirstPageFunc, NextPageFunc);
             }
             );
-        }
-
-        /// <summary> Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response to get the next page of virtual machines. </summary>
-        /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
-        /// <param name="restOperations"> Resource client operations. </param>
-        /// <param name="statusOnly"> statusOnly=true enables fetching run time status of all Virtual Machines in the subscription. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        private static Pageable<OvenData> ListAll(ClientDiagnostics clientDiagnostics, OvensRestOperations restOperations, string statusOnly = null, CancellationToken cancellationToken = default)
-        {
-            Page<OvenData> FirstPageFunc(int? pageSizeHint)
-            {
-                using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
-                scope.Start();
-                try
-                {
-                    var response = restOperations.ListAll(statusOnly, cancellationToken);
-                    return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
-                }
-                catch (Exception e)
-                {
-                    scope.Failed(e);
-                    throw;
-                }
-            }
-            Page<OvenData> NextPageFunc(string nextLink, int? pageSizeHint)
-            {
-                using var scope = clientDiagnostics.CreateScope("OvenOperations.ListAll");
-                scope.Start();
-                try
-                {
-                    var response = restOperations.ListAllNextPage(nextLink, statusOnly, cancellationToken);
-                    return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
-                }
-                catch (Exception e)
-                {
-                    scope.Failed(e);
-                    throw;
-                }
-            }
-            return PageableHelpers.CreateEnumerable(FirstPageFunc, NextPageFunc);
         }
 
         /// <summary> Filters the list of Ovens for a Azure.ResourceManager.Core.SubscriptionOperations represented as generic resources. </summary>

--- a/test/TestProjects/SubscriptionExtensions/SubscriptionExtensions.csproj
+++ b/test/TestProjects/SubscriptionExtensions/SubscriptionExtensions.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/SupersetFlattenInheritance/SupersetFlattenInheritance.csproj
+++ b/test/TestProjects/SupersetFlattenInheritance/SupersetFlattenInheritance.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/SupersetInheritance/SupersetInheritance.csproj
+++ b/test/TestProjects/SupersetInheritance/SupersetInheritance.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/TenantOnly/TenantOnly.csproj
+++ b/test/TestProjects/TenantOnly/TenantOnly.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210610.1" />
+    <PackageReference Include="Azure.ResourceManager.Core" Version="1.0.0-alpha.20210615.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description
* Updated Azure.ResourceManager.Core version
* Removed PhWrappingAsyncPageable from all methods that return this type.
* Refactored subscription extensions paging method and used the common code for method definition.
* Moved pagination method definition from ClientWriter to DataPlaneClientWriter, since it was the only class using that method.

# Issue
* https://dev.azure.com/azure-mgmt-ex/DotNET%20Management%20SDK/_backlogs/backlog/DotNET%20Management%20SDK%20Team/Features/?showParents=true&workitem=5970

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first