### PR TITLE
Add `ToString` function to `OperationGroup` to get more readable error messages

### DIFF
--- a/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
@@ -226,5 +226,13 @@ namespace AutoRest.CSharp.Input
             }
         }
     }
+
+    internal partial class OperationGroup
+    {
+        public override string ToString()
+        {
+            return $"OperationGroup(Key: {Key})";
+        }
+    }
 }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.


### PR DESCRIPTION
# Description
Add `ToString` function to `OperationGroup` to make the exceptions more readable, since we are using those as keys of dictionaries everywhere.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first