### PR TITLE
expose skip url encoding in parameters

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -566,8 +566,8 @@ namespace AutoRest.CSharp.Output.Models
                 TypeFactory.GetInputType(type),
                 defaultValue,
                 isRequired,
-                SkipUrlEncoding: requestParameter.Extensions?.SkipEncoding ?? false,
-                IsApiVersionParameter: requestParameter.Origin == "modelerfour:synthesized/api-version");
+                IsApiVersionParameter: requestParameter.Origin == "modelerfour:synthesized/api-version",
+                SkipUrlEncoding: requestParameter.Extensions?.SkipEncoding ?? false);
         }
 
         private Constant ParseConstant(ConstantSchema constant) =>

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -566,7 +566,8 @@ namespace AutoRest.CSharp.Output.Models
                 TypeFactory.GetInputType(type),
                 defaultValue,
                 isRequired,
-                requestParameter.Origin == "modelerfour:synthesized/api-version");
+                SkipUrlEncoding: requestParameter.Extensions?.SkipEncoding ?? false,
+                IsApiVersionParameter: requestParameter.Origin == "modelerfour:synthesized/api-version");
         }
 
         private Constant ParseConstant(ConstantSchema constant) =>

--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -5,5 +5,5 @@ using AutoRest.CSharp.Generation.Types;
 
 namespace AutoRest.CSharp.Output.Models.Shared
 {
-    internal record Parameter(string Name, string? Description, CSharpType Type, Constant? DefaultValue, bool ValidateNotNull, bool SkipUrlEncoding = false, bool IsApiVersionParameter = false);
+    internal record Parameter(string Name, string? Description, CSharpType Type, Constant? DefaultValue, bool ValidateNotNull, bool IsApiVersionParameter = false, bool SkipUrlEncoding = false);
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -5,5 +5,5 @@ using AutoRest.CSharp.Generation.Types;
 
 namespace AutoRest.CSharp.Output.Models.Shared
 {
-    internal record Parameter(string Name, string? Description, CSharpType Type, Constant? DefaultValue, bool ValidateNotNull, bool IsApiVersionParameter = false);
+    internal record Parameter(string Name, string? Description, CSharpType Type, Constant? DefaultValue, bool ValidateNotNull, bool SkipUrlEncoding = false, bool IsApiVersionParameter = false);
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelFactoryTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelFactoryTypeProvider.cs
@@ -60,7 +60,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                     inputType,
                     defaultValue,
                     ctorParameter.ValidateNotNull,
-                    ctorParameter.IsApiVersionParameter
+                    IsApiVersionParameter: ctorParameter.IsApiVersionParameter
                 );
 
                 methodParameters[i] = methodParameter;

--- a/test/AutoRest.TestServer.Tests/Common/Output/Models/Requests/PagingMethodTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/Output/Models/Requests/PagingMethodTests.cs
@@ -59,7 +59,6 @@ namespace AutoRest.CSharp.Output.Models.Requests.Tests
                 "test parameter",
                 inputType,
                 null,
-                false,
                 false
             ));
         }


### PR DESCRIPTION
# Description

The generator also needs to know this extension to determine whether a parameter is a normal parameter which can only accept a single name, or it is a "scope" parameter which could accept a ID of another resource
We have similar logic when building the `PathSegment`, I am borrowing those and pass it into the constructor of `Parameter`.
I also made this new property optional so that other target does not have to pass that.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first