### PR TITLE
[LLC] Use `Azure.Core.ContentType` for content type

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -258,7 +258,16 @@ namespace AutoRest.CSharp.Generation.Writers
             using (WriteValueNullCheck(writer, header.Value))
             {
                 writer.Append($"{request}.Headers.{method}({header.Name:L}, ");
-                WriteConstantOrParameter(writer, header.Value, enumAsString: true);
+
+                if (!header.Value.IsConstant && header.Value.Reference.Type.IsFrameworkType && header.Value.Reference.Type.FrameworkType == typeof(Azure.Core.ContentType))
+                {
+                    WriteConstantOrParameterAsString(writer, header.Value);
+                }
+                else
+                {
+                    WriteConstantOrParameter(writer, header.Value, enumAsString: true);
+                }
+
                 if (delimiter != null)
                 {
                     writer.Append($", {delimiter:L}");

--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -259,7 +259,7 @@ namespace AutoRest.CSharp.Generation.Writers
             {
                 writer.Append($"{request}.Headers.{method}({header.Name:L}, ");
 
-                if (!header.Value.IsConstant && header.Value.Reference.Type.IsFrameworkType && header.Value.Reference.Type.FrameworkType == typeof(Azure.Core.ContentType))
+                if (header.Value.Type.Equals(typeof(Azure.Core.ContentType)))
                 {
                     WriteConstantOrParameterAsString(writer, header.Value);
                 }

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClient.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClient.cs
@@ -134,8 +134,8 @@ namespace AutoRest.CSharp.Output.Models
                 "nextLink",
                 "The URL to the next page of results.",
                 typeof(string),
-                defaultValue: null,
-                validateNotNull: true);
+                DefaultValue: null,
+                ValidateNotNull: true);
 
             PathSegment[] pathSegments = method.Request.PathSegments
                 .Where(ps => ps.IsRaw)

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -551,20 +551,10 @@ namespace AutoRest.CSharp.Output.Models
                 defaultValue = Constant.Default(type);
             }
 
-            CSharpType parameterType = TypeFactory.GetInputType(type);
-
-            // ModelerFour synthesiszes a content type parameter for operations which consume different content types.
-            // When producing a low level client, model this parameter as an instance of Azure.Core.ContentType
-            // instead of just a "string".
-            if (_context.Configuration.LowLevelClient && requestParameter.Origin == "modelerfour:synthesized/content-type")
-            {
-                parameterType = new CSharpType(typeof(Azure.Core.ContentType));
-            }
-
             return new Parameter(
                 requestParameter.CSharpName(),
                 CreateDescription(requestParameter),
-                parameterType,
+                TypeFactory.GetInputType(type),
                 defaultValue,
                 isRequired,
                 requestParameter.Origin == "modelerfour:synthesized/api-version");

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -550,10 +550,21 @@ namespace AutoRest.CSharp.Output.Models
             {
                 defaultValue = Constant.Default(type);
             }
+
+            CSharpType parameterType = TypeFactory.GetInputType(type);
+
+            // ModelerFour synthesiszes a content type parameter for operations which consume different content types.
+            // When producing a low level client, model this parameter as an instance of Azure.Core.ContentType
+            // instead of just a "string".
+            if (_context.Configuration.LowLevelClient && requestParameter.Origin == "modelerfour:synthesized/content-type")
+            {
+                parameterType = new CSharpType(typeof(Azure.Core.ContentType));
+            }
+
             return new Parameter(
                 requestParameter.CSharpName(),
                 CreateDescription(requestParameter),
-                TypeFactory.GetInputType(type),
+                parameterType,
                 defaultValue,
                 isRequired,
                 requestParameter.Origin == "modelerfour:synthesized/api-version");

--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -1,28 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+#pragma warning disable AD0001 // Doesn't understand record decleration, and the anaylizer throws an exception.
+#pragma warning disable SA1649 // Doesn't understand record decleration, and the anaylizer throws an exception.
 
 using AutoRest.CSharp.Generation.Types;
 
 namespace AutoRest.CSharp.Output.Models.Shared
 {
-    internal class Parameter
-    {
-        public Parameter(string name, string? description, CSharpType type, Constant? defaultValue, bool validateNotNull, bool isApiVersionParameter = false)
-        {
-            Name = name;
-            Description = description;
-            Type = type;
-            DefaultValue = defaultValue;
-            ValidateNotNull = validateNotNull;
-            IsApiVersionParameter = isApiVersionParameter;
-        }
-
-        public CSharpType Type { get; }
-        public string Name { get; }
-        public string? Description { get; }
-        public Constant? DefaultValue { get; }
-        public bool ValidateNotNull { get; }
-        public bool IsApiVersionParameter { get; }
-    }
+    internal record Parameter(string Name, string? Description, CSharpType Type, Constant? DefaultValue, bool ValidateNotNull, bool IsApiVersionParameter = false);
 }

--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClient.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelRestClient.cs
@@ -79,11 +79,15 @@ namespace AutoRest.CSharp.Output.Models
                         body = new RequestContentRequestBody(bodyParam);
                         schemaDocumentation = GetSchemaDocumentationsForParameter(bodyParameter);
 
-                        // If there's a Content-Type parameter in the parameters list, move it to after the parameter for the body.
-                        int contentTypeParamIndex = parameters.FindIndex(p => p.Type.FrameworkType == typeof(Azure.Core.ContentType));
-                        if (contentTypeParamIndex >= 0)
+
+                        // If there's a Content-Type parameter in the parameters list, move it to after the parameter for the body, and change the
+                        // type to be `Content-Type`
+                        RequestParameter contentTypeRequestParameter = requestParameters.FirstOrDefault(IsSynthesizedContentTypeParameter);
+                        if (contentTypeRequestParameter != null)
                         {
-                            Parameter contentTypeParameter = parameters[contentTypeParamIndex];
+                            int contentTypeParamIndex = parameters.FindIndex(p => p.Name == contentTypeRequestParameter.CSharpName());
+                            Parameter contentTypeParameter = parameters[contentTypeParamIndex] with { Type = new CSharpType(typeof(Azure.Core.ContentType)) };
+
                             parameters.RemoveAt(contentTypeParamIndex);
 
                             // If the content-type paramter came before the the body, the removal of it above shifted the body parameter

--- a/test/AutoRest.TestServerLowLevel.Tests/BodyAndPath.cs
+++ b/test/AutoRest.TestServerLowLevel.Tests/BodyAndPath.cs
@@ -28,8 +28,7 @@ namespace AutoRest.TestServer.Tests
             ParameterInfo[] parameters = typeof(BodyAndPathClient).GetMethod("CreateStream").GetParameters();
             Assert.AreEqual(typeof(string), parameters[0].ParameterType);
             Assert.AreEqual(typeof(RequestContent), parameters[1].ParameterType);
-            Assert.AreEqual(typeof(ContentType), parameters[1].ParameterType);
-            Assert.AreEqual(typeof(RequestOptions), parameters[2].ParameterType);
+            Assert.AreEqual(typeof(ContentType), parameters[2].ParameterType);
         }
     }
 }

--- a/test/AutoRest.TestServerLowLevel.Tests/BodyAndPath.cs
+++ b/test/AutoRest.TestServerLowLevel.Tests/BodyAndPath.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Threading.Tasks;
+using AutoRest.TestServer.Tests.Infrastructure;
 using Azure;
 using Azure.Core;
 using BodyAndPath_LowLevel;
@@ -9,7 +11,7 @@ using NUnit.Framework;
 
 namespace AutoRest.TestServer.Tests
 {
-    public class BodayAndPath
+    public class BodayAndPathTest
     {
         [Test]
         public void BodyParameterIsLast()
@@ -17,6 +19,16 @@ namespace AutoRest.TestServer.Tests
             ParameterInfo[] parameters = typeof(BodyAndPathClient).GetMethod("Create").GetParameters();
             Assert.AreEqual(typeof(string), parameters[0].ParameterType);
             Assert.AreEqual(typeof(RequestContent), parameters[1].ParameterType);
+            Assert.AreEqual(typeof(RequestOptions), parameters[2].ParameterType);
+        }
+
+        [Test]
+        public void ContentTypeParameterIsAfterBodyParameter()
+        {
+            ParameterInfo[] parameters = typeof(BodyAndPathClient).GetMethod("CreateStream").GetParameters();
+            Assert.AreEqual(typeof(string), parameters[0].ParameterType);
+            Assert.AreEqual(typeof(RequestContent), parameters[1].ParameterType);
+            Assert.AreEqual(typeof(ContentType), parameters[1].ParameterType);
             Assert.AreEqual(typeof(RequestOptions), parameters[2].ParameterType);
         }
     }

--- a/test/AutoRest.TestServerLowLevel.Tests/media_types.cs
+++ b/test/AutoRest.TestServerLowLevel.Tests/media_types.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using AutoRest.TestServer.Tests.Infrastructure;
+using Azure.Core;
+using media_types_LowLevel;
+using NUnit.Framework;
+
+namespace AutoRest.TestServer.Tests
+{
+    public class MediaTypesTests : TestServerLowLevelTestBase
+    {
+        [Test]
+        public Task MediaTypeJson() => Test(async (host) =>
+        {
+            var value = new
+            {
+                source = "anything"
+            };
+            var response = await new MediaTypesClient(Key, host).AnalyzeBodyAsync(RequestContent.Create(value), ContentType.ApplicationJson);
+            Assert.AreEqual("Nice job with JSON", response.Content.ToObjectFromJson<string>());
+        });
+
+        [Test]
+        public Task MediaTypePdf() => Test(async (host) =>
+        {
+            await using var value = new MemoryStream(Encoding.UTF8.GetBytes("PDF"));
+            var response = await new MediaTypesClient(Key, host).AnalyzeBodyAsync(RequestContent.Create(value), new ContentType("application/pdf"));
+            Assert.AreEqual("Nice job with PDF", response.Content.ToObjectFromJson<string>());
+        });
+    }
+}

--- a/test/TestProjects/BodyAndPath-LowLevel/BodyAndPath-LowLevel.json
+++ b/test/TestProjects/BodyAndPath-LowLevel/BodyAndPath-LowLevel.json
@@ -39,6 +39,51 @@
             }
           }
         }
+      },
+      "/{itemNameStream}": {
+        "post": {
+          "operationId": "createStream",
+          "summary": "Create products",
+          "description": "Resets products.",
+          "consumes": [
+            "application/octet-stream",
+            "application/json"
+          ],
+          "parameters": [
+            {
+              "name": "itemNameStream",
+              "in": "path",
+              "description": "item name.",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "in": "query",
+              "name": "excluded",
+              "description": "Excluded connection Ids.",
+              "type": "array",
+              "items": {
+                  "type": "string"
+              },
+              "collectionFormat": "multi"
+            },
+            {
+              "in": "body",
+              "name": "message",
+              "description": "The payload body.",
+              "required": true,
+              "schema": {
+                  "format": "binary",
+                  "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "ok"
+            }
+          }
+        }
       }      
     },
     "definitions": {},

--- a/test/TestProjects/BodyAndPath-LowLevel/Generated/BodyAndPathClient.cs
+++ b/test/TestProjects/BodyAndPath-LowLevel/Generated/BodyAndPathClient.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
@@ -147,6 +148,117 @@ namespace BodyAndPath_LowLevel
             uri.AppendPath(itemName, true);
             request.Uri = uri;
             request.Headers.Add("Content-Type", "application/json");
+            request.Content = content;
+            return message;
+        }
+
+        /// <summary> Resets products. </summary>
+        /// <param name="itemNameStream"> item name. </param>
+        /// <param name="content"> The content to send as the body of the request. </param>
+        /// <param name="contentType"> Upload file type. </param>
+        /// <param name="excluded"> Excluded connection Ids. </param>
+        /// <param name="options"> The request options. </param>
+#pragma warning disable AZC0002
+        public virtual async Task<Response> CreateStreamAsync(string itemNameStream, RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            options ??= new RequestOptions();
+            HttpMessage message = CreateCreateStreamRequest(itemNameStream, content, contentType, excluded, options);
+            if (options.PerCallPolicy != null)
+            {
+                message.SetProperty("RequestOptionsPerCallPolicyCallback", options.PerCallPolicy);
+            }
+            using var scope = _clientDiagnostics.CreateScope("BodyAndPathClient.CreateStream");
+            scope.Start();
+            try
+            {
+                await Pipeline.SendAsync(message, options.CancellationToken).ConfigureAwait(false);
+                if (options.StatusOption == ResponseStatusOption.Default)
+                {
+                    switch (message.Response.Status)
+                    {
+                        case 200:
+                            return message.Response;
+                        default:
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    return message.Response;
+                }
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Resets products. </summary>
+        /// <param name="itemNameStream"> item name. </param>
+        /// <param name="content"> The content to send as the body of the request. </param>
+        /// <param name="contentType"> Upload file type. </param>
+        /// <param name="excluded"> Excluded connection Ids. </param>
+        /// <param name="options"> The request options. </param>
+#pragma warning disable AZC0002
+        public virtual Response CreateStream(string itemNameStream, RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            options ??= new RequestOptions();
+            HttpMessage message = CreateCreateStreamRequest(itemNameStream, content, contentType, excluded, options);
+            if (options.PerCallPolicy != null)
+            {
+                message.SetProperty("RequestOptionsPerCallPolicyCallback", options.PerCallPolicy);
+            }
+            using var scope = _clientDiagnostics.CreateScope("BodyAndPathClient.CreateStream");
+            scope.Start();
+            try
+            {
+                Pipeline.Send(message, options.CancellationToken);
+                if (options.StatusOption == ResponseStatusOption.Default)
+                {
+                    switch (message.Response.Status)
+                    {
+                        case 200:
+                            return message.Response;
+                        default:
+                            throw _clientDiagnostics.CreateRequestFailedException(message.Response);
+                    }
+                }
+                else
+                {
+                    return message.Response;
+                }
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Create Request for <see cref="CreateStream"/> and <see cref="CreateStreamAsync"/> operations. </summary>
+        /// <param name="itemNameStream"> item name. </param>
+        /// <param name="content"> The content to send as the body of the request. </param>
+        /// <param name="contentType"> Upload file type. </param>
+        /// <param name="excluded"> Excluded connection Ids. </param>
+        /// <param name="options"> The request options. </param>
+        private HttpMessage CreateCreateStreamRequest(string itemNameStream, RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
+        {
+            var message = Pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.Reset(endpoint);
+            uri.AppendPath("/", false);
+            uri.AppendPath(itemNameStream, true);
+            if (excluded != null)
+            {
+                uri.AppendQueryDelimited("excluded", excluded, ",", true);
+            }
+            request.Uri = uri;
+            request.Headers.Add("Content-Type", contentType.ToString());
             request.Content = content;
             return message;
         }

--- a/test/TestProjects/BodyAndPath-LowLevel/Generated/CodeModel.yaml
+++ b/test/TestProjects/BodyAndPath-LowLevel/Generated/CodeModel.yaml
@@ -11,7 +11,7 @@ schemas: !Schemas
           name: String
           description: simple string
       protocol: !Protocols {}
-    - !StringSchema &ref_2
+    - !StringSchema &ref_3
       type: string
       apiVersions:
         - !ApiVersion 
@@ -21,8 +21,40 @@ schemas: !Schemas
           name: String
           description: ''
       protocol: !Protocols {}
+    - !StringSchema &ref_1
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 2014-04-01-preview
+      language: !Languages 
+        default:
+          name: Post1ItemsItem
+          description: ''
+      protocol: !Protocols {}
+  sealedChoices:
+    - !SealedChoiceSchema &ref_9
+      choices:
+        - !ChoiceValue 
+          value: application/json
+          language:
+            default:
+              name: ApplicationJson
+              description: Content Type 'application/json'
+        - !ChoiceValue 
+          value: application/octet-stream
+          language:
+            default:
+              name: ApplicationOctetStream
+              description: Content Type 'application/octet-stream'
+      type: sealed-choice
+      choiceType: *ref_0
+      language: !Languages 
+        default:
+          name: ContentType
+          description: Content type for upload
+      protocol: !Protocols {}
   constants:
-    - !ConstantSchema &ref_3
+    - !ConstantSchema &ref_4
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -33,15 +65,38 @@ schemas: !Schemas
           description: Content Type 'application/json'
       protocol: !Protocols {}
   any:
-    - !AnySchema &ref_4
+    - !AnySchema &ref_5
       type: any
       language: !Languages 
         default:
           name: any
           description: Anything
       protocol: !Protocols {}
+  binaries:
+    - !BinarySchema &ref_10
+      type: binary
+      apiVersions:
+        - !ApiVersion 
+          version: 2014-04-01-preview
+      language: !Languages 
+        default:
+          name: binary
+          description: ''
+      protocol: !Protocols {}
+  arrays:
+    - !ArraySchema &ref_8
+      type: array
+      apiVersions:
+        - !ApiVersion 
+          version: 2014-04-01-preview
+      elementType: *ref_1
+      language: !Languages 
+        default:
+          name: ArrayOfPost1ItemsItem
+          description: Array of Post1ItemsItem
+      protocol: !Protocols {}
 globalParameters:
-  - !Parameter &ref_1
+  - !Parameter &ref_2
     schema: *ref_0
     clientDefaultValue: http://localhost:3000
     implementation: Client
@@ -66,9 +121,9 @@ operationGroups:
           - !ApiVersion 
             version: 2014-04-01-preview
         parameters:
-          - *ref_1
-          - !Parameter &ref_6
-            schema: *ref_2
+          - *ref_2
+          - !Parameter &ref_7
+            schema: *ref_3
             implementation: Method
             required: true
             language: !Languages 
@@ -83,7 +138,7 @@ operationGroups:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_3
+                schema: *ref_4
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -95,8 +150,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_5
-                schema: *ref_4
+              - !Parameter &ref_6
+                schema: *ref_5
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -108,7 +163,7 @@ operationGroups:
                     in: body
                     style: json
             signatureParameters:
-              - *ref_5
+              - *ref_6
             language: !Languages 
               default:
                 name: ''
@@ -122,7 +177,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_6
+          - *ref_7
         responses:
           - !Response 
             language: !Languages 
@@ -136,6 +191,101 @@ operationGroups:
         language: !Languages 
           default:
             name: Create
+            description: Resets products.
+            summary: Create products
+        protocol: !Protocols {}
+      - !Operation 
+        apiVersions:
+          - !ApiVersion 
+            version: 2014-04-01-preview
+        parameters:
+          - *ref_2
+          - !Parameter &ref_13
+            schema: *ref_3
+            implementation: Method
+            required: true
+            language: !Languages 
+              default:
+                name: itemNameStream
+                description: item name.
+                serializedName: itemNameStream
+            protocol: !Protocols 
+              http: !HttpParameter 
+                in: path
+          - !Parameter &ref_14
+            schema: *ref_8
+            implementation: Method
+            language: !Languages 
+              default:
+                name: excluded
+                description: Excluded connection Ids.
+                serializedName: excluded
+            protocol: !Protocols 
+              http: !HttpParameter 
+                explode: true
+                in: query
+                style: form
+        requests:
+          - !Request 
+            parameters:
+              - !Parameter &ref_11
+                schema: *ref_9
+                implementation: Method
+                origin: modelerfour:synthesized/content-type
+                required: true
+                language: !Languages 
+                  default:
+                    name: contentType
+                    description: Upload file type
+                    serializedName: Content-Type
+                protocol: !Protocols 
+                  http: !HttpParameter 
+                    in: header
+              - !Parameter &ref_12
+                schema: *ref_10
+                implementation: Method
+                required: true
+                language: !Languages 
+                  default:
+                    name: message
+                    description: The payload body.
+                protocol: !Protocols 
+                  http: !HttpParameter 
+                    in: body
+                    style: binary
+            signatureParameters:
+              - *ref_11
+              - *ref_12
+            language: !Languages 
+              default:
+                name: ''
+                description: ''
+            protocol: !Protocols 
+              http: !HttpBinaryRequest 
+                path: /{itemNameStream}
+                method: post
+                binary: true
+                knownMediaType: binary
+                mediaTypes:
+                  - application/json
+                  - application/octet-stream
+                uri: '{$host}'
+        signatureParameters:
+          - *ref_13
+          - *ref_14
+        responses:
+          - !Response 
+            language: !Languages 
+              default:
+                name: ''
+                description: ok
+            protocol: !Protocols 
+              http: !HttpResponse 
+                statusCodes:
+                  - '200'
+        language: !Languages 
+          default:
+            name: CreateStream
             description: Resets products.
             summary: Create products
         protocol: !Protocols {}

--- a/test/TestServerProjectsLowLevel/media_types/Generated/MediaTypesClient.cs
+++ b/test/TestServerProjectsLowLevel/media_types/Generated/MediaTypesClient.cs
@@ -51,15 +51,15 @@ namespace media_types_LowLevel
         }
 
         /// <summary> Analyze body, that could be different media types. </summary>
-        /// <param name="contentType"> Upload file type. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
+        /// <param name="contentType"> Upload file type. </param>
         /// <param name="options"> The request options. </param>
 #pragma warning disable AZC0002
-        public virtual async Task<Response> AnalyzeBodyAsync(string contentType, RequestContent content, RequestOptions options = null)
+        public virtual async Task<Response> AnalyzeBodyAsync(RequestContent content, ContentType contentType, RequestOptions options = null)
 #pragma warning restore AZC0002
         {
             options ??= new RequestOptions();
-            HttpMessage message = CreateAnalyzeBodyRequest(contentType, content, options);
+            HttpMessage message = CreateAnalyzeBodyRequest(content, contentType, options);
             if (options.PerCallPolicy != null)
             {
                 message.SetProperty("RequestOptionsPerCallPolicyCallback", options.PerCallPolicy);
@@ -92,15 +92,15 @@ namespace media_types_LowLevel
         }
 
         /// <summary> Analyze body, that could be different media types. </summary>
-        /// <param name="contentType"> Upload file type. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
+        /// <param name="contentType"> Upload file type. </param>
         /// <param name="options"> The request options. </param>
 #pragma warning disable AZC0002
-        public virtual Response AnalyzeBody(string contentType, RequestContent content, RequestOptions options = null)
+        public virtual Response AnalyzeBody(RequestContent content, ContentType contentType, RequestOptions options = null)
 #pragma warning restore AZC0002
         {
             options ??= new RequestOptions();
-            HttpMessage message = CreateAnalyzeBodyRequest(contentType, content, options);
+            HttpMessage message = CreateAnalyzeBodyRequest(content, contentType, options);
             if (options.PerCallPolicy != null)
             {
                 message.SetProperty("RequestOptionsPerCallPolicyCallback", options.PerCallPolicy);
@@ -133,10 +133,10 @@ namespace media_types_LowLevel
         }
 
         /// <summary> Create Request for <see cref="AnalyzeBody"/> and <see cref="AnalyzeBodyAsync"/> operations. </summary>
-        /// <param name="contentType"> Upload file type. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
+        /// <param name="contentType"> Upload file type. </param>
         /// <param name="options"> The request options. </param>
-        private HttpMessage CreateAnalyzeBodyRequest(string contentType, RequestContent content, RequestOptions options = null)
+        private HttpMessage CreateAnalyzeBodyRequest(RequestContent content, ContentType contentType, RequestOptions options = null)
         {
             var message = Pipeline.CreateMessage();
             var request = message.Request;
@@ -146,7 +146,7 @@ namespace media_types_LowLevel
             uri.AppendPath("/mediatypes/analyze", false);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Content-Type", contentType);
+            request.Headers.Add("Content-Type", contentType.ToString());
             request.Content = content;
             return message;
         }


### PR DESCRIPTION
When an operation consumes multiple content types, the generated
operation method includes a parameter for the content type. For low
level clients, we'd like to use the new `Azure.Core.ContentType` type
for this parameter. In addition, we'd like it to come /after/ the
parameter for the body of the operation. This allows us to add helpers
where the content type is inferred while keeping the content in the
same location.

For example:

```csharp
// Hand authored overload that calls SendMessage(..., ContentType.TextPlain);
Response SendMessage(string s);
// Hand authored overload that calls SendMessage(..., ContentType.ApplicationOctetStream);
Response SendMessage(Stream s);
// Generated protocol method.
Response SendMessage(RequestContent content, ContentType contentType);
```

Fixes #1333
