### PR TITLE
refactor(generator): improve get operation missing message

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
@@ -61,7 +61,8 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 writer.Append($"{type}, ");
 
                 if (resourceOperation.GetMethod == null && baseClass == typeof(ResourceOperationsBase))
-                    throw new Exception($"Get operation is missing for {resource.Type.Name} resource.");
+                    throw new Exception($"Get operation is missing for '{resource.Type.Name}' resource under operation group '{operationGroup.Key}'. " +
+                        "Check the swagger definition, and use 'operation-group-to-resource' directive to specify the correct resource if necessary.");
 
                 CSharpType inheritType = new CSharpType(typeof(TrackedResource<>), resourceOperation.ResourceIdentifierType);
                 if (resourceData.Inherits != null && resourceData.Inherits.Name == inheritType.Name)


### PR DESCRIPTION
# Description

1. add more contextual information so that users can quickly locate the problematic resource definition
2. add prompt to use `operation-group-to-resource` directive as a solution to fix this error

Here is an example of how the error message looks like:

```
Exception: Get operation is missing for 'PacketCapture' resource under operation group 'PacketCaptures'. Check the swagger definition, and use 'operation-group-to-resource' directive to specify the correct resource if necessary.
```

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first