### PR TITLE
Add JsonConverter for PropertyReferenceType Serialization

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -254,7 +254,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         public bool IncludeSerializer => _usage.HasFlag(SchemaTypeUsage.Input);
         public bool IncludeDeserializer => _usage.HasFlag(SchemaTypeUsage.Output);
-        public bool IncludeConverter => _usage.HasFlag(SchemaTypeUsage.Converter);
+        public virtual bool IncludeConverter => _usage.HasFlag(SchemaTypeUsage.Converter);
         protected bool SkipSerializerConstructor => !IncludeDeserializer;
         public CSharpType? ImplementsDictionaryType => _implementsDictionaryType ??= CreateInheritedDictionaryType();
         protected override IEnumerable<ObjectTypeConstructor> BuildConstructors()

--- a/src/AutoRest.CSharp/Mgmt/Generation/ReferenceTypeWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ReferenceTypeWriter.cs
@@ -24,6 +24,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
             var extensions = schema.ObjectSchema.Extensions;
             if (extensions != null)
             {
+                writer.UseNamespace("Azure.ResourceManager.Core");
                 if (extensions.MgmtReferenceType)
                 {
                     writer.Line($"[{ReferenceClassFinder.ReferenceTypeAttribute}]");

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtReferenceType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtReferenceType.cs
@@ -16,5 +16,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             : base(objectSchema, context)
         {
         }
+
+        public override bool IncludeConverter => ObjectSchema.Extensions?.MgmtPropertyReferenceType == true && ObjectSchema.Extensions?.MgmtReferenceType != true || base.IncludeConverter;
     }
 }

--- a/test/TestProjects/ReferenceTypes/Generated/Models/ResourceReference.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/ResourceReference.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using Azure.ResourceManager.Core;
+
 namespace Azure.ResourceManager.Resources.Models
 {
     /// <summary> Common fields that are returned in the response for all Azure Resource Manager resources. </summary>

--- a/test/TestProjects/ReferenceTypes/Generated/Models/SkuReference.Serialization.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/SkuReference.Serialization.cs
@@ -5,11 +5,14 @@
 
 #nullable disable
 
+using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {
+    [JsonConverter(typeof(SkuReferenceConverter))]
     public partial class SkuReference : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
@@ -86,6 +89,19 @@ namespace Azure.ResourceManager.Resources.Models
                 }
             }
             return new SkuReference(name, Optional.ToNullable(tier), size.Value, family.Value, Optional.ToNullable(capacity));
+        }
+
+        internal partial class SkuReferenceConverter : JsonConverter<SkuReference>
+        {
+            public override void Write(Utf8JsonWriter writer, SkuReference model, JsonSerializerOptions options)
+            {
+                writer.WriteObjectValue(model);
+            }
+            public override SkuReference Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                using var document = JsonDocument.ParseValue(ref reader);
+                return DeserializeSkuReference(document.RootElement);
+            }
         }
     }
 }

--- a/test/TestProjects/ReferenceTypes/Generated/Models/SkuReference.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/SkuReference.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {

--- a/test/TestProjects/ReferenceTypes/Generated/Models/TrackedResourceReference.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/TrackedResourceReference.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using Azure.Core;
+using Azure.ResourceManager.Core;
 
 namespace Azure.ResourceManager.Resources.Models
 {


### PR DESCRIPTION
# Description
This PR adds JsonConverter for PropertyReferenceType Serialization.

This PR also fixes the missing namespace `Azure.ResourceManager.Core` which will be needed by real armCore code. The tests in autorest use the fake ReferenceTypeAttribute and PropertyReferenceTypeAttribute created under `Azure.ResourceManager.Resources.Models` as the real ones are internal and can only be used by armCore package (i.e. Azure.ResourceManager). The real ReferenceTypeAttribute and PropertyReferenceTypeAttribute are under namespace `Azure.ResourceManager.Core`.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first