### PR TITLE
fix(generator): add xml comments to valid resource type property

### DIFF
--- a/samples/Azure.Management.Storage/Generated/BlobContainerOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobContainerOperations.cs
@@ -37,7 +37,9 @@ namespace Azure.Management.Storage
             _restClient = new BlobContainersRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/blobServices/default/containers";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/BlobServiceOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobServiceOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.Management.Storage
             _restClient = new BlobServicesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/blobServices";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/EncryptionScopeOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/EncryptionScopeOperations.cs
@@ -37,7 +37,9 @@ namespace Azure.Management.Storage
             _restClient = new EncryptionScopesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/encryptionScopes";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/FileServiceOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/FileServiceOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.Management.Storage
             _restClient = new FileServicesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/fileServices";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/FileShareOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/FileShareOperations.cs
@@ -37,7 +37,9 @@ namespace Azure.Management.Storage
             _restClient = new FileSharesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/fileServices/default/shares";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/ManagementPolicyOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/ManagementPolicyOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.Management.Storage
             _restClient = new ManagementPoliciesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/managementPolicies";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/ObjectReplicationPolicyOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.Management.Storage
             _restClient = new ObjectReplicationPoliciesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/objectReplicationPolicies";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/PrivateEndpointConnectionOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.Management.Storage
             _restClient = new PrivateEndpointConnectionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts/privateEndpointConnections";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.Management.Storage/Generated/StorageAccountOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/StorageAccountOperations.cs
@@ -39,7 +39,9 @@ namespace Azure.Management.Storage
             _privateLinkResourcesRestClient = new PrivateLinkResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Storage/storageAccounts";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new DedicatedHostGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/hostGroups";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new DedicatedHostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/hostGroups/hosts";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/ImageOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImageOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new ImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/images";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new ProximityPlacementGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/proximityPlacementGroups";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new SshPublicKeysRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/sshPublicKeys";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachineExtensionImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/locations/publishers/vmextension";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachineExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachines/extensions";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionVirtualMachineScaleSetOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachineScaleSetVMExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/extensions";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachinesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachines";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachineScaleSetExtensionsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachineScaleSets/extensions";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachineScaleSetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachineScaleSets";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeOperations.cs
@@ -25,7 +25,9 @@ namespace Azure.ResourceManager.Sample
         {
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachineScaleSets/rollingUpgrades";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVMOperations.cs
@@ -36,7 +36,9 @@ namespace Azure.ResourceManager.Sample
             _restClient = new VirtualMachineScaleSetVMsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachineScaleSets/virtualmachines";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
@@ -158,7 +158,9 @@ Check the swagger definition, and use 'operation-group-to-resource' directive to
         private void WriteClientProperties(CodeWriter writer, ResourceOperation resourceOperation, MgmtConfiguration config)
         {
             writer.Line();
+            writer.WriteXmlDocumentationSummary($"Gets the resource type for the operation group");
             writer.Line($"public static readonly {typeof(ResourceType)} ResourceType = \"{resourceOperation.OperationGroup.ResourceType(config)}\";");
+            writer.WriteXmlDocumentationSummary($"Gets the valid resource type for this object");
             writer.Line($"protected override {typeof(ResourceType)} ValidResourceType => ResourceType;");
         }
 

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
@@ -158,7 +158,7 @@ Check the swagger definition, and use 'operation-group-to-resource' directive to
         private void WriteClientProperties(CodeWriter writer, ResourceOperation resourceOperation, MgmtConfiguration config)
         {
             writer.Line();
-            writer.WriteXmlDocumentationSummary($"Gets the resource type for the operation group");
+            writer.WriteXmlDocumentationSummary($"Gets the resource type for the operations");
             writer.Line($"public static readonly {typeof(ResourceType)} ResourceType = \"{resourceOperation.OperationGroup.ResourceType(config)}\";");
             writer.WriteXmlDocumentationSummary($"Gets the valid resource type for the operations");
             writer.Line($"protected override {typeof(ResourceType)} ValidResourceType => ResourceType;");

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceOperationWriter.cs
@@ -160,7 +160,7 @@ Check the swagger definition, and use 'operation-group-to-resource' directive to
             writer.Line();
             writer.WriteXmlDocumentationSummary($"Gets the resource type for the operation group");
             writer.Line($"public static readonly {typeof(ResourceType)} ResourceType = \"{resourceOperation.OperationGroup.ResourceType(config)}\";");
-            writer.WriteXmlDocumentationSummary($"Gets the valid resource type for this object");
+            writer.WriteXmlDocumentationSummary($"Gets the valid resource type for the operations");
             writer.Line($"protected override {typeof(ResourceType)} ValidResourceType => ResourceType;");
         }
 

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel1Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel1Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new AzureResourceFlattenModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/azureResourceFlattenModel1";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel2Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel2Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new AzureResourceFlattenModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/azureResourceFlattenModel2";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel3Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel3Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new AzureResourceFlattenModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/azureResourceFlattenModel3";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel4Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel4Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new AzureResourceFlattenModel4SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/azureResourceFlattenModel4";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel5Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel5Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new AzureResourceFlattenModel5SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/azureResourceFlattenModel5";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel2Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel2Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new CustomModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/customModel2";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel3Operations.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/CustomModel3Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchFlattenInheritance
             _restClient = new CustomModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/customModel3";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel1Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchInheritance
             _restClient = new ExactMatchModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/exactMatchModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel3Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchInheritance
             _restClient = new ExactMatchModel3SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/exactMatchModel3s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Operations.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/ExactMatchModel5Operations.cs
@@ -36,7 +36,9 @@ namespace ExactMatchInheritance
             _restClient = new ExactMatchModel5SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/exactMatchModel5s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtListOnly/Generated/FakeOperations.cs
+++ b/test/TestProjects/MgmtListOnly/Generated/FakeOperations.cs
@@ -42,7 +42,9 @@ namespace MgmtListOnly
             _childWithPostsRestClient = new ChildWithPostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Fake/fakes";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/AnotherParentOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/AnotherParentOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtMultipleParentResource
             _restClient = new AnotherParentsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/anotherParents";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/ChildBodyAnotherParentOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/ChildBodyAnotherParentOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtMultipleParentResource
             _restClient = new AnotherChildrenRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/anotherParents/children";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/ChildBodySubParentOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/ChildBodySubParentOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtMultipleParentResource
             _restClient = new ChildrenRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/parents/subParents/children";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/ParentOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/ParentOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtMultipleParentResource
             _restClient = new ParentsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/parents";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/SubParentOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/SubParentOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtMultipleParentResource
             _restClient = new SubParentsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/parents/subParents";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetChildOperations.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetChildOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtOperations
             _restClient = new AvailabilitySetChildRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets/availabilitySetChild";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetGrandChildOperations.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetGrandChildOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtOperations
             _restClient = new AvailabilitySetGrandChildRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets/availabilitySetChild/availabilitySetGrandChild";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetOperations.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetOperations.cs
@@ -37,7 +37,9 @@ namespace MgmtOperations
             _restClient = new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/AvailabilitySetOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/AvailabilitySetOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtParent
             _restClient = new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtParent
             _restClient = new DedicatedHostGroupsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/hostGroups";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtParent
             _restClient = new DedicatedHostsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/hostGroups/hosts";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtParent
             _restClient = new VirtualMachineExtensionImagesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/locations/publishers/vmextension";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtPropertyChooser/Generated/VirtualMachineOperations.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/VirtualMachineOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtPropertyChooser
             _restClient = new VirtualMachinesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachines";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtSingleton/Generated/ParentResourceOperations.cs
+++ b/test/TestProjects/MgmtSingleton/Generated/ParentResourceOperations.cs
@@ -36,7 +36,9 @@ namespace MgmtSingleton
             _restClient = new ParentResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/parentResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/MgmtSingleton/Generated/SingletonResource2Operations.cs
+++ b/test/TestProjects/MgmtSingleton/Generated/SingletonResource2Operations.cs
@@ -25,7 +25,9 @@ namespace MgmtSingleton
         {
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/parentResources/singletonResources2";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
     }
 }

--- a/test/TestProjects/MgmtSingleton/Generated/SingletonResourceOperations.cs
+++ b/test/TestProjects/MgmtSingleton/Generated/SingletonResourceOperations.cs
@@ -25,7 +25,9 @@ namespace MgmtSingleton
         {
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/parentResources/singletonResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
     }
 }

--- a/test/TestProjects/MgmtSingleton/Generated/SubscriptionParentSingletonOperations.cs
+++ b/test/TestProjects/MgmtSingleton/Generated/SubscriptionParentSingletonOperations.cs
@@ -25,7 +25,9 @@ namespace MgmtSingleton
         {
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/SubscriptionParentSingleton/default";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
     }
 }

--- a/test/TestProjects/MgmtSingleton/Generated/TenantParentSingletonOperations.cs
+++ b/test/TestProjects/MgmtSingleton/Generated/TenantParentSingletonOperations.cs
@@ -25,7 +25,9 @@ namespace MgmtSingleton
         {
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/TenantParentSingleton/default";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
     }
 }

--- a/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetOperations.cs
+++ b/test/TestProjects/OperationGroupMappings/Generated/AvailabilitySetOperations.cs
@@ -36,7 +36,9 @@ namespace OperationGroupMappings
             _restClient = new AvailabilitySetsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeDecimalModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeDecimalModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeDecimalModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeDecimalModel";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeDoubleModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeDoubleModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeDoubleModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeDoubleModel";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeFloatModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeFloatModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeFloatModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeFloatModel";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeInt32ModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeInt32ModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeInt32ModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeInt32Model";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeInt64ModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeInt64ModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeInt64ModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeInt64Model";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeIntegerModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeIntegerModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeIntegerModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeIntegerModel";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeNumericModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeNumericModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeNumericModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeNumericModel";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/Pagination/Generated/PageSizeStringModelOperations.cs
+++ b/test/TestProjects/Pagination/Generated/PageSizeStringModelOperations.cs
@@ -36,7 +36,9 @@ namespace Pagination
             _restClient = new PageSizeStringModelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/pageSizeStringModel";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/ModelDataOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/ModelDataOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new ModelDatasRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Network/ModelDatas";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceGroupResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceGroupResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new ResourceGroupResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/ResourceGroupResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceLevelOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/ResourceLevelOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new ResourceLevelsRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Network/ResourceLevels";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes2ResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes2ResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new SubRes2ResourcesRestOperations(_clientDiagnostics, Pipeline, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/SubRes2Resources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes3ResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubRes3ResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new SubRes3ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/SubRes3Resources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubResResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubResResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new SubResResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/SubResResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/SubscriptionLevelResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/SubscriptionLevelResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new SubscriptionLevelResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/SubscriptionLevelResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/TenantLevelResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/TenantLevelResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new TenantLevelResourcesRestOperations(_clientDiagnostics, Pipeline, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/TenantLevelResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes2ResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes2ResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new WritableSubRes2ResourcesRestOperations(_clientDiagnostics, Pipeline, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/WritableSubRes2Resources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes3ResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubRes3ResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new WritableSubRes3ResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/WritableSubRes3Resources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubResResourceOperations.cs
+++ b/test/TestProjects/ResourceIdentifierChooser/Generated/WritableSubResResourceOperations.cs
@@ -36,7 +36,9 @@ namespace ResourceIdentifierChooser
             _restClient = new WritableSubResResourcesRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/WritableSubResResources";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SubscriptionExtensions/Generated/OvenOperations.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/OvenOperations.cs
@@ -36,7 +36,9 @@ namespace SubscriptionExtensions
             _restClient = new OvensRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/virtualMachines";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SubscriptionExtensions/Generated/ToasterOperations.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/ToasterOperations.cs
@@ -36,7 +36,9 @@ namespace SubscriptionExtensions
             _restClient = new ToastersRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/availabilitySets";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel1Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel1Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new CustomModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/customModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel2Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/CustomModel2Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new CustomModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/customModel2s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel1Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel1Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new ResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/resourceModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel2Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/ResourceModel2Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new ResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/resourceModel2s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel1Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel1Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new SubResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/subResourceModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel2Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/SubResourceModel2Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new SubResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/subResourceModel2s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel1Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel1Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new TrackedResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/trackedResourceModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel2Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/TrackedResourceModel2Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new TrackedResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/trackedResourceModel2s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel1Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel1Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new WritableSubResourceModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/writableSubResourceModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel2Operations.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/WritableSubResourceModel2Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetFlattenInheritance
             _restClient = new WritableSubResourceModel2SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/writableSubResourceModel2s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Operations.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel1Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetInheritance
             _restClient = new SupersetModel1SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/supersetModel1s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Operations.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/SupersetModel4Operations.cs
@@ -36,7 +36,9 @@ namespace SupersetInheritance
             _restClient = new SupersetModel4SRestOperations(_clientDiagnostics, Pipeline, Id.SubscriptionId, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Compute/supersetModel4s";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/TenantOnly/Generated/AgreementOperations.cs
+++ b/test/TestProjects/TenantOnly/Generated/AgreementOperations.cs
@@ -36,7 +36,9 @@ namespace TenantOnly
             _restClient = new AgreementsRestOperations(_clientDiagnostics, Pipeline, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/billingAccounts/agreements";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />

--- a/test/TestProjects/TenantOnly/Generated/BillingAccountOperations.cs
+++ b/test/TestProjects/TenantOnly/Generated/BillingAccountOperations.cs
@@ -36,7 +36,9 @@ namespace TenantOnly
             _restClient = new BillingAccountsRestOperations(_clientDiagnostics, Pipeline, BaseUri);
         }
 
+        /// <summary> Gets the resource type for the operations. </summary>
         public static readonly ResourceType ResourceType = "Microsoft.Billing/billingAccounts";
+        /// <summary> Gets the valid resource type for the operations. </summary>
         protected override ResourceType ValidResourceType => ResourceType;
 
         /// <inheritdoc />


### PR DESCRIPTION
# Description

`ResourceType` and `ValidResourceType` in generated codes do not have xml comments, which will result in CS1591 compiler error.
This commit will add the summary comment to resolve CS1591.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first