### PR TITLE
Fix #1313: CodeGenSuppress with non-existant types crashes autorest.csharp in LLC mode

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/MemberRemoverRewriter.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/MemberRemoverRewriter.cs
@@ -144,9 +144,11 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                     {
                         if (argument.Value is IErrorTypeSymbol errorType)
                         {
-                            var fullName = typeSymbol.ToDisplayString(_fullyQualifiedNameFormat);
                             var attribute = attributeData.ApplicationSyntaxReference.GetText();
-                            ErrorHelpers.ThrowError($"Type '{errorType.Name}' is not defined in attribute '{attribute}' applied to '{fullName}'.");
+                            var fileLinePosition = attributeData.ApplicationSyntaxReference.GetFileLinePosition();
+                            var filePath = fileLinePosition.Path;
+                            var line = fileLinePosition.StartLinePosition.Line + 1;
+                            ErrorHelpers.ThrowError($"The undefined type '{errorType.Name}' is referenced in the '{attribute}' attribute ({filePath}, line: {line}). Please define this type or remove it from the attribute.");
                         }
                     }
                     else

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/MemberRemoverRewriter.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/MemberRemoverRewriter.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
+using AutoRest.CSharp.Utilities;
 using Azure.Core;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -93,6 +95,8 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             {
                 if (attributeData.AttributeClass?.Equals(_suppressAttribute) == true)
                 {
+                    ValidateArguments(namedTypeSymbol, attributeData);
+
                     suppressions ??= new List<Supression>();
                     var name = attributeData.ConstructorArguments[0].Value as string;
                     var parameterTypes = attributeData.ConstructorArguments[1].Values.Select(v => (ISymbol?)v.Value).ToArray();
@@ -105,6 +109,54 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 _suppressionCache.Add(namedTypeSymbol, suppressions);
             }
             return suppressions;
+
+            static void ValidateArguments(INamedTypeSymbol typeSymbol, AttributeData attributeData)
+            {
+                var arguments = attributeData.ConstructorArguments;
+                if (arguments.Length == 0)
+                {
+                    var fullName = typeSymbol.ToDisplayString(_fullyQualifiedNameFormat);
+                    ErrorHelpers.ThrowError($"CodeGenSuppress attribute on {fullName} must specify a method name as its first argument.");
+                }
+
+                if (arguments.Length == 1 || arguments[0].Kind != TypedConstantKind.Primitive || arguments[0].Value is not string)
+                {
+                    var attribute = attributeData.ApplicationSyntaxReference.GetText();
+                    var fullName = typeSymbol.ToDisplayString(_fullyQualifiedNameFormat);
+                    ErrorHelpers.ThrowError($"{attribute} attribute on {fullName} must specify a method name as its first argument.");
+                }
+
+                if (arguments.Length == 2 && arguments[1].Kind == TypedConstantKind.Array)
+                {
+                    ValidateTypeArguments(typeSymbol, attributeData, arguments[1].Values);
+                }
+                else
+                {
+                    ValidateTypeArguments(typeSymbol, attributeData, arguments.Skip(1));
+                }
+            }
+
+            static void ValidateTypeArguments(INamedTypeSymbol typeSymbol, AttributeData attributeData, IEnumerable<TypedConstant> arguments)
+            {
+                foreach (var argument in arguments)
+                {
+                    if (argument.Kind == TypedConstantKind.Type)
+                    {
+                        if (argument.Value is IErrorTypeSymbol errorType)
+                        {
+                            var fullName = typeSymbol.ToDisplayString(_fullyQualifiedNameFormat);
+                            var attribute = attributeData.ApplicationSyntaxReference.GetText();
+                            ErrorHelpers.ThrowError($"Type '{errorType.Name}' is not defined in attribute '{attribute}' applied to '{fullName}'.");
+                        }
+                    }
+                    else
+                    {
+                        var fullName = typeSymbol.ToDisplayString(_fullyQualifiedNameFormat);
+                        var attribute = attributeData.ApplicationSyntaxReference.GetText();
+                        ErrorHelpers.ThrowError($"Argument '{argument.ToCSharpString()}' in attribute '{attribute}' applied to '{fullName}' must be a type.");
+                    }
+                }
+            }
         }
 
         private bool IsSuppressedType(BaseTypeDeclarationSyntax typeSyntax)

--- a/src/AutoRest.CSharp/Common/Utilities/SyntaxReferenceExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Utilities/SyntaxReferenceExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace AutoRest.CSharp.Utilities
+{
+    internal static class SyntaxReferenceExtensions
+    {
+        public static string GetText(this SyntaxReference? syntaxReference)
+            => syntaxReference?.SyntaxTree.GetText().ToString(syntaxReference.Span) ?? string.Empty;
+    }
+}

--- a/src/AutoRest.CSharp/Common/Utilities/SyntaxReferenceExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Utilities/SyntaxReferenceExtensions.cs
@@ -9,5 +9,8 @@ namespace AutoRest.CSharp.Utilities
     {
         public static string GetText(this SyntaxReference? syntaxReference)
             => syntaxReference?.SyntaxTree.GetText().ToString(syntaxReference.Span) ?? string.Empty;
+
+        public static FileLinePositionSpan GetFileLinePosition(this SyntaxReference? syntaxReference)
+            => syntaxReference?.SyntaxTree.GetLocation(syntaxReference.Span).GetLineSpan() ?? default;
     }
 }


### PR DESCRIPTION
The error happens because Roslyn can't resolve the reference to a type that doesn't exist (it doesn't exist anymore because generator has been switched to LLC). While failure happens in codegen, the issue is in fact in the user customization file.