### PR TITLE
fix(generator): error when generating non resource long running method

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationHelper.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationHelper.cs
@@ -31,11 +31,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                 // 2. some operations belong to non-resource
                 if (context.Library.TryGetResourceData(operationGroup, out var resourceData))
                 {
-                    var resourceDataType = resourceData.Type;
-                    if (resultType.Name.Equals(resourceDataType.Name))
-                    {
-                        return true;
-                    }
+                    return resultType.Name.Equals(resourceData.Type.Name);
                 }
             }
             return false;

--- a/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationHelper.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationHelper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
+using AutoRest.CSharp.Mgmt.Output;
 using AutoRest.CSharp.Output.Models.Types;
 
 namespace AutoRest.CSharp.Mgmt.Decorator
@@ -25,12 +26,16 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                 && operation.Requests.FirstOrDefault().Protocol.Http is HttpRequest httpRequest
                 && (httpRequest.Method == HttpMethod.Put || httpRequest.Method == HttpMethod.Patch))
             {
-                // need to check result type is [Resource]Data because
-                // some PUT operation returns differently and we don't want to wrap that with [Resource]
-                var resourceDataType = context.Library.GetResourceData(operationGroup).Type;
-                if (resultType.Name.Equals(resourceDataType.Name))
+                // need to check result type is [Resource]Data because:
+                // 1. some PUT operation returns differently and we don't want to wrap that with [Resource]
+                // 2. some operations belong to non-resource
+                if (context.Library.TryGetResourceData(operationGroup, out var resourceData))
                 {
-                    return true;
+                    var resourceDataType = resourceData.Type;
+                    if (resultType.Name.Equals(resourceDataType.Name))
+                    {
+                        return true;
+                    }
                 }
             }
             return false;


### PR DESCRIPTION
# Description

Non-resource case is missing from the current logic of judging whether to wrap the return type.
This commit will first check if the operation is regarding a non-resource type. If so, return false directly.

See [this API](https://github.com/Azure/azure-rest-api-specs/blob/e0b9ed9e1913aa30da29062715bc14bd38113776/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/networkVirtualAppliance.json#L686) as an example.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first