### PR TITLE
Pass BaseUri along from container to restOperation

### DIFF
--- a/samples/Azure.Management.Storage/Generated/BlobContainerContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobContainerContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private BlobContainersRestOperations _restClient => new BlobContainersRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private BlobContainersRestOperations _restClient => new BlobContainersRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/BlobServiceContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobServiceContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private BlobServicesRestOperations _restClient => new BlobServicesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private BlobServicesRestOperations _restClient => new BlobServicesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/EncryptionScopeContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/EncryptionScopeContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private EncryptionScopesRestOperations _restClient => new EncryptionScopesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private EncryptionScopesRestOperations _restClient => new EncryptionScopesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/FileServiceContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/FileServiceContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private FileServicesRestOperations _restClient => new FileServicesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private FileServicesRestOperations _restClient => new FileServicesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/FileShareContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/FileShareContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private FileSharesRestOperations _restClient => new FileSharesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private FileSharesRestOperations _restClient => new FileSharesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/ManagementPolicyContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/ManagementPolicyContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ManagementPoliciesRestOperations _restClient => new ManagementPoliciesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ManagementPoliciesRestOperations _restClient => new ManagementPoliciesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ObjectReplicationPoliciesRestOperations _restClient => new ObjectReplicationPoliciesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ObjectReplicationPoliciesRestOperations _restClient => new ObjectReplicationPoliciesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private PrivateEndpointConnectionsRestOperations _restClient => new PrivateEndpointConnectionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private PrivateEndpointConnectionsRestOperations _restClient => new PrivateEndpointConnectionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.Management.Storage/Generated/RestApiContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/RestApiContainer.cs
@@ -22,7 +22,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private RestOperations _restClient => new RestOperations(_clientDiagnostics, Pipeline);
+        private RestOperations _restClient => new RestOperations(_clientDiagnostics, Pipeline, BaseUri);
 
         /// <summary> Initializes a new instance of the <see cref="RestApiContainer"/> class for mocking. </summary>
         protected RestApiContainer()

--- a/samples/Azure.Management.Storage/Generated/StorageAccountContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccountContainer.cs
@@ -35,7 +35,7 @@ namespace Azure.Management.Storage
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private StorageAccountsRestOperations _restClient => new StorageAccountsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private StorageAccountsRestOperations _restClient => new StorageAccountsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private DedicatedHostsRestOperations _restClient => new DedicatedHostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private DedicatedHostsRestOperations _restClient => new DedicatedHostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private DedicatedHostGroupsRestOperations _restClient => new DedicatedHostGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private DedicatedHostGroupsRestOperations _restClient => new DedicatedHostGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/ImageContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImageContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ImagesRestOperations _restClient => new ImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ImagesRestOperations _restClient => new ImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ProximityPlacementGroupsRestOperations _restClient => new ProximityPlacementGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ProximityPlacementGroupsRestOperations _restClient => new ProximityPlacementGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/RestApiContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestApiContainer.cs
@@ -21,7 +21,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private RestOperations _restClient => new RestOperations(_clientDiagnostics, Pipeline);
+        private RestOperations _restClient => new RestOperations(_clientDiagnostics, Pipeline, BaseUri);
 
         /// <summary> Initializes a new instance of the <see cref="RestApiContainer"/> class for mocking. </summary>
         protected RestApiContainer()

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SshPublicKeysRestOperations _restClient => new SshPublicKeysRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SshPublicKeysRestOperations _restClient => new SshPublicKeysRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachinesRestOperations _restClient => new VirtualMachinesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachinesRestOperations _restClient => new VirtualMachinesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachineExtensionsRestOperations _restClient => new VirtualMachineExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachineExtensionsRestOperations _restClient => new VirtualMachineExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSetsContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSetsContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachineScaleSetVMExtensionsRestOperations _restClient => new VirtualMachineScaleSetVMExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachineScaleSetVMExtensionsRestOperations _restClient => new VirtualMachineScaleSetVMExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachineScaleSetsRestOperations _restClient => new VirtualMachineScaleSetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachineScaleSetsRestOperations _restClient => new VirtualMachineScaleSetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachineScaleSetExtensionsRestOperations _restClient => new VirtualMachineScaleSetExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachineScaleSetExtensionsRestOperations _restClient => new VirtualMachineScaleSetExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMContainer.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMContainer.cs
@@ -34,7 +34,7 @@ namespace Azure.ResourceManager.Sample
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachineScaleSetVMsRestOperations _restClient => new VirtualMachineScaleSetVMsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachineScaleSetVMsRestOperations _restClient => new VirtualMachineScaleSetVMsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -30,6 +30,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
         protected override string RestClientField => "_" + RestClientVariable;
         protected override string RestClientAccessibility => "private";
         protected virtual string ContextProperty => "";
+        protected const string BaseUriField = "BaseUri";
 
         protected void WriteUsings(CodeWriter writer)
         {
@@ -46,7 +47,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
             writer.WriteXmlDocumentationSummary($"Represents the REST operations.");
             // subscriptionId might not always be needed. For example `RestOperations` does not have it.
             var subIdIfNeeded = restClient.Parameters.FirstOrDefault()?.Name == "subscriptionId" ? ", Id.SubscriptionId" : "";
-            writer.Line($"private {restClient.Type} {RestClientField} => new {restClient.Type}({ClientDiagnosticsField}, {PipelineProperty}{subIdIfNeeded});");
+            writer.Line($"private {restClient.Type} {RestClientField} => new {restClient.Type}({ClientDiagnosticsField}, {PipelineProperty}{subIdIfNeeded}, {BaseUriField});");
             writer.Line();
         }
 

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel1Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel1Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AzureResourceFlattenModel1SRestOperations _restClient => new AzureResourceFlattenModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AzureResourceFlattenModel1SRestOperations _restClient => new AzureResourceFlattenModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel2Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel2Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AzureResourceFlattenModel2SRestOperations _restClient => new AzureResourceFlattenModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AzureResourceFlattenModel2SRestOperations _restClient => new AzureResourceFlattenModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel3Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel3Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AzureResourceFlattenModel3SRestOperations _restClient => new AzureResourceFlattenModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AzureResourceFlattenModel3SRestOperations _restClient => new AzureResourceFlattenModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel4Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel4Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AzureResourceFlattenModel4SRestOperations _restClient => new AzureResourceFlattenModel4SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AzureResourceFlattenModel4SRestOperations _restClient => new AzureResourceFlattenModel4SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel5Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel5Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AzureResourceFlattenModel5SRestOperations _restClient => new AzureResourceFlattenModel5SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AzureResourceFlattenModel5SRestOperations _restClient => new AzureResourceFlattenModel5SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel2Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel2Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private CustomModel2SRestOperations _restClient => new CustomModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private CustomModel2SRestOperations _restClient => new CustomModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel3Container.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel3Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private CustomModel3SRestOperations _restClient => new CustomModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private CustomModel3SRestOperations _restClient => new CustomModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ExactMatchModel1SRestOperations _restClient => new ExactMatchModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ExactMatchModel1SRestOperations _restClient => new ExactMatchModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ExactMatchModel3SRestOperations _restClient => new ExactMatchModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ExactMatchModel3SRestOperations _restClient => new ExactMatchModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Container.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Container.cs
@@ -33,7 +33,7 @@ namespace ExactMatchInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ExactMatchModel5SRestOperations _restClient => new ExactMatchModel5SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ExactMatchModel5SRestOperations _restClient => new ExactMatchModel5SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetChildContainer.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetChildContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtOperations
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AvailabilitySetChildRestOperations _restClient => new AvailabilitySetChildRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AvailabilitySetChildRestOperations _restClient => new AvailabilitySetChildRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetContainer.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtOperations
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetGrandChildContainer.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetGrandChildContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtOperations
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AvailabilitySetGrandChildRestOperations _restClient => new AvailabilitySetGrandChildRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AvailabilitySetGrandChildRestOperations _restClient => new AvailabilitySetGrandChildRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtParent/Generated/AvailabilitySetContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/AvailabilitySetContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtParent
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtParent
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private DedicatedHostsRestOperations _restClient => new DedicatedHostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private DedicatedHostsRestOperations _restClient => new DedicatedHostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupContainer.cs
@@ -33,7 +33,7 @@ namespace MgmtParent
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private DedicatedHostGroupsRestOperations _restClient => new DedicatedHostGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private DedicatedHostGroupsRestOperations _restClient => new DedicatedHostGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageContainer.cs
+++ b/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtParent
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private VirtualMachineExtensionImagesRestOperations _restClient => new VirtualMachineExtensionImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private VirtualMachineExtensionImagesRestOperations _restClient => new VirtualMachineExtensionImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/MgmtSingleton/Generated/ParentResourceContainer.cs
+++ b/test/TestProjects/MgmtSingleton/Generated/ParentResourceContainer.cs
@@ -34,7 +34,7 @@ namespace MgmtSingleton
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ParentResourcesRestOperations _restClient => new ParentResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ParentResourcesRestOperations _restClient => new ParentResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetContainer.cs
+++ b/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetContainer.cs
@@ -33,7 +33,7 @@ namespace OperationGroupMappings
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AvailabilitySetsRestOperations _restClient => new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/ModelDataContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/ModelDataContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ModelDatasRestOperations _restClient => new ModelDatasRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ModelDatasRestOperations _restClient => new ModelDatasRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceGroupResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceGroupResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ResourceGroupResourcesRestOperations _restClient => new ResourceGroupResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ResourceGroupResourcesRestOperations _restClient => new ResourceGroupResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceLevelContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceLevelContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ResourceLevelsRestOperations _restClient => new ResourceLevelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ResourceLevelsRestOperations _restClient => new ResourceLevelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes2ResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes2ResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SubRes2ResourcesRestOperations _restClient => new SubRes2ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SubRes2ResourcesRestOperations _restClient => new SubRes2ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes3ResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes3ResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SubRes3ResourcesRestOperations _restClient => new SubRes3ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SubRes3ResourcesRestOperations _restClient => new SubRes3ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubResResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubResResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SubResResourcesRestOperations _restClient => new SubResResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SubResResourcesRestOperations _restClient => new SubResResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubscriptionLevelResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubscriptionLevelResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SubscriptionLevelResourcesRestOperations _restClient => new SubscriptionLevelResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SubscriptionLevelResourcesRestOperations _restClient => new SubscriptionLevelResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/TenantLevelResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/TenantLevelResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private TenantLevelResourcesRestOperations _restClient => new TenantLevelResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private TenantLevelResourcesRestOperations _restClient => new TenantLevelResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes2ResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes2ResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private WritableSubRes2ResourcesRestOperations _restClient => new WritableSubRes2ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private WritableSubRes2ResourcesRestOperations _restClient => new WritableSubRes2ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes3ResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes3ResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private WritableSubRes3ResourcesRestOperations _restClient => new WritableSubRes3ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private WritableSubRes3ResourcesRestOperations _restClient => new WritableSubRes3ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubResResourceContainer.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubResResourceContainer.cs
@@ -33,7 +33,7 @@ namespace ResourceIdentifierChooser
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private WritableSubResResourcesRestOperations _restClient => new WritableSubResResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private WritableSubResResourcesRestOperations _restClient => new WritableSubResResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SubscriptionExtensions/Generated/OvenContainer.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/OvenContainer.cs
@@ -35,7 +35,7 @@ namespace SubscriptionExtensions
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private OvensRestOperations _restClient => new OvensRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private OvensRestOperations _restClient => new OvensRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SubscriptionExtensions/Generated/ToasterContainer.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/ToasterContainer.cs
@@ -34,7 +34,7 @@ namespace SubscriptionExtensions
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ToastersRestOperations _restClient => new ToastersRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ToastersRestOperations _restClient => new ToastersRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel1Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel1Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private CustomModel1SRestOperations _restClient => new CustomModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private CustomModel1SRestOperations _restClient => new CustomModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel2Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel2Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private CustomModel2SRestOperations _restClient => new CustomModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private CustomModel2SRestOperations _restClient => new CustomModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel1Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel1Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ResourceModel1SRestOperations _restClient => new ResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ResourceModel1SRestOperations _restClient => new ResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel2Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel2Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private ResourceModel2SRestOperations _restClient => new ResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private ResourceModel2SRestOperations _restClient => new ResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel1Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel1Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SubResourceModel1SRestOperations _restClient => new SubResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SubResourceModel1SRestOperations _restClient => new SubResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel2Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel2Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SubResourceModel2SRestOperations _restClient => new SubResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SubResourceModel2SRestOperations _restClient => new SubResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel1Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel1Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private TrackedResourceModel1SRestOperations _restClient => new TrackedResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private TrackedResourceModel1SRestOperations _restClient => new TrackedResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel2Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel2Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private TrackedResourceModel2SRestOperations _restClient => new TrackedResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private TrackedResourceModel2SRestOperations _restClient => new TrackedResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel1Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel1Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private WritableSubResourceModel1SRestOperations _restClient => new WritableSubResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private WritableSubResourceModel1SRestOperations _restClient => new WritableSubResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel2Container.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel2Container.cs
@@ -33,7 +33,7 @@ namespace SupersetFlattenInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private WritableSubResourceModel2SRestOperations _restClient => new WritableSubResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private WritableSubResourceModel2SRestOperations _restClient => new WritableSubResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Container.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Container.cs
@@ -33,7 +33,7 @@ namespace SupersetInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SupersetModel1SRestOperations _restClient => new SupersetModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SupersetModel1SRestOperations _restClient => new SupersetModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Container.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Container.cs
@@ -33,7 +33,7 @@ namespace SupersetInheritance
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private SupersetModel4SRestOperations _restClient => new SupersetModel4SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private SupersetModel4SRestOperations _restClient => new SupersetModel4SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/TenantOnly/Generated/AgreementContainer.cs
+++ b/test/TestProjects/TenantOnly/Generated/AgreementContainer.cs
@@ -33,7 +33,7 @@ namespace TenantOnly
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private AgreementsRestOperations _restClient => new AgreementsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private AgreementsRestOperations _restClient => new AgreementsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;

--- a/test/TestProjects/TenantOnly/Generated/BillingAccountContainer.cs
+++ b/test/TestProjects/TenantOnly/Generated/BillingAccountContainer.cs
@@ -33,7 +33,7 @@ namespace TenantOnly
         private readonly ClientDiagnostics _clientDiagnostics;
 
         /// <summary> Represents the REST operations. </summary>
-        private BillingAccountsRestOperations _restClient => new BillingAccountsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId);
+        private BillingAccountsRestOperations _restClient => new BillingAccountsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
 
         /// <summary> Typed Resource Identifier for the container. </summary>
         public new ResourceGroupResourceIdentifier Id => base.Id as ResourceGroupResourceIdentifier;


### PR DESCRIPTION
# Description
BaseUri was not passed along to restOperation inside container, causing it always use `management.azure.com` endpoint.
This PR fixes that.

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first