### PR TITLE
Fix memory issue when running UpdateAzureSdkForNet.ps1

### DIFF
--- a/eng/UpdateAzureSdkForNet.ps1
+++ b/eng/UpdateAzureSdkForNet.ps1
@@ -13,5 +13,5 @@ $PackagesProps = "$SdkRepoRoot\eng\Packages.Data.props"
     "<PackageReference Update=`"Microsoft.Azure.AutoRest.CSharp`" Version=`"$Version`" PrivateAssets=`"All`" />" | `
     Set-Content $PackagesProps -NoNewline
 
-$Env:NODE_OPTIONS = "--max-old-space-size=8192"
+$Env:NODE_OPTIONS = "--max-old-space-size=4096"
 dotnet msbuild /restore /t:GenerateCode "$SdkRepoRoot\eng\service.proj"

--- a/eng/UpdateAzureSdkForNet.ps1
+++ b/eng/UpdateAzureSdkForNet.ps1
@@ -13,4 +13,5 @@ $PackagesProps = "$SdkRepoRoot\eng\Packages.Data.props"
     "<PackageReference Update=`"Microsoft.Azure.AutoRest.CSharp`" Version=`"$Version`" PrivateAssets=`"All`" />" | `
     Set-Content $PackagesProps -NoNewline
 
+$Env:NODE_OPTIONS = "--max-old-space-size=8192"
 dotnet msbuild /restore /t:GenerateCode "$SdkRepoRoot\eng\service.proj"


### PR DESCRIPTION
# Description
The [AutoRest C# - Publish](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1375&_a=summary) pipeline is failing, caused by no enough memory when generating Network SDK. This PR fixes it by setting `max-old-space-size` to 4G.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first