### PR TITLE
Use PropertyReferenceType from Core package and do not generate them in other RP packages

### DIFF
--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -15,9 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.16.0" />
+    <PackageReference Include="Azure.Core" Version="1.17.0" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.12" />
-    <PackageReference Include="Azure.ResourceManager" Version="1.0.0-alpha.20210730.2" />
+    <!-- <PackageReference Include="Azure.ResourceManager" Version="1.0.0-alpha.20210730.2" /> -->
+    <ProjectReference Include="../../../azure-sdk-for-net/sdk/resourcemanager/Azure.ResourceManager/src/Azure.ResourceManager.csproj" />
     <PackageReference Include="Humanizer.Core" Version="2.11.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0-1.final" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/src/AutoRest.CSharp/Common/Generation/Writers/JsonCodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/JsonCodeWriterExtensions.cs
@@ -522,6 +522,11 @@ namespace AutoRest.CSharp.Generation.Writers
                 writer.Append($"({frameworkType}){element}.GetString()");
                 return;
             }
+            else if (frameworkType.Namespace?.StartsWith("Azure.ResourceManager") == true)
+            {
+                writer.Append($"{frameworkType}.Deserialize{frameworkType.Name}({element})");
+                return;
+            }
             else
                 writer.Append($"{element}.");
 

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -87,9 +87,9 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
                 foreach (var operation in operationGroup.Operations)
                 {
                     var curName = operation.Language.Default.Name;
-                    if (curName.Equals("List"))
+                    if (curName.Equals("List") || curName.StartsWith("ListBy"))
                     {
-                        operation.Language.Default.Name = "GetAll";
+                        operation.Language.Default.Name = curName.Replace("List", "GetAll");
                     }
                     else if (curName.Equals("ListAll"))
                     {

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -8,6 +8,7 @@ using AutoRest.CSharp.Input.Source;
 using AutoRest.CSharp.Mgmt.AutoRest;
 using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Mgmt.Generation;
+using AutoRest.CSharp.Mgmt.Output;
 using AutoRest.CSharp.Output.Models.Types;
 
 namespace AutoRest.CSharp.AutoRest.Plugins
@@ -26,6 +27,19 @@ namespace AutoRest.CSharp.AutoRest.Plugins
 
             foreach (var model in context.Library.Models)
             {
+                // For the shared models in Core and Resources/Management, we should generate them in Core package and skip in Resources/Management package.
+                if (context.Configuration.LibraryName != "Core")
+                {
+                    if (context.SourceInputModel?.FindForType($"{model.Declaration.Namespace}", model.Declaration.Name) != null)
+                    {
+                        continue;
+                    }
+                    var mgmtObj = model as MgmtObjectType;
+                    if (mgmtObj != null && ReferenceTypePropertyChooser.GetExactMatch(mgmtObj) != null)
+                    {
+                        continue;
+                    }
+                }
                 var codeWriter = new CodeWriter();
                 modelWriter.WriteModel(codeWriter, model);
 

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -465,7 +465,6 @@ namespace AutoRest.CSharp.Mgmt.Generation
             }
 
             MakeResourceNameParamPassThrough(method, parameterMapping, parentNameStack);
-            MakeByIdParamPassThrough(method, parameterMapping, parentNameStack);
 
             // set the arguments for name parameters reversely: Id.Parent.Name, Id.Parent.Parent.Name, ...
             foreach (var parameter in parameterMapping)
@@ -473,8 +472,8 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 if (IsMandatory(parameter.Parameter) && !parameter.IsPassThru && string.IsNullOrEmpty(parameter.ValueExpression))
                 {
                     var parentName = parentNameStack.Pop();
-                    // scope is a whole Id, remove ".Name" for it.
-                    parameter.ValueExpression = parameter.Parameter.Name == "scope" ? parentName.Substring(0, parentName.LastIndexOf(".Name")) : parentName;
+                    // {scope} or {resourceId} is a whole Id, remove ".Name" for it.
+                    parameter.ValueExpression = (parameter.Parameter.Name == "scope" || method.IsByIdMethod()) ? parentName.Substring(0, parentName.LastIndexOf(".Name")) : parentName;
                 }
             }
 
@@ -482,20 +481,6 @@ namespace AutoRest.CSharp.Mgmt.Generation
         }
 
         protected abstract void MakeResourceNameParamPassThrough(RestClientMethod method, List<ParameterMapping> parameterMapping, Stack<string> parentNameStack);
-
-        protected virtual void MakeByIdParamPassThrough(RestClientMethod method, List<ParameterMapping> parameterMapping, Stack<string> parentNameStack)
-        {
-            var request = method.Operation?.Requests.FirstOrDefault(r => r.Protocol.Http is HttpRequest);
-            if (method.IsByIdMethod())
-            {
-                var firstString = parameterMapping.FirstOrDefault(parameter => parameter.Parameter.Name.Equals(method.Parameters[0].Name, StringComparison.InvariantCultureIgnoreCase));
-                if (firstString?.Parameter != null)
-                {
-                    firstString.IsPassThru = true;
-                    firstString.Parameter = firstString.Parameter with { Type = typeof(ResourceIdentifier) };
-                }
-            }
-        }
 
         protected abstract bool ShouldPassThrough(ref string dotParent, Stack<string> parentNameStack, Parameter parameter, ref string valueExpression);
 


### PR DESCRIPTION
# Description
This PR fixed some cases of Property matching for Resources SDK so that for the shared models with Core package, Resources SDK will reference them from vCore and do not generate them again.

**TODO:**
Property matching logic needs further improvement, for instances, ErrorResponse will only be matched in Resources and not in other RPs with a different namespace. The tricky part is that `ErrorResponse` has a property of `List<ErrorResponse>`. 
Eventually, we may need to compare all subproperties recursively but store the Class types we are comparing and return true for a Type that was already stored for comparison to avoid infinite loop. 

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first