### PR TITLE
refactor(generator): remove `int16` type

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -175,7 +175,6 @@ namespace AutoRest.CSharp.Generation.Types
             // Assumes AllSchemaTypes.Integer
             _ => schema.Precision switch
             {
-                16 => typeof(short),
                 64 => typeof(long),
                 _ => typeof(int)
             }


### PR DESCRIPTION
# Description

`int16` (or `short`) type is actually not supported in either swagger spec or in autorest.
- For swagger, see: https://docs.swagger.io/spec.html#431-primitives
- For autorest:
  - The supported integer formats are here: https://github.com/Azure/autorest/blob/7c68312403154a29770a1783fdca152a67fcc180/packages/libs/openapi/src/formats.ts#L51
  - In the modelfour test case, `int16` will be transformed to `int32`: https://github.com/Azure/autorest/blob/7c68312403154a29770a1783fdca152a67fcc180/packages/extensions/modelerfour/test/modeler/modelerfour.test.ts#L179

Besides, if we define `int16` or `short` as the `format`, autorest will print the warning messages like below:
```
WARNING (Modeler): Integer schema 'schemas:84' with unknown format: 'short' is not valid.  Treating it as 'int32'.
```

So we'd better remove it, to align with upstream specs.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first