### PR TITLE
[LLC] Fix StyleCop error in `LowLevelBinaryDataOperation`

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-#pragma warning disable AD0001 // Doesn't understand record decleration, and the anaylizer throws an exception.
-#pragma warning disable SA1649 // Doesn't understand record decleration, and the anaylizer throws an exception.
-
 using AutoRest.CSharp.Generation.Types;
 
 namespace AutoRest.CSharp.Output.Models.Shared

--- a/src/assets/Generator.Shared/LowLevelBinaryDataOperation.cs
+++ b/src/assets/Generator.Shared/LowLevelBinaryDataOperation.cs
@@ -55,5 +55,4 @@ namespace Azure.Core
 
         ValueTask<BinaryData> IOperationSource<BinaryData>.CreateResultAsync(Response response, CancellationToken cancellationToken) => new ValueTask<BinaryData>(response.Content);
     }
-
 }


### PR DESCRIPTION
An extra blank line was causing StyleCop errors when we tried to
update some packages in azure-sdk-for-net. This fixes the stylecop
error (and cleans up a supression we had in our code base we no longer
need)