### PR TITLE
Change to not writing GetResource() in [Resource] and it's operation class

### DIFF
--- a/samples/Azure.Management.Storage/Generated/BlobContainer.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobContainer.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the BlobContainerData. </summary>
         public BlobContainerData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override BlobContainer GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<BlobContainer> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/BlobService.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobService.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the BlobServiceData. </summary>
         public BlobServiceData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override BlobService GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<BlobService> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/EncryptionScope.cs
+++ b/samples/Azure.Management.Storage/Generated/EncryptionScope.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the EncryptionScopeData. </summary>
         public EncryptionScopeData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override EncryptionScope GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<EncryptionScope> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/FileService.cs
+++ b/samples/Azure.Management.Storage/Generated/FileService.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the FileServiceData. </summary>
         public FileServiceData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override FileService GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<FileService> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/FileShare.cs
+++ b/samples/Azure.Management.Storage/Generated/FileShare.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the FileShareData. </summary>
         public FileShareData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override FileShare GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<FileShare> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/ManagementPolicy.cs
+++ b/samples/Azure.Management.Storage/Generated/ManagementPolicy.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the ManagementPolicyData. </summary>
         public ManagementPolicyData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override ManagementPolicy GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<ManagementPolicy> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicy.cs
+++ b/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicy.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the ObjectReplicationPolicyData. </summary>
         public ObjectReplicationPolicyData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override ObjectReplicationPolicy GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<ObjectReplicationPolicy> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/PrivateEndpointConnection.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateEndpointConnection.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the PrivateEndpointConnectionData. </summary>
         public PrivateEndpointConnectionData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override PrivateEndpointConnection GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<PrivateEndpointConnection> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/StorageAccount.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccount.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Management.Storage.Models;
 using Azure.ResourceManager.Core;
 
@@ -25,17 +23,5 @@ namespace Azure.Management.Storage
 
         /// <summary> Gets or sets the StorageAccountData. </summary>
         public StorageAccountData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override StorageAccount GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<StorageAccount> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/StorageAccountOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccountOperations.cs
@@ -261,7 +261,7 @@ namespace Azure.Management.Storage
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new StorageAccountUpdateParameters();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -292,7 +292,7 @@ namespace Azure.Management.Storage
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new StorageAccountUpdateParameters();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -458,7 +458,7 @@ namespace Azure.Management.Storage
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new StorageAccountUpdateParameters();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -488,7 +488,7 @@ namespace Azure.Management.Storage
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new StorageAccountUpdateParameters();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySet.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySet.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the AvailabilitySetData. </summary>
         public AvailabilitySetData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override AvailabilitySet GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<AvailabilitySet> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetOperations.cs
@@ -220,7 +220,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new AvailabilitySetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -251,7 +251,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new AvailabilitySetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -417,7 +417,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new AvailabilitySetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -447,7 +447,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new AvailabilitySetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHost.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHost.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the DedicatedHostData. </summary>
         public DedicatedHostData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override DedicatedHost GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<DedicatedHost> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroup.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroup.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the DedicatedHostGroupData. </summary>
         public DedicatedHostGroupData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override DedicatedHostGroup GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<DedicatedHostGroup> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupOperations.cs
@@ -220,7 +220,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -251,7 +251,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -417,7 +417,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -447,7 +447,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostOperations.cs
@@ -220,7 +220,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -251,7 +251,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -417,7 +417,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -447,7 +447,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new DedicatedHostUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/Image.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Image.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the ImageData. </summary>
         public ImageData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override Image GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<Image> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/ImageOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImageOperations.cs
@@ -258,7 +258,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ImageUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -289,7 +289,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ImageUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -455,7 +455,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ImageUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -485,7 +485,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ImageUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroup.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroup.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the ProximityPlacementGroupData. </summary>
         public ProximityPlacementGroupData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override ProximityPlacementGroup GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<ProximityPlacementGroup> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupOperations.cs
@@ -258,7 +258,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ProximityPlacementGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -289,7 +289,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ProximityPlacementGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -455,7 +455,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ProximityPlacementGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -485,7 +485,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new ProximityPlacementGroupUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKey.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKey.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the SshPublicKeyData. </summary>
         public SshPublicKeyData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override SshPublicKey GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<SshPublicKey> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyOperations.cs
@@ -220,7 +220,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new SshPublicKeyUpdateResource();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -251,7 +251,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new SshPublicKeyUpdateResource();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -417,7 +417,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new SshPublicKeyUpdateResource();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -447,7 +447,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new SshPublicKeyUpdateResource();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachine.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachine.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineData. </summary>
         public VirtualMachineData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachine GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachine> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtension.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtension.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineExtensionData. </summary>
         public VirtualMachineExtensionData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachineExtension GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachineExtension> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImage.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImage.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineExtensionImageData. </summary>
         public VirtualMachineExtensionImageData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachineExtensionImage GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachineExtensionImage> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionOperations.cs
@@ -258,7 +258,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -289,7 +289,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -455,7 +455,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -485,7 +485,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSet.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSet.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineExtensionData. </summary>
         public VirtualMachineExtensionData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachineExtensionVirtualMachineScaleSet GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachineExtensionVirtualMachineScaleSet> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSetOperations.cs
@@ -258,7 +258,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -289,7 +289,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -455,7 +455,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -485,7 +485,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineExtensionUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineOperations.cs
@@ -224,7 +224,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -255,7 +255,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -421,7 +421,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -451,7 +451,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSet.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSet.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineScaleSetData. </summary>
         public VirtualMachineScaleSetData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachineScaleSet GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachineScaleSet> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtension.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtension.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineScaleSetExtensionData. </summary>
         public VirtualMachineScaleSetExtensionData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachineScaleSetExtension GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachineScaleSetExtension> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetOperations.cs
@@ -220,7 +220,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineScaleSetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -251,7 +251,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineScaleSetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags[key] = value;
@@ -417,7 +417,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineScaleSetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);
@@ -447,7 +447,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 var patchable = new VirtualMachineScaleSetUpdate();
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
                 patchable.Tags.Remove(key);

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVM.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVM.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Sample
@@ -24,17 +22,5 @@ namespace Azure.ResourceManager.Sample
 
         /// <summary> Gets or sets the VirtualMachineScaleSetVMData. </summary>
         public VirtualMachineScaleSetVMData Data { get; private set; }
-
-        /// <inheritdoc />
-        protected override VirtualMachineScaleSetVM GetResource(CancellationToken cancellation = default)
-        {
-            return this;
-        }
-
-        /// <inheritdoc />
-        protected override Task<VirtualMachineScaleSetVM> GetResourceAsync(CancellationToken cancellation = default)
-        {
-            return Task.FromResult(this);
-        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMOperations.cs
@@ -220,7 +220,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 Id.TryGetLocation(out LocationData locationData);
                 var patchable = new VirtualMachineScaleSetVMData(locationData);
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
@@ -252,7 +252,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 Id.TryGetLocation(out LocationData locationData);
                 var patchable = new VirtualMachineScaleSetVMData(locationData);
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
@@ -421,7 +421,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 Id.TryGetLocation(out LocationData locationData);
                 var patchable = new VirtualMachineScaleSetVMData(locationData);
                 patchable.Tags.ReplaceWith(resource.Data.Tags);
@@ -452,7 +452,7 @@ namespace Azure.ResourceManager.Sample
             scope.Start();
             try
             {
-                var resource = GetResource();
+                var resource = Get();
                 Id.TryGetLocation(out LocationData locationData);
                 var patchable = new VirtualMachineScaleSetVMData(locationData);
                 patchable.Tags.ReplaceWith(resource.Data.Tags);

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
@@ -512,7 +512,7 @@ Check the swagger definition, and use 'operation-group-to-resource' directive to
                 {
                     var updateParameterType = clientMethod.NonPathParameters.FirstOrDefault().Type;
                     var resourceVar = new CodeWriterDeclaration("resource");
-                    writer.Line($"var {resourceVar:D} = GetResource();");
+                    writer.Line($"var {resourceVar:D} = Get();");
                     var patchable = new CodeWriterDeclaration("patchable");
                     if (clientMethod.Request.HttpMethod == RequestMethod.Put)
                     {
@@ -717,7 +717,7 @@ Check the swagger definition, and use 'operation-group-to-resource' directive to
                 {
                     var updateParameterType = clientMethod.NonPathParameters.FirstOrDefault().Type;
                     var resourceVar = new CodeWriterDeclaration("resource");
-                    writer.Line($"var {resourceVar:D} = GetResource();");
+                    writer.Line($"var {resourceVar:D} = Get();");
                     var patchable = new CodeWriterDeclaration("patchable");
                     if (clientMethod.Request.HttpMethod == RequestMethod.Put)
                     {

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceWriter.cs
@@ -48,30 +48,6 @@ namespace AutoRest.CSharp.Mgmt.Generation
                     writer.Append($"public {resourceDataObject.Type} Data");
                     writer.Append($"{{ get; private set; }}");
                     writer.Line();
-
-                    // Only write GetResource if it is NOT singleton.
-                    if (!resource.OperationGroup.IsSingletonResource(context.Configuration.MgmtConfiguration))
-                    {
-                        // protected override GetResource
-                        writer.Line();
-                        writer.WriteXmlDocumentationInheritDoc();
-                        using (writer.Scope(
-                            $"protected override {cs.Name} GetResource({typeof(CancellationToken)} cancellation = default)")
-                        )
-                        {
-                            writer.LineRaw("return this;");
-                        }
-
-                        // protected override GetResourceAsync
-                        writer.Line();
-                        writer.WriteXmlDocumentationInheritDoc();
-                        using (writer.Scope(
-                            $"protected override {typeof(Task)}<{cs.Name}> GetResourceAsync({typeof(CancellationToken)} cancellation = default)")
-                        )
-                        {
-                            writer.Line($"return {typeof(Task)}.FromResult(this);");
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
Writers need to emit writing GetResource() since it has been removed in ResourceOperationsBase in Azure.ResourceManager.Core.
# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first