### PR TITLE
[LLC] Disable Flatting and Grouping for LLC

### DIFF
--- a/src/AutoRest.CSharp/readme.md
+++ b/src/AutoRest.CSharp/readme.md
@@ -7,9 +7,6 @@ use-extension:
   "@autorest/modelerfour": "4.19.3"
 modelerfour:
   always-create-content-type-parameter: true
-  flatten-models: true
-  flatten-payloads: true
-  group-parameters: true
 pipeline:
   csharpgen:
     input: modelerfour/identity
@@ -19,6 +16,13 @@ pipeline:
 output-scope:
   output-artifact: source-file-csharp
 shared-source-folders: $(this-folder)/Generator.Shared;$(this-folder)/Azure.Core.Shared
+```
+
+```yaml !$(low-level-client)
+modelerfour:
+  flatten-models: true
+  flatten-payloads: true
+  group-parameters: true
 ```
 
 ```yaml !$(skip-csproj)

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/CodeModel.yaml
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/CodeModel.yaml
@@ -504,7 +504,7 @@ schemas: !Schemas
           description: Colors possible
       protocol: !Protocols {}
   constants:
-    - !ConstantSchema &ref_80
+    - !ConstantSchema &ref_81
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -514,7 +514,7 @@ schemas: !Schemas
           name: Accept
           description: 'Accept: application/json'
       protocol: !Protocols {}
-    - !ConstantSchema &ref_78
+    - !ConstantSchema &ref_79
       type: constant
       value: !ConstantValue 
         value: '2016-02-29'
@@ -524,7 +524,7 @@ schemas: !Schemas
           name: ApiVersion20160229
           description: Api Version (2016-02-29)
       protocol: !Protocols {}
-    - !ConstantSchema &ref_84
+    - !ConstantSchema &ref_85
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -671,7 +671,7 @@ schemas: !Schemas
           description: ''
       protocol: !Protocols {}
   objects:
-    - !ObjectSchema &ref_81
+    - !ObjectSchema &ref_82
       type: object
       apiVersions:
         - !ApiVersion 
@@ -713,7 +713,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_82
+    - !ObjectSchema &ref_83
       type: object
       apiVersions:
         - !ApiVersion 
@@ -745,7 +745,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_86
+    - !ObjectSchema &ref_87
       type: object
       apiVersions:
         - !ApiVersion 
@@ -778,7 +778,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_88
+    - !ObjectSchema &ref_89
       type: object
       apiVersions:
         - !ApiVersion 
@@ -811,7 +811,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_90
+    - !ObjectSchema &ref_91
       type: object
       apiVersions:
         - !ApiVersion 
@@ -844,7 +844,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_92
+    - !ObjectSchema &ref_93
       type: object
       apiVersions:
         - !ApiVersion 
@@ -877,7 +877,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_94
+    - !ObjectSchema &ref_95
       type: object
       apiVersions:
         - !ApiVersion 
@@ -910,7 +910,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_96
+    - !ObjectSchema &ref_97
       type: object
       apiVersions:
         - !ApiVersion 
@@ -951,7 +951,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_98
+    - !ObjectSchema &ref_99
       type: object
       apiVersions:
         - !ApiVersion 
@@ -984,7 +984,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_100
+    - !ObjectSchema &ref_101
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1017,7 +1017,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_102
+    - !ObjectSchema &ref_103
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1050,7 +1050,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_104
+    - !ObjectSchema &ref_105
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1075,7 +1075,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_106
+    - !ObjectSchema &ref_107
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1100,14 +1100,14 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_108
+    - !ObjectSchema &ref_109
       type: object
       apiVersions:
         - !ApiVersion 
           version: '2016-02-29'
       properties:
         - !Property 
-          schema: !ArraySchema &ref_73
+          schema: !ArraySchema &ref_74
             type: array
             apiVersions:
               - !ApiVersion 
@@ -1135,7 +1135,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_111
+    - !ObjectSchema &ref_112
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1253,7 +1253,7 @@ schemas: !Schemas
                     description: ''
                 protocol: !Protocols {}
               - !Property 
-                schema: !ArraySchema &ref_74
+                schema: !ArraySchema &ref_75
                   type: array
                   apiVersions:
                     - !ApiVersion 
@@ -1609,7 +1609,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_75
+          schema: !ArraySchema &ref_76
             type: array
             apiVersions:
               - !ApiVersion 
@@ -1721,7 +1721,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_116
+    - !ObjectSchema &ref_117
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1736,7 +1736,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_76
+          schema: !ArraySchema &ref_77
             type: array
             apiVersions:
               - !ApiVersion 
@@ -1762,7 +1762,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_77
+          schema: !ArraySchema &ref_78
             type: array
             apiVersions:
               - !ApiVersion 
@@ -1791,7 +1791,7 @@ schemas: !Schemas
       protocol: !Protocols {}
     - *ref_60
     - *ref_39
-    - !ObjectSchema &ref_121
+    - !ObjectSchema &ref_122
       type: object
       apiVersions:
         - !ApiVersion 
@@ -1893,15 +1893,37 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_72
-          flattenedNames:
-            - helper
-            - propBH1
+          schema: !ObjectSchema &ref_73
+            type: object
+            apiVersions:
+              - !ApiVersion 
+                version: '2016-02-29'
+            properties:
+              - !Property 
+                schema: *ref_72
+                serializedName: propBH1
+                language: !Languages 
+                  default:
+                    name: propBH1
+                    description: ''
+                protocol: !Protocols {}
+            serializationFormats:
+              - json
+            usage:
+              - output
+            language: !Languages 
+              default:
+                name: MyBaseHelperType
+                description: ''
+                namespace: ''
+            protocol: !Protocols {}
           required: false
-          serializedName: propBH1
+          serializedName: helper
+          extensions:
+            x-ms-client-flatten: true
           language: !Languages 
             default:
-              name: propBH1
+              name: helper
               description: ''
           protocol: !Protocols {}
       serializationFormats:
@@ -1914,6 +1936,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
+    - *ref_73
     - *ref_43
     - *ref_46
     - *ref_50
@@ -1921,13 +1944,13 @@ schemas: !Schemas
     - *ref_52
     - *ref_68
   arrays:
-    - *ref_73
     - *ref_74
     - *ref_75
     - *ref_76
     - *ref_77
+    - *ref_78
 globalParameters:
-  - !Parameter &ref_79
+  - !Parameter &ref_80
     schema: *ref_0
     clientDefaultValue: http://localhost:3000
     implementation: Client
@@ -1943,8 +1966,8 @@ globalParameters:
     protocol: !Protocols 
       http: !HttpParameter 
         in: uri
-  - !Parameter &ref_83
-    schema: *ref_78
+  - !Parameter &ref_84
+    schema: *ref_79
     implementation: Client
     origin: modelerfour:synthesized/api-version
     required: true
@@ -1965,12 +1988,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1995,7 +2018,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_81
+            schema: *ref_82
             language: !Languages 
               default:
                 name: ''
@@ -2009,7 +2032,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2031,13 +2054,13 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
-          - *ref_83
+          - *ref_80
+          - *ref_84
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2049,8 +2072,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_85
-                schema: *ref_81
+              - !Parameter &ref_86
+                schema: *ref_82
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -2062,7 +2085,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2075,7 +2098,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_85
+              - *ref_86
             language: !Languages 
               default:
                 name: ''
@@ -2101,7 +2124,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2123,12 +2146,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2153,7 +2176,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_81
+            schema: *ref_82
             language: !Languages 
               default:
                 name: ''
@@ -2167,7 +2190,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2189,12 +2212,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2219,7 +2242,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_81
+            schema: *ref_82
             language: !Languages 
               default:
                 name: ''
@@ -2233,7 +2256,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2255,12 +2278,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2285,7 +2308,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_81
+            schema: *ref_82
             language: !Languages 
               default:
                 name: ''
@@ -2299,7 +2322,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2321,12 +2344,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2351,7 +2374,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_81
+            schema: *ref_82
             language: !Languages 
               default:
                 name: ''
@@ -2365,7 +2388,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2395,12 +2418,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2425,7 +2448,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_86
+            schema: *ref_87
             language: !Languages 
               default:
                 name: ''
@@ -2439,7 +2462,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2461,12 +2484,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2478,8 +2501,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_87
-                schema: *ref_86
+              - !Parameter &ref_88
+                schema: *ref_87
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -2491,7 +2514,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2504,7 +2527,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_87
+              - *ref_88
             language: !Languages 
               default:
                 name: ''
@@ -2530,7 +2553,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2552,12 +2575,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2582,7 +2605,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_88
+            schema: *ref_89
             language: !Languages 
               default:
                 name: ''
@@ -2596,7 +2619,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2618,12 +2641,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2635,8 +2658,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_89
-                schema: *ref_88
+              - !Parameter &ref_90
+                schema: *ref_89
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -2648,7 +2671,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2661,7 +2684,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_89
+              - *ref_90
             language: !Languages 
               default:
                 name: ''
@@ -2687,7 +2710,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2709,12 +2732,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2739,7 +2762,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_90
+            schema: *ref_91
             language: !Languages 
               default:
                 name: ''
@@ -2753,7 +2776,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2775,12 +2798,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2792,8 +2815,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_91
-                schema: *ref_90
+              - !Parameter &ref_92
+                schema: *ref_91
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -2805,7 +2828,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2818,7 +2841,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_91
+              - *ref_92
             language: !Languages 
               default:
                 name: ''
@@ -2844,7 +2867,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2866,12 +2889,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2896,7 +2919,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_92
+            schema: *ref_93
             language: !Languages 
               default:
                 name: ''
@@ -2910,7 +2933,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -2932,12 +2955,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2949,8 +2972,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_93
-                schema: *ref_92
+              - !Parameter &ref_94
+                schema: *ref_93
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -2962,7 +2985,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2975,7 +2998,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_93
+              - *ref_94
             language: !Languages 
               default:
                 name: ''
@@ -3001,7 +3024,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3023,12 +3046,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3053,7 +3076,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_94
+            schema: *ref_95
             language: !Languages 
               default:
                 name: ''
@@ -3067,7 +3090,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3089,12 +3112,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3106,8 +3129,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_95
-                schema: *ref_94
+              - !Parameter &ref_96
+                schema: *ref_95
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -3119,7 +3142,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3132,7 +3155,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_95
+              - *ref_96
             language: !Languages 
               default:
                 name: ''
@@ -3158,7 +3181,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3180,12 +3203,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3210,7 +3233,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_96
+            schema: *ref_97
             language: !Languages 
               default:
                 name: ''
@@ -3224,7 +3247,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3246,12 +3269,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3263,8 +3286,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_97
-                schema: *ref_96
+              - !Parameter &ref_98
+                schema: *ref_97
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -3276,7 +3299,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3289,7 +3312,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_97
+              - *ref_98
             language: !Languages 
               default:
                 name: ''
@@ -3315,7 +3338,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3337,12 +3360,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3367,7 +3390,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_98
+            schema: *ref_99
             language: !Languages 
               default:
                 name: ''
@@ -3381,7 +3404,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3403,12 +3426,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3420,8 +3443,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_99
-                schema: *ref_98
+              - !Parameter &ref_100
+                schema: *ref_99
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -3433,7 +3456,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3446,7 +3469,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_99
+              - *ref_100
             language: !Languages 
               default:
                 name: ''
@@ -3472,7 +3495,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3494,12 +3517,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3524,7 +3547,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_100
+            schema: *ref_101
             language: !Languages 
               default:
                 name: ''
@@ -3538,7 +3561,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3560,12 +3583,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3577,8 +3600,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_101
-                schema: *ref_100
+              - !Parameter &ref_102
+                schema: *ref_101
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -3590,7 +3613,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3603,7 +3626,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_101
+              - *ref_102
             language: !Languages 
               default:
                 name: ''
@@ -3629,7 +3652,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3651,12 +3674,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3681,7 +3704,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_102
+            schema: *ref_103
             language: !Languages 
               default:
                 name: ''
@@ -3695,7 +3718,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3717,12 +3740,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3734,8 +3757,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_103
-                schema: *ref_102
+              - !Parameter &ref_104
+                schema: *ref_103
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -3747,7 +3770,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3760,7 +3783,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_103
+              - *ref_104
             language: !Languages 
               default:
                 name: ''
@@ -3786,7 +3809,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3808,12 +3831,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3838,7 +3861,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_104
+            schema: *ref_105
             language: !Languages 
               default:
                 name: ''
@@ -3852,7 +3875,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3874,12 +3897,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3891,8 +3914,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_105
-                schema: *ref_104
+              - !Parameter &ref_106
+                schema: *ref_105
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -3904,7 +3927,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3917,7 +3940,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_105
+              - *ref_106
             language: !Languages 
               default:
                 name: ''
@@ -3943,7 +3966,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -3965,12 +3988,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3995,7 +4018,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_106
+            schema: *ref_107
             language: !Languages 
               default:
                 name: ''
@@ -4009,7 +4032,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4031,12 +4054,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4048,8 +4071,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_107
-                schema: *ref_106
+              - !Parameter &ref_108
+                schema: *ref_107
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -4061,7 +4084,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4074,7 +4097,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_107
+              - *ref_108
             language: !Languages 
               default:
                 name: ''
@@ -4100,7 +4123,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4130,12 +4153,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4160,7 +4183,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_108
+            schema: *ref_109
             language: !Languages 
               default:
                 name: ''
@@ -4174,7 +4197,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4196,12 +4219,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4213,8 +4236,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_109
-                schema: *ref_108
+              - !Parameter &ref_110
+                schema: *ref_109
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -4226,7 +4249,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4239,7 +4262,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_109
+              - *ref_110
             language: !Languages 
               default:
                 name: ''
@@ -4265,7 +4288,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4287,12 +4310,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4317,7 +4340,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_108
+            schema: *ref_109
             language: !Languages 
               default:
                 name: ''
@@ -4331,7 +4354,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4353,12 +4376,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4370,8 +4393,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_110
-                schema: *ref_108
+              - !Parameter &ref_111
+                schema: *ref_109
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -4383,7 +4406,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4396,7 +4419,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_110
+              - *ref_111
             language: !Languages 
               default:
                 name: ''
@@ -4422,7 +4445,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4444,12 +4467,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4474,7 +4497,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_108
+            schema: *ref_109
             language: !Languages 
               default:
                 name: ''
@@ -4488,7 +4511,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4518,12 +4541,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4548,7 +4571,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_111
+            schema: *ref_112
             language: !Languages 
               default:
                 name: ''
@@ -4562,7 +4585,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4584,12 +4607,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4601,8 +4624,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_112
-                schema: *ref_111
+              - !Parameter &ref_113
+                schema: *ref_112
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -4614,7 +4637,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4627,7 +4650,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_112
+              - *ref_113
             language: !Languages 
               default:
                 name: ''
@@ -4653,7 +4676,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4675,12 +4698,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4705,7 +4728,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_111
+            schema: *ref_112
             language: !Languages 
               default:
                 name: ''
@@ -4719,7 +4742,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4741,12 +4764,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4758,8 +4781,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_113
-                schema: *ref_111
+              - !Parameter &ref_114
+                schema: *ref_112
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -4771,7 +4794,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4784,7 +4807,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_113
+              - *ref_114
             language: !Languages 
               default:
                 name: ''
@@ -4810,7 +4833,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4832,12 +4855,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4862,7 +4885,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_111
+            schema: *ref_112
             language: !Languages 
               default:
                 name: ''
@@ -4876,7 +4899,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4898,12 +4921,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4928,7 +4951,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_111
+            schema: *ref_112
             language: !Languages 
               default:
                 name: ''
@@ -4942,7 +4965,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -4972,12 +4995,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5016,7 +5039,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5038,12 +5061,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5055,7 +5078,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_114
+              - !Parameter &ref_115
                 schema: *ref_34
                 implementation: Method
                 required: true
@@ -5068,7 +5091,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5081,7 +5104,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_114
+              - *ref_115
             language: !Languages 
               default:
                 name: ''
@@ -5107,7 +5130,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5137,12 +5160,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5213,7 +5236,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5235,12 +5258,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5252,7 +5275,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_115
+              - !Parameter &ref_116
                 schema: *ref_41
                 implementation: Method
                 required: true
@@ -5298,7 +5321,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5311,7 +5334,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_115
+              - *ref_116
             language: !Languages 
               default:
                 name: ''
@@ -5337,7 +5360,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5359,12 +5382,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5403,7 +5426,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5425,12 +5448,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5455,7 +5478,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_116
+            schema: *ref_117
             language: !Languages 
               default:
                 name: ''
@@ -5469,7 +5492,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5491,12 +5514,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5521,7 +5544,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_116
+            schema: *ref_117
             language: !Languages 
               default:
                 name: ''
@@ -5535,7 +5558,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5557,12 +5580,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5601,7 +5624,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5623,12 +5646,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5640,7 +5663,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_117
+              - !Parameter &ref_118
                 schema: *ref_39
                 implementation: Method
                 required: true
@@ -5653,7 +5676,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5666,7 +5689,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_117
+              - *ref_118
             language: !Languages 
               default:
                 name: ''
@@ -5692,7 +5715,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5714,12 +5737,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5731,7 +5754,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_118
+              - !Parameter &ref_119
                 schema: *ref_39
                 implementation: Method
                 required: true
@@ -5744,7 +5767,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5757,7 +5780,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_118
+              - *ref_119
             language: !Languages 
               default:
                 name: ''
@@ -5787,7 +5810,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5809,12 +5832,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5826,7 +5849,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_119
+              - !Parameter &ref_120
                 schema: *ref_41
                 implementation: Method
                 required: true
@@ -5865,7 +5888,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5878,7 +5901,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_119
+              - *ref_120
             language: !Languages 
               default:
                 name: ''
@@ -5904,7 +5927,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -5934,12 +5957,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6038,7 +6061,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -6060,12 +6083,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6077,7 +6100,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_120
+              - !Parameter &ref_121
                 schema: *ref_41
                 implementation: Method
                 required: true
@@ -6143,7 +6166,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6156,7 +6179,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_120
+              - *ref_121
             language: !Languages 
               default:
                 name: ''
@@ -6182,7 +6205,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -6212,12 +6235,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6242,7 +6265,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_121
+            schema: *ref_122
             language: !Languages 
               default:
                 name: ''
@@ -6256,7 +6279,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -6278,12 +6301,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_84
+                schema: *ref_85
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6295,8 +6318,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_122
-                schema: *ref_121
+              - !Parameter &ref_123
+                schema: *ref_122
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -6308,7 +6331,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6321,7 +6344,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_122
+              - *ref_123
             language: !Languages 
               default:
                 name: ''
@@ -6347,7 +6370,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_82
+            schema: *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -6377,12 +6400,12 @@ operationGroups:
           - !ApiVersion 
             version: '2016-02-29'
         parameters:
-          - *ref_79
+          - *ref_80
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_80
+                schema: *ref_81
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true

--- a/test/TestServerProjectsLowLevel/body-complex/Generated/FlattencomplexClient.cs
+++ b/test/TestServerProjectsLowLevel/body-complex/Generated/FlattencomplexClient.cs
@@ -56,7 +56,9 @@ namespace body_complex_LowLevel
         /// <code>{
         ///   kind: &quot;Kind1&quot;,
         ///   propB1: string,
-        ///   propBH1: string
+        ///   helper: {
+        ///     propBH1: string
+        ///   }
         /// }
         /// </code>
         /// 
@@ -101,7 +103,9 @@ namespace body_complex_LowLevel
         /// <code>{
         ///   kind: &quot;Kind1&quot;,
         ///   propB1: string,
-        ///   propBH1: string
+        ///   helper: {
+        ///     propBH1: string
+        ///   }
         /// }
         /// </code>
         /// 

--- a/test/TestServerProjectsLowLevel/lro/Generated/CodeModel.yaml
+++ b/test/TestServerProjectsLowLevel/lro/Generated/CodeModel.yaml
@@ -4,7 +4,7 @@ info: !Info
   title: AutoRest Long-running Operation Test Service
 schemas: !Schemas 
   numbers:
-    - !NumberSchema &ref_11
+    - !NumberSchema &ref_12
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -15,7 +15,7 @@ schemas: !Schemas
           name: CloudErrorCode
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_45
+    - !NumberSchema &ref_47
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -27,19 +27,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_52
-      type: integer
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      precision: 32
-      language: !Languages 
-        default:
-          name: Integer
-          description: ''
-          header: Retry-After
-      protocol: !Protocols {}
-    - !NumberSchema &ref_64
+    - !NumberSchema &ref_54
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -99,7 +87,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_77
+    - !NumberSchema &ref_74
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -111,7 +99,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_80
+    - !NumberSchema &ref_79
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -123,7 +111,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_83
+    - !NumberSchema &ref_82
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -135,7 +123,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_86
+    - !NumberSchema &ref_85
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -147,7 +135,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_89
+    - !NumberSchema &ref_88
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -159,7 +147,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_92
+    - !NumberSchema &ref_91
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -171,7 +159,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_96
+    - !NumberSchema &ref_94
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -183,7 +171,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_100
+    - !NumberSchema &ref_98
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -195,7 +183,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_104
+    - !NumberSchema &ref_102
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -207,7 +195,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_108
+    - !NumberSchema &ref_106
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -219,7 +207,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_113
+    - !NumberSchema &ref_110
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -255,7 +243,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_120
+    - !NumberSchema &ref_119
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -267,7 +255,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_123
+    - !NumberSchema &ref_122
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -279,7 +267,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_127
+    - !NumberSchema &ref_125
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -291,7 +279,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_134
+    - !NumberSchema &ref_129
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -327,7 +315,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_141
+    - !NumberSchema &ref_140
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -339,7 +327,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_144
+    - !NumberSchema &ref_143
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -351,7 +339,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_147
+    - !NumberSchema &ref_146
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -363,7 +351,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_151
+    - !NumberSchema &ref_149
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -375,7 +363,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_156
+    - !NumberSchema &ref_153
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -387,7 +375,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_160
+    - !NumberSchema &ref_158
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -399,7 +387,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_163
+    - !NumberSchema &ref_162
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -411,7 +399,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_166
+    - !NumberSchema &ref_165
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -423,7 +411,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_170
+    - !NumberSchema &ref_168
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -435,7 +423,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_175
+    - !NumberSchema &ref_172
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -447,7 +435,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_179
+    - !NumberSchema &ref_177
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -471,7 +459,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_184
+    - !NumberSchema &ref_183
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -483,7 +471,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_187
+    - !NumberSchema &ref_186
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -495,7 +483,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_190
+    - !NumberSchema &ref_189
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -507,7 +495,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_194
+    - !NumberSchema &ref_192
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -519,7 +507,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_198
+    - !NumberSchema &ref_196
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -531,7 +519,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_202
+    - !NumberSchema &ref_200
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -543,7 +531,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_206
+    - !NumberSchema &ref_204
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -555,7 +543,7 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_210
+    - !NumberSchema &ref_208
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -567,7 +555,19 @@ schemas: !Schemas
           description: ''
           header: Retry-After
       protocol: !Protocols {}
-    - !NumberSchema &ref_21
+    - !NumberSchema &ref_212
+      type: integer
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      precision: 32
+      language: !Languages 
+        default:
+          name: Integer
+          description: ''
+          header: Retry-After
+      protocol: !Protocols {}
+    - !NumberSchema &ref_23
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -647,7 +647,7 @@ schemas: !Schemas
           name: ProductPropertiesProvisioningState
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_12
+    - !StringSchema &ref_13
       type: string
       apiVersions:
         - !ApiVersion 
@@ -657,7 +657,7 @@ schemas: !Schemas
           name: CloudErrorMessage
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_32
+    - !StringSchema &ref_34
       type: string
       apiVersions:
         - !ApiVersion 
@@ -668,7 +668,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_33
+    - !StringSchema &ref_35
       type: string
       apiVersions:
         - !ApiVersion 
@@ -678,17 +678,6 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_41
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: location
       protocol: !Protocols {}
     - !StringSchema &ref_43
       type: string
@@ -699,20 +688,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
+          header: location
       protocol: !Protocols {}
-    - !StringSchema &ref_44
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_47
+    - !StringSchema &ref_45
       type: string
       apiVersions:
         - !ApiVersion 
@@ -723,7 +701,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_48
+    - !StringSchema &ref_46
       type: string
       apiVersions:
         - !ApiVersion 
@@ -733,6 +711,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_49
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_50
       type: string
@@ -743,20 +732,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
-      protocol: !Protocols {}
-    - !StringSchema &ref_51
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_54
+    - !StringSchema &ref_52
       type: string
       apiVersions:
         - !ApiVersion 
@@ -767,7 +745,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_55
+    - !StringSchema &ref_53
       type: string
       apiVersions:
         - !ApiVersion 
@@ -777,6 +755,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_56
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_57
       type: string
@@ -787,9 +776,20 @@ schemas: !Schemas
         default:
           name: String
           description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_59
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_13
+    - !StringSchema &ref_14
       type: string
       apiVersions:
         - !ApiVersion 
@@ -799,7 +799,7 @@ schemas: !Schemas
           name: SkuName
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_14
+    - !StringSchema &ref_15
       type: string
       apiVersions:
         - !ApiVersion 
@@ -809,7 +809,7 @@ schemas: !Schemas
           name: SkuId
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_19
+    - !StringSchema &ref_20
       type: string
       apiVersions:
         - !ApiVersion 
@@ -819,7 +819,7 @@ schemas: !Schemas
           name: SubResourceId
           description: Sub Resource Id
       protocol: !Protocols {}
-    - !StringSchema &ref_16
+    - !StringSchema &ref_17
       type: string
       apiVersions:
         - !ApiVersion 
@@ -828,17 +828,6 @@ schemas: !Schemas
         default:
           name: SubProductPropertiesProvisioningState
           description: ''
-      protocol: !Protocols {}
-    - !StringSchema &ref_63
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
       protocol: !Protocols {}
     - !StringSchema &ref_65
       type: string
@@ -895,17 +884,6 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_74
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
     - !StringSchema &ref_75
       type: string
       apiVersions:
@@ -915,7 +893,7 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
+          header: Location
       protocol: !Protocols {}
     - !StringSchema &ref_76
       type: string
@@ -928,7 +906,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_78
+    - !StringSchema &ref_77
       type: string
       apiVersions:
         - !ApiVersion 
@@ -939,7 +917,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_79
+    - !StringSchema &ref_78
       type: string
       apiVersions:
         - !ApiVersion 
@@ -949,6 +927,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_80
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_81
       type: string
@@ -959,9 +948,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
+          header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_82
+    - !StringSchema &ref_83
       type: string
       apiVersions:
         - !ApiVersion 
@@ -970,7 +959,7 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Location
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_84
       type: string
@@ -981,42 +970,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
-      protocol: !Protocols {}
-    - !StringSchema &ref_85
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_88
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_91
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_94
+    - !StringSchema &ref_86
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1027,7 +983,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_95
+    - !StringSchema &ref_87
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1038,7 +994,29 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_98
+    - !StringSchema &ref_90
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_93
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_96
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1049,7 +1027,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_99
+    - !StringSchema &ref_97
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1060,7 +1038,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_102
+    - !StringSchema &ref_100
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1071,7 +1049,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_103
+    - !StringSchema &ref_101
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1082,7 +1060,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_106
+    - !StringSchema &ref_104
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1093,7 +1071,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_107
+    - !StringSchema &ref_105
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1104,7 +1082,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_111
+    - !StringSchema &ref_108
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1115,7 +1093,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_112
+    - !StringSchema &ref_109
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1125,6 +1103,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_113
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_114
       type: string
@@ -1157,31 +1146,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
-      protocol: !Protocols {}
-    - !StringSchema &ref_119
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_122
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_125
+    - !StringSchema &ref_120
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1192,7 +1159,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_126
+    - !StringSchema &ref_121
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1203,7 +1170,18 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_132
+    - !StringSchema &ref_124
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_127
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1214,7 +1192,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_133
+    - !StringSchema &ref_128
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1224,6 +1202,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_134
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_135
       type: string
@@ -1256,42 +1245,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
-      protocol: !Protocols {}
-    - !StringSchema &ref_140
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_143
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_146
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_149
+    - !StringSchema &ref_141
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1302,7 +1258,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_150
+    - !StringSchema &ref_142
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1313,7 +1269,29 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_154
+    - !StringSchema &ref_145
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_148
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_151
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1324,7 +1302,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_155
+    - !StringSchema &ref_152
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1335,7 +1313,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_158
+    - !StringSchema &ref_156
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1346,7 +1324,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_159
+    - !StringSchema &ref_157
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1356,6 +1334,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_160
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_161
       type: string
@@ -1366,31 +1355,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
-      protocol: !Protocols {}
-    - !StringSchema &ref_162
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_165
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_168
+    - !StringSchema &ref_163
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1401,7 +1368,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_169
+    - !StringSchema &ref_164
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1412,7 +1379,18 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_173
+    - !StringSchema &ref_167
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_170
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1423,7 +1401,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_174
+    - !StringSchema &ref_171
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1434,7 +1412,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_177
+    - !StringSchema &ref_175
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1445,7 +1423,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_178
+    - !StringSchema &ref_176
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1455,6 +1433,17 @@ schemas: !Schemas
           name: String
           description: ''
           header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_179
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_180
       type: string
@@ -1476,9 +1465,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
+          header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_183
+    - !StringSchema &ref_184
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1487,7 +1476,7 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Location
+          header: Azure-AsyncOperation
       protocol: !Protocols {}
     - !StringSchema &ref_185
       type: string
@@ -1498,31 +1487,9 @@ schemas: !Schemas
         default:
           name: String
           description: ''
-          header: Azure-AsyncOperation
-      protocol: !Protocols {}
-    - !StringSchema &ref_186
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_189
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_192
+    - !StringSchema &ref_187
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1533,7 +1500,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_193
+    - !StringSchema &ref_188
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1544,7 +1511,18 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_196
+    - !StringSchema &ref_191
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_194
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1555,7 +1533,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_197
+    - !StringSchema &ref_195
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1566,7 +1544,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_200
+    - !StringSchema &ref_198
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1577,7 +1555,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_201
+    - !StringSchema &ref_199
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1588,18 +1566,7 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_205
-      type: string
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      language: !Languages 
-        default:
-          name: String
-          description: ''
-          header: Location
-      protocol: !Protocols {}
-    - !StringSchema &ref_208
+    - !StringSchema &ref_202
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1610,7 +1577,7 @@ schemas: !Schemas
           description: ''
           header: Azure-AsyncOperation
       protocol: !Protocols {}
-    - !StringSchema &ref_209
+    - !StringSchema &ref_203
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1621,7 +1588,40 @@ schemas: !Schemas
           description: ''
           header: Location
       protocol: !Protocols {}
-    - !StringSchema &ref_22
+    - !StringSchema &ref_207
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_210
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Azure-AsyncOperation
+      protocol: !Protocols {}
+    - !StringSchema &ref_211
+      type: string
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      language: !Languages 
+        default:
+          name: String
+          description: ''
+          header: Location
+      protocol: !Protocols {}
+    - !StringSchema &ref_24
       type: string
       apiVersions:
         - !ApiVersion 
@@ -1710,7 +1710,7 @@ schemas: !Schemas
           name: ProductPropertiesProvisioningStateValues
           description: ''
       protocol: !Protocols {}
-    - !ChoiceSchema &ref_17
+    - !ChoiceSchema &ref_18
       choices:
         - !ChoiceValue 
           value: Succeeded
@@ -1788,7 +1788,7 @@ schemas: !Schemas
           name: SubProductPropertiesProvisioningStateValues
           description: ''
       protocol: !Protocols {}
-    - !ChoiceSchema &ref_20
+    - !ChoiceSchema &ref_22
       choices:
         - !ChoiceValue 
           value: Succeeded
@@ -1867,7 +1867,7 @@ schemas: !Schemas
           description: The status of the request
       protocol: !Protocols {}
   constants:
-    - !ConstantSchema &ref_25
+    - !ConstantSchema &ref_27
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -1877,7 +1877,7 @@ schemas: !Schemas
           name: ApplicationJson
           description: Content Type 'application/json'
       protocol: !Protocols {}
-    - !ConstantSchema &ref_26
+    - !ConstantSchema &ref_28
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -1916,26 +1916,50 @@ schemas: !Schemas
                 - *ref_2
             properties:
               - !Property 
-                schema: *ref_3
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
+                schema: !ObjectSchema &ref_11
+                  type: object
+                  apiVersions:
+                    - !ApiVersion 
+                      version: 1.0.0
+                  properties:
+                    - !Property 
+                      schema: *ref_3
+                      serializedName: provisioningState
+                      language: !Languages 
+                        default:
+                          name: provisioningState
+                          description: ''
+                      protocol: !Protocols {}
+                    - !Property 
+                      schema: *ref_4
+                      readOnly: true
+                      serializedName: provisioningStateValues
+                      language: !Languages 
+                        default:
+                          name: provisioningStateValues
+                          description: ''
+                      protocol: !Protocols {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - input
+                    - output
+                  extensions:
+                    x-internal-autorest-anonymous-schema:
+                      anonymous: true
+                    x-ms-client-flatten: true
+                  language: !Languages 
+                    default:
+                      name: ProductProperties
+                      description: ''
+                      namespace: ''
+                  protocol: !Protocols {}
+                serializedName: properties
+                extensions:
+                  x-ms-client-flatten: true
                 language: !Languages 
                   default:
-                    name: provisioningState
-                    description: ''
-                protocol: !Protocols {}
-              - !Property 
-                schema: *ref_4
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
-                readOnly: true
-                serializedName: provisioningStateValues
-                language: !Languages 
-                  default:
-                    name: provisioningStateValues
+                    name: properties
                     description: ''
                 protocol: !Protocols {}
             serializationFormats:
@@ -2009,14 +2033,15 @@ schemas: !Schemas
           namespace: ''
       protocol: !Protocols {}
     - *ref_5
-    - !ObjectSchema &ref_28
+    - *ref_11
+    - !ObjectSchema &ref_30
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_11
+          schema: *ref_12
           serializedName: code
           language: !Languages 
             default:
@@ -2024,7 +2049,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_12
+          schema: *ref_13
           serializedName: message
           language: !Languages 
             default:
@@ -2043,14 +2068,14 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_58
+    - !ObjectSchema &ref_60
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_13
+          schema: *ref_14
           serializedName: name
           language: !Languages 
             default:
@@ -2058,7 +2083,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_14
+          schema: *ref_15
           serializedName: id
           language: !Languages 
             default:
@@ -2076,45 +2101,69 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_15
+    - !ObjectSchema &ref_16
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       children: !Relations 
         all:
-          - !ObjectSchema &ref_18
+          - !ObjectSchema &ref_19
             type: object
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
             parents: !Relations 
               all:
-                - *ref_15
+                - *ref_16
               immediate:
-                - *ref_15
+                - *ref_16
             properties:
               - !Property 
-                schema: *ref_16
-                flattenedNames:
-                  - properties
-                  - provisioningState
-                serializedName: provisioningState
+                schema: !ObjectSchema &ref_21
+                  type: object
+                  apiVersions:
+                    - !ApiVersion 
+                      version: 1.0.0
+                  properties:
+                    - !Property 
+                      schema: *ref_17
+                      serializedName: provisioningState
+                      language: !Languages 
+                        default:
+                          name: provisioningState
+                          description: ''
+                      protocol: !Protocols {}
+                    - !Property 
+                      schema: *ref_18
+                      readOnly: true
+                      serializedName: provisioningStateValues
+                      language: !Languages 
+                        default:
+                          name: provisioningStateValues
+                          description: ''
+                      protocol: !Protocols {}
+                  serializationFormats:
+                    - json
+                  usage:
+                    - input
+                    - output
+                  extensions:
+                    x-internal-autorest-anonymous-schema:
+                      anonymous: true
+                    x-ms-client-flatten: true
+                  language: !Languages 
+                    default:
+                      name: SubProductProperties
+                      description: ''
+                      namespace: ''
+                  protocol: !Protocols {}
+                serializedName: properties
+                extensions:
+                  x-ms-client-flatten: true
                 language: !Languages 
                   default:
-                    name: provisioningState
-                    description: ''
-                protocol: !Protocols {}
-              - !Property 
-                schema: *ref_17
-                flattenedNames:
-                  - properties
-                  - provisioningStateValues
-                readOnly: true
-                serializedName: provisioningStateValues
-                language: !Languages 
-                  default:
-                    name: provisioningStateValues
+                    name: properties
                     description: ''
                 protocol: !Protocols {}
             serializationFormats:
@@ -2129,10 +2178,10 @@ schemas: !Schemas
                 namespace: ''
             protocol: !Protocols {}
         immediate:
-          - *ref_18
+          - *ref_19
       properties:
         - !Property 
-          schema: *ref_19
+          schema: *ref_20
           readOnly: true
           serializedName: id
           language: !Languages 
@@ -2153,7 +2202,8 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - *ref_18
+    - *ref_19
+    - *ref_21
     - !ObjectSchema 
       type: object
       apiVersions:
@@ -2161,7 +2211,7 @@ schemas: !Schemas
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_20
+          schema: *ref_22
           serializedName: status
           language: !Languages 
             default:
@@ -2169,14 +2219,14 @@ schemas: !Schemas
               description: The status of the request
           protocol: !Protocols {}
         - !Property 
-          schema: !ObjectSchema &ref_23
+          schema: !ObjectSchema &ref_25
             type: object
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
             properties:
               - !Property 
-                schema: *ref_21
+                schema: *ref_23
                 serializedName: code
                 language: !Languages 
                   default:
@@ -2184,7 +2234,7 @@ schemas: !Schemas
                     description: The error code for an operation failure
                 protocol: !Protocols {}
               - !Property 
-                schema: *ref_22
+                schema: *ref_24
                 serializedName: message
                 language: !Languages 
                   default:
@@ -2212,9 +2262,9 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - *ref_23
+    - *ref_25
   arrays:
-    - !ArraySchema &ref_31
+    - !ArraySchema &ref_33
       type: array
       apiVersions:
         - !ApiVersion 
@@ -2226,7 +2276,7 @@ schemas: !Schemas
           description: Array of Product
       protocol: !Protocols {}
 globalParameters:
-  - !Parameter &ref_24
+  - !Parameter &ref_26
     schema: *ref_0
     clientDefaultValue: http://localhost:3000
     implementation: Client
@@ -2251,12 +2301,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2268,7 +2318,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_27
+              - !Parameter &ref_29
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2281,7 +2331,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2294,7 +2344,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_27
+              - *ref_29
             language: !Languages 
               default:
                 name: ''
@@ -2333,7 +2383,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2357,12 +2407,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2374,7 +2424,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_29
+              - !Parameter &ref_31
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2387,7 +2437,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2400,7 +2450,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_29
+              - *ref_31
             language: !Languages 
               default:
                 name: ''
@@ -2438,7 +2488,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2462,12 +2512,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2479,7 +2529,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_30
+              - !Parameter &ref_32
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2492,7 +2542,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2505,7 +2555,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_30
+              - *ref_32
             language: !Languages 
               default:
                 name: ''
@@ -2535,7 +2585,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2559,12 +2609,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2589,7 +2639,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_31
+            schema: *ref_33
             language: !Languages 
               default:
                 name: ''
@@ -2610,14 +2660,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_32
+                    schema: *ref_34
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/list/pollingGet'
                   - !HttpHeader 
-                    schema: *ref_33
+                    schema: *ref_35
                     header: Location
                     language:
                       default:
@@ -2627,7 +2677,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2651,12 +2701,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2668,7 +2718,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_34
+              - !Parameter &ref_36
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2681,7 +2731,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2694,7 +2744,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_34
+              - *ref_36
             language: !Languages 
               default:
                 name: ''
@@ -2724,7 +2774,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2748,12 +2798,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2765,7 +2815,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_35
+              - !Parameter &ref_37
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2778,7 +2828,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2791,7 +2841,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_35
+              - *ref_37
             language: !Languages 
               default:
                 name: ''
@@ -2821,7 +2871,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2845,12 +2895,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2862,7 +2912,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_36
+              - !Parameter &ref_38
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2875,7 +2925,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2888,7 +2938,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_36
+              - *ref_38
             language: !Languages 
               default:
                 name: ''
@@ -2931,7 +2981,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -2955,12 +3005,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -2972,7 +3022,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_37
+              - !Parameter &ref_39
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -2985,7 +3035,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -2998,7 +3048,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_37
+              - *ref_39
             language: !Languages 
               default:
                 name: ''
@@ -3028,7 +3078,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3052,12 +3102,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3069,7 +3119,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_38
+              - !Parameter &ref_40
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -3082,7 +3132,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3095,7 +3145,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_38
+              - *ref_40
             language: !Languages 
               default:
                 name: ''
@@ -3138,7 +3188,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3162,12 +3212,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3179,7 +3229,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_39
+              - !Parameter &ref_41
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -3192,7 +3242,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3205,7 +3255,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_39
+              - *ref_41
             language: !Languages 
               default:
                 name: ''
@@ -3235,7 +3285,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3259,117 +3309,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
-                implementation: Method
-                origin: modelerfour:synthesized/content-type
-                required: true
-                language: !Languages 
-                  default:
-                    name: contentType
-                    description: Body Parameter content-type
-                    serializedName: Content-Type
-                protocol: !Protocols 
-                  http: !HttpParameter 
-                    in: header
-              - !Parameter &ref_40
-                schema: *ref_5
-                implementation: Method
-                required: false
-                language: !Languages 
-                  default:
-                    name: product
-                    description: Product to put
-                protocol: !Protocols 
-                  http: !HttpParameter 
-                    in: body
-                    style: json
-              - !Parameter 
-                schema: *ref_26
-                implementation: Method
-                origin: modelerfour:synthesized/accept
-                required: true
-                language: !Languages 
-                  default:
-                    name: accept
-                    description: Accept header
-                    serializedName: Accept
-                protocol: !Protocols 
-                  http: !HttpParameter 
-                    in: header
-            signatureParameters:
-              - *ref_40
-            language: !Languages 
-              default:
-                name: ''
-                description: ''
-            protocol: !Protocols 
-              http: !HttpWithBodyRequest 
-                path: /lro/put/noheader/202/200
-                method: put
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                uri: '{$host}'
-        signatureParameters: []
-        responses:
-          - !SchemaResponse 
-            schema: *ref_5
-            language: !Languages 
-              default:
-                name: ''
-                description: Initial response with ProvisioningState='Accepted'
-            protocol: !Protocols 
-              http: !HttpResponse 
-                headers:
-                  - !HttpHeader 
-                    schema: *ref_41
-                    header: location
-                    language:
-                      default:
-                        name: Location
-                        description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - '202'
-        exceptions:
-          - !SchemaResponse 
-            schema: *ref_28
-            language: !Languages 
-              default:
-                name: ''
-                description: Unexpected error
-            protocol: !Protocols 
-              http: !HttpResponse 
-                knownMediaType: json
-                mediaTypes:
-                  - application/json
-                statusCodes:
-                  - default
-        extensions:
-          x-ms-long-running-operation: true
-        language: !Languages 
-          default:
-            name: PutNoHeaderInRetry
-            description: Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
-        protocol: !Protocols {}
-      - !Operation 
-        apiVersions:
-          - !ApiVersion 
-            version: 1.0.0
-        parameters:
-          - *ref_24
-        requests:
-          - !Request 
-            parameters:
-              - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3394,7 +3339,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3408,6 +3353,111 @@ operationGroups:
                     in: header
             signatureParameters:
               - *ref_42
+            language: !Languages 
+              default:
+                name: ''
+                description: ''
+            protocol: !Protocols 
+              http: !HttpWithBodyRequest 
+                path: /lro/put/noheader/202/200
+                method: put
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                uri: '{$host}'
+        signatureParameters: []
+        responses:
+          - !SchemaResponse 
+            schema: *ref_5
+            language: !Languages 
+              default:
+                name: ''
+                description: Initial response with ProvisioningState='Accepted'
+            protocol: !Protocols 
+              http: !HttpResponse 
+                headers:
+                  - !HttpHeader 
+                    schema: *ref_43
+                    header: location
+                    language:
+                      default:
+                        name: Location
+                        description: 'Location to poll for result status: will be set to /lro/putasync/noheader/202/200/operationResults'
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - '202'
+        exceptions:
+          - !SchemaResponse 
+            schema: *ref_30
+            language: !Languages 
+              default:
+                name: ''
+                description: Unexpected error
+            protocol: !Protocols 
+              http: !HttpResponse 
+                knownMediaType: json
+                mediaTypes:
+                  - application/json
+                statusCodes:
+                  - default
+        extensions:
+          x-ms-long-running-operation: true
+        language: !Languages 
+          default:
+            name: PutNoHeaderInRetry
+            description: Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
+        protocol: !Protocols {}
+      - !Operation 
+        apiVersions:
+          - !ApiVersion 
+            version: 1.0.0
+        parameters:
+          - *ref_26
+        requests:
+          - !Request 
+            parameters:
+              - !Parameter 
+                schema: *ref_27
+                implementation: Method
+                origin: modelerfour:synthesized/content-type
+                required: true
+                language: !Languages 
+                  default:
+                    name: contentType
+                    description: Body Parameter content-type
+                    serializedName: Content-Type
+                protocol: !Protocols 
+                  http: !HttpParameter 
+                    in: header
+              - !Parameter &ref_44
+                schema: *ref_5
+                implementation: Method
+                required: false
+                language: !Languages 
+                  default:
+                    name: product
+                    description: Product to put
+                protocol: !Protocols 
+                  http: !HttpParameter 
+                    in: body
+                    style: json
+              - !Parameter 
+                schema: *ref_28
+                implementation: Method
+                origin: modelerfour:synthesized/accept
+                required: true
+                language: !Languages 
+                  default:
+                    name: accept
+                    description: Accept header
+                    serializedName: Accept
+                protocol: !Protocols 
+                  http: !HttpParameter 
+                    in: header
+            signatureParameters:
+              - *ref_44
             language: !Languages 
               default:
                 name: ''
@@ -3432,21 +3482,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_43
+                    schema: *ref_45
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_44
+                    schema: *ref_46
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_45
+                    schema: *ref_47
                     header: Retry-After
                     language:
                       default:
@@ -3459,7 +3509,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3483,12 +3533,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3500,7 +3550,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_46
+              - !Parameter &ref_48
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -3513,7 +3563,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3526,7 +3576,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_46
+              - *ref_48
             language: !Languages 
               default:
                 name: ''
@@ -3551,14 +3601,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_47
+                    schema: *ref_49
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/noretry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_48
+                    schema: *ref_50
                     header: Location
                     language:
                       default:
@@ -3571,7 +3621,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3595,12 +3645,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3612,7 +3662,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_49
+              - !Parameter &ref_51
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -3625,7 +3675,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3638,7 +3688,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_49
+              - *ref_51
             language: !Languages 
               default:
                 name: ''
@@ -3663,21 +3713,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_50
+                    schema: *ref_52
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_51
+                    schema: *ref_53
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_52
+                    schema: *ref_54
                     header: Retry-After
                     language:
                       default:
@@ -3690,7 +3740,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3714,12 +3764,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3731,7 +3781,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_53
+              - !Parameter &ref_55
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -3744,7 +3794,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3757,7 +3807,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_53
+              - *ref_55
             language: !Languages 
               default:
                 name: ''
@@ -3782,14 +3832,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_54
+                    schema: *ref_56
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/noretry/canceled/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_55
+                    schema: *ref_57
                     header: Location
                     language:
                       default:
@@ -3802,7 +3852,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3826,12 +3876,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3843,7 +3893,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_56
+              - !Parameter &ref_58
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -3856,7 +3906,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3869,7 +3919,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_56
+              - *ref_58
             language: !Languages 
               default:
                 name: ''
@@ -3894,7 +3944,7 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_57
+                    schema: *ref_59
                     header: Azure-AsyncOperation
                     language:
                       default:
@@ -3907,7 +3957,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -3931,12 +3981,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -3948,8 +3998,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_59
-                schema: *ref_58
+              - !Parameter &ref_61
+                schema: *ref_60
                 implementation: Method
                 required: false
                 language: !Languages 
@@ -3961,7 +4011,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -3974,7 +4024,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_59
+              - *ref_61
             language: !Languages 
               default:
                 name: ''
@@ -3990,7 +4040,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_58
+            schema: *ref_60
             language: !Languages 
               default:
                 name: ''
@@ -4004,7 +4054,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4028,12 +4078,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4045,8 +4095,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_60
-                schema: *ref_58
+              - !Parameter &ref_62
+                schema: *ref_60
                 implementation: Method
                 required: false
                 language: !Languages 
@@ -4058,7 +4108,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4071,7 +4121,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_60
+              - *ref_62
             language: !Languages 
               default:
                 name: ''
@@ -4087,7 +4137,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_58
+            schema: *ref_60
             language: !Languages 
               default:
                 name: ''
@@ -4101,7 +4151,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4125,12 +4175,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4142,8 +4192,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_61
-                schema: *ref_18
+              - !Parameter &ref_63
+                schema: *ref_19
                 implementation: Method
                 required: false
                 language: !Languages 
@@ -4155,7 +4205,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4168,7 +4218,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_61
+              - *ref_63
             language: !Languages 
               default:
                 name: ''
@@ -4184,7 +4234,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_18
+            schema: *ref_19
             language: !Languages 
               default:
                 name: ''
@@ -4198,7 +4248,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4222,12 +4272,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -4239,8 +4289,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_62
-                schema: *ref_18
+              - !Parameter &ref_64
+                schema: *ref_19
                 implementation: Method
                 required: false
                 language: !Languages 
@@ -4252,7 +4302,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4265,7 +4315,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_62
+              - *ref_64
             language: !Languages 
               default:
                 name: ''
@@ -4281,7 +4331,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_18
+            schema: *ref_19
             language: !Languages 
               default:
                 name: ''
@@ -4295,7 +4345,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4319,12 +4369,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4371,14 +4421,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_63
+                    schema: *ref_65
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/delete/provisioning/202/accepted/200/succeeded'
                   - !HttpHeader 
-                    schema: *ref_64
+                    schema: *ref_66
                     header: Retry-After
                     language:
                       default:
@@ -4391,7 +4441,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4417,12 +4467,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4469,14 +4519,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_65
+                    schema: *ref_67
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/delete/provisioning/202/deleting/200/failed'
                   - !HttpHeader 
-                    schema: *ref_66
+                    schema: *ref_68
                     header: Retry-After
                     language:
                       default:
@@ -4489,7 +4539,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4513,12 +4563,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4565,14 +4615,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_67
+                    schema: *ref_69
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/delete/provisioning/202/deleting/200/canceled'
                   - !HttpHeader 
-                    schema: *ref_68
+                    schema: *ref_70
                     header: Retry-After
                     language:
                       default:
@@ -4585,7 +4635,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4611,12 +4661,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4651,7 +4701,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4675,12 +4725,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4726,14 +4776,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_69
+                    schema: *ref_71
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/delete/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_70
+                    schema: *ref_72
                     header: Retry-After
                     language:
                       default:
@@ -4743,7 +4793,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4767,12 +4817,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4818,14 +4868,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_71
+                    schema: *ref_73
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/delete/202/noretry/204'
                   - !HttpHeader 
-                    schema: *ref_72
+                    schema: *ref_74
                     header: Retry-After
                     language:
                       default:
@@ -4835,7 +4885,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4859,12 +4909,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4897,7 +4947,7 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_73
+                    schema: *ref_75
                     header: Location
                     language:
                       default:
@@ -4916,7 +4966,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -4940,12 +4990,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -4978,7 +5028,7 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_74
+                    schema: *ref_76
                     header: Location
                     language:
                       default:
@@ -4997,7 +5047,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5021,12 +5071,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5059,21 +5109,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_75
+                    schema: *ref_77
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_76
+                    schema: *ref_78
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_77
+                    schema: *ref_79
                     header: Retry-After
                     language:
                       default:
@@ -5083,7 +5133,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5107,12 +5157,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5145,21 +5195,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_78
+                    schema: *ref_80
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/noretry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_79
+                    schema: *ref_81
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/noretry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_80
+                    schema: *ref_82
                     header: Retry-After
                     language:
                       default:
@@ -5169,7 +5219,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5193,12 +5243,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5231,21 +5281,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_81
+                    schema: *ref_83
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_82
+                    schema: *ref_84
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_83
+                    schema: *ref_85
                     header: Retry-After
                     language:
                       default:
@@ -5255,7 +5305,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5279,12 +5329,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5317,21 +5367,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_84
+                    schema: *ref_86
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/canceled/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_85
+                    schema: *ref_87
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/canceled/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_86
+                    schema: *ref_88
                     header: Retry-After
                     language:
                       default:
@@ -5341,7 +5391,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5365,12 +5415,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5395,7 +5445,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_58
+            schema: *ref_60
             language: !Languages 
               default:
                 name: ''
@@ -5408,7 +5458,7 @@ operationGroups:
                 statusCodes:
                   - '200'
           - !SchemaResponse 
-            schema: *ref_58
+            schema: *ref_60
             language: !Languages 
               default:
                 name: ''
@@ -5422,7 +5472,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5446,12 +5496,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5463,7 +5513,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_87
+              - !Parameter &ref_89
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -5476,7 +5526,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5489,7 +5539,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_87
+              - *ref_89
             language: !Languages 
               default:
                 name: ''
@@ -5513,14 +5563,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_88
+                    schema: *ref_90
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/post/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_89
+                    schema: *ref_91
                     header: Retry-After
                     language:
                       default:
@@ -5530,7 +5580,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5554,12 +5604,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5571,7 +5621,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_90
+              - !Parameter &ref_92
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -5584,7 +5634,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5597,7 +5647,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_90
+              - *ref_92
             language: !Languages 
               default:
                 name: ''
@@ -5622,14 +5672,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_91
+                    schema: *ref_93
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/post/202/noretry/204'
                   - !HttpHeader 
-                    schema: *ref_92
+                    schema: *ref_94
                     header: Retry-After
                     language:
                       default:
@@ -5642,7 +5692,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5666,12 +5716,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5710,7 +5760,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5736,12 +5786,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5780,7 +5830,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5806,12 +5856,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5850,7 +5900,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -5876,12 +5926,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -5893,7 +5943,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_93
+              - !Parameter &ref_95
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -5906,7 +5956,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -5919,7 +5969,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_93
+              - *ref_95
             language: !Languages 
               default:
                 name: ''
@@ -5956,21 +6006,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_94
+                    schema: *ref_96
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_95
+                    schema: *ref_97
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_96
+                    schema: *ref_98
                     header: Retry-After
                     language:
                       default:
@@ -5980,7 +6030,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6004,12 +6054,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6021,7 +6071,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_97
+              - !Parameter &ref_99
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -6034,7 +6084,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6047,7 +6097,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_97
+              - *ref_99
             language: !Languages 
               default:
                 name: ''
@@ -6084,21 +6134,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_98
+                    schema: *ref_100
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_99
+                    schema: *ref_101
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_100
+                    schema: *ref_102
                     header: Retry-After
                     language:
                       default:
@@ -6108,7 +6158,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6132,12 +6182,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6149,7 +6199,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_101
+              - !Parameter &ref_103
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -6162,7 +6212,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6175,7 +6225,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_101
+              - *ref_103
             language: !Languages 
               default:
                 name: ''
@@ -6199,21 +6249,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_102
+                    schema: *ref_104
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_103
+                    schema: *ref_105
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_104
+                    schema: *ref_106
                     header: Retry-After
                     language:
                       default:
@@ -6223,7 +6273,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6247,12 +6297,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6264,7 +6314,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_105
+              - !Parameter &ref_107
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -6277,7 +6327,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6290,7 +6340,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_105
+              - *ref_107
             language: !Languages 
               default:
                 name: ''
@@ -6314,21 +6364,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_106
+                    schema: *ref_108
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/canceled/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_107
+                    schema: *ref_109
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/canceled/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_108
+                    schema: *ref_110
                     header: Retry-After
                     language:
                       default:
@@ -6338,7 +6388,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6370,12 +6420,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6387,7 +6437,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_109
+              - !Parameter &ref_111
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -6400,7 +6450,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6413,7 +6463,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_109
+              - *ref_111
             language: !Languages 
               default:
                 name: ''
@@ -6456,7 +6506,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6482,12 +6532,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6499,7 +6549,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_110
+              - !Parameter &ref_112
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -6512,7 +6562,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6525,7 +6575,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_110
+              - *ref_112
             language: !Languages 
               default:
                 name: ''
@@ -6550,21 +6600,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_111
+                    schema: *ref_113
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_112
+                    schema: *ref_114
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_113
+                    schema: *ref_115
                     header: Retry-After
                     language:
                       default:
@@ -6577,7 +6627,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6601,12 +6651,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6653,14 +6703,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_114
+                    schema: *ref_116
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/delete/provisioning/202/accepted/200/succeeded'
                   - !HttpHeader 
-                    schema: *ref_115
+                    schema: *ref_117
                     header: Retry-After
                     language:
                       default:
@@ -6673,7 +6723,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6699,12 +6749,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6737,14 +6787,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_116
+                    schema: *ref_118
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_117
+                    schema: *ref_119
                     header: Retry-After
                     language:
                       default:
@@ -6754,7 +6804,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6778,12 +6828,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6816,21 +6866,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_118
+                    schema: *ref_120
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/retryerror/deleteasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_119
+                    schema: *ref_121
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/deleteasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_120
+                    schema: *ref_122
                     header: Retry-After
                     language:
                       default:
@@ -6840,7 +6890,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6864,12 +6914,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6881,7 +6931,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_121
+              - !Parameter &ref_123
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -6894,7 +6944,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -6907,7 +6957,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_121
+              - *ref_123
             language: !Languages 
               default:
                 name: ''
@@ -6931,14 +6981,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_122
+                    schema: *ref_124
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_123
+                    schema: *ref_125
                     header: Retry-After
                     language:
                       default:
@@ -6948,7 +6998,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -6972,12 +7022,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -6989,7 +7039,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_124
+              - !Parameter &ref_126
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7002,7 +7052,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7015,7 +7065,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_124
+              - *ref_126
             language: !Languages 
               default:
                 name: ''
@@ -7039,21 +7089,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_125
+                    schema: *ref_127
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_126
+                    schema: *ref_128
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_127
+                    schema: *ref_129
                     header: Retry-After
                     language:
                       default:
@@ -7063,7 +7113,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7097,12 +7147,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -7114,7 +7164,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_128
+              - !Parameter &ref_130
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7127,7 +7177,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7140,7 +7190,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_128
+              - *ref_130
             language: !Languages 
               default:
                 name: ''
@@ -7183,7 +7233,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7207,12 +7257,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -7224,7 +7274,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_129
+              - !Parameter &ref_131
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7237,7 +7287,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7250,7 +7300,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_129
+              - *ref_131
             language: !Languages 
               default:
                 name: ''
@@ -7293,7 +7343,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7317,12 +7367,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -7334,7 +7384,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_130
+              - !Parameter &ref_132
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7347,7 +7397,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7360,7 +7410,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_130
+              - *ref_132
             language: !Languages 
               default:
                 name: ''
@@ -7403,7 +7453,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7427,12 +7477,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -7444,7 +7494,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_131
+              - !Parameter &ref_133
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7457,7 +7507,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7470,7 +7520,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_131
+              - *ref_133
             language: !Languages 
               default:
                 name: ''
@@ -7495,21 +7545,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_132
+                    schema: *ref_134
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400'
                   - !HttpHeader 
-                    schema: *ref_133
+                    schema: *ref_135
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400'
                   - !HttpHeader 
-                    schema: *ref_134
+                    schema: *ref_136
                     header: Retry-After
                     language:
                       default:
@@ -7522,7 +7572,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7546,12 +7596,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7584,14 +7634,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_135
+                    schema: *ref_137
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_136
+                    schema: *ref_138
                     header: Retry-After
                     language:
                       default:
@@ -7601,7 +7651,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7625,12 +7675,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7663,14 +7713,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_137
+                    schema: *ref_139
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_138
+                    schema: *ref_140
                     header: Retry-After
                     language:
                       default:
@@ -7680,7 +7730,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7704,12 +7754,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7742,21 +7792,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_139
+                    schema: *ref_141
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/nonretryerror/deleteasync/retry/operationResults/400'
                   - !HttpHeader 
-                    schema: *ref_140
+                    schema: *ref_142
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/nonretryerror/deleteasync/retry/operationResults/400'
                   - !HttpHeader 
-                    schema: *ref_141
+                    schema: *ref_143
                     header: Retry-After
                     language:
                       default:
@@ -7766,7 +7816,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7790,12 +7840,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -7807,7 +7857,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_142
+              - !Parameter &ref_144
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7820,7 +7870,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7833,7 +7883,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_142
+              - *ref_144
             language: !Languages 
               default:
                 name: ''
@@ -7857,14 +7907,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_143
+                    schema: *ref_145
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_144
+                    schema: *ref_146
                     header: Retry-After
                     language:
                       default:
@@ -7874,7 +7924,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -7898,12 +7948,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -7915,7 +7965,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_145
+              - !Parameter &ref_147
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -7928,7 +7978,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -7941,7 +7991,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_145
+              - *ref_147
             language: !Languages 
               default:
                 name: ''
@@ -7965,14 +8015,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_146
+                    schema: *ref_148
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_147
+                    schema: *ref_149
                     header: Retry-After
                     language:
                       default:
@@ -7982,7 +8032,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8006,12 +8056,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8023,7 +8073,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_148
+              - !Parameter &ref_150
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8036,7 +8086,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8049,7 +8099,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_148
+              - *ref_150
             language: !Languages 
               default:
                 name: ''
@@ -8073,21 +8123,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_149
+                    schema: *ref_151
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400'
                   - !HttpHeader 
-                    schema: *ref_150
+                    schema: *ref_152
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/nonretryerror/putasync/retry/operationResults/400'
                   - !HttpHeader 
-                    schema: *ref_151
+                    schema: *ref_153
                     header: Retry-After
                     language:
                       default:
@@ -8097,7 +8147,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8121,12 +8171,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8138,7 +8188,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_152
+              - !Parameter &ref_154
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8151,7 +8201,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8164,7 +8214,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_152
+              - *ref_154
             language: !Languages 
               default:
                 name: ''
@@ -8207,7 +8257,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8231,12 +8281,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8248,7 +8298,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_153
+              - !Parameter &ref_155
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8261,7 +8311,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8274,7 +8324,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_153
+              - *ref_155
             language: !Languages 
               default:
                 name: ''
@@ -8299,21 +8349,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_154
+                    schema: *ref_156
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_155
+                    schema: *ref_157
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_156
+                    schema: *ref_158
                     header: Retry-After
                     language:
                       default:
@@ -8326,7 +8376,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8350,12 +8400,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8367,7 +8417,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_157
+              - !Parameter &ref_159
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8380,7 +8430,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8393,7 +8443,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_157
+              - *ref_159
             language: !Languages 
               default:
                 name: ''
@@ -8418,21 +8468,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_158
+                    schema: *ref_160
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_159
+                    schema: *ref_161
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_160
+                    schema: *ref_162
                     header: Retry-After
                     language:
                       default:
@@ -8445,7 +8495,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8469,12 +8519,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8509,7 +8559,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8533,12 +8583,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8571,21 +8621,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_161
+                    schema: *ref_163
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_162
+                    schema: *ref_164
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/deleteasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_163
+                    schema: *ref_165
                     header: Retry-After
                     language:
                       default:
@@ -8595,7 +8645,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8619,12 +8669,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8636,7 +8686,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_164
+              - !Parameter &ref_166
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8649,7 +8699,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8662,7 +8712,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_164
+              - *ref_166
             language: !Languages 
               default:
                 name: ''
@@ -8686,14 +8736,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_165
+                    schema: *ref_167
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will not be set'
                   - !HttpHeader 
-                    schema: *ref_166
+                    schema: *ref_168
                     header: Retry-After
                     language:
                       default:
@@ -8703,7 +8753,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8727,12 +8777,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8744,7 +8794,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_167
+              - !Parameter &ref_169
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8757,7 +8807,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8770,7 +8820,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_167
+              - *ref_169
             language: !Languages 
               default:
                 name: ''
@@ -8794,21 +8844,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_168
+                    schema: *ref_170
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/error/putasync/retry/failed/operationResults/nopayload'
                   - !HttpHeader 
-                    schema: *ref_169
+                    schema: *ref_171
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/error/putasync/retry/failed/operationResults/nopayload'
                   - !HttpHeader 
-                    schema: *ref_170
+                    schema: *ref_172
                     header: Retry-After
                     language:
                       default:
@@ -8818,7 +8868,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8842,12 +8892,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8859,7 +8909,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_171
+              - !Parameter &ref_173
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8872,7 +8922,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8885,7 +8935,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_171
+              - *ref_173
             language: !Languages 
               default:
                 name: ''
@@ -8924,7 +8974,7 @@ operationGroups:
                   - '204'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -8948,12 +8998,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -8965,7 +9015,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_172
+              - !Parameter &ref_174
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -8978,7 +9028,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -8991,7 +9041,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_172
+              - *ref_174
             language: !Languages 
               default:
                 name: ''
@@ -9016,21 +9066,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_173
+                    schema: *ref_175
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_174
+                    schema: *ref_176
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_175
+                    schema: *ref_177
                     header: Retry-After
                     language:
                       default:
@@ -9043,7 +9093,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9067,12 +9117,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -9084,7 +9134,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_176
+              - !Parameter &ref_178
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -9097,7 +9147,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9110,7 +9160,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_176
+              - *ref_178
             language: !Languages 
               default:
                 name: ''
@@ -9135,21 +9185,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_177
+                    schema: *ref_179
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_178
+                    schema: *ref_180
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/putasync/retry/failed/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_179
+                    schema: *ref_181
                     header: Retry-After
                     language:
                       default:
@@ -9162,7 +9212,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9186,12 +9236,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9224,14 +9274,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_180
+                    schema: *ref_182
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /foo'
                   - !HttpHeader 
-                    schema: *ref_181
+                    schema: *ref_183
                     header: Retry-After
                     language:
                       default:
@@ -9241,7 +9291,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9265,12 +9315,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9303,21 +9353,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_182
+                    schema: *ref_184
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /foo'
                   - !HttpHeader 
-                    schema: *ref_183
+                    schema: *ref_185
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /foo'
                   - !HttpHeader 
-                    schema: *ref_184
+                    schema: *ref_186
                     header: Retry-After
                     language:
                       default:
@@ -9327,7 +9377,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9351,12 +9401,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9389,21 +9439,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_185
+                    schema: *ref_187
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling'
                   - !HttpHeader 
-                    schema: *ref_186
+                    schema: *ref_188
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling'
                   - !HttpHeader 
-                    schema: *ref_187
+                    schema: *ref_189
                     header: Retry-After
                     language:
                       default:
@@ -9413,7 +9463,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9437,12 +9487,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -9454,7 +9504,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_188
+              - !Parameter &ref_190
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -9467,7 +9517,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9480,7 +9530,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_188
+              - *ref_190
             language: !Languages 
               default:
                 name: ''
@@ -9504,14 +9554,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_189
+                    schema: *ref_191
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /foo'
                   - !HttpHeader 
-                    schema: *ref_190
+                    schema: *ref_192
                     header: Retry-After
                     language:
                       default:
@@ -9521,7 +9571,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9545,12 +9595,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -9562,7 +9612,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_191
+              - !Parameter &ref_193
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -9575,7 +9625,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9588,7 +9638,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_191
+              - *ref_193
             language: !Languages 
               default:
                 name: ''
@@ -9612,21 +9662,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_192
+                    schema: *ref_194
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to foo'
                   - !HttpHeader 
-                    schema: *ref_193
+                    schema: *ref_195
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to foo'
                   - !HttpHeader 
-                    schema: *ref_194
+                    schema: *ref_196
                     header: Retry-After
                     language:
                       default:
@@ -9636,7 +9686,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9660,12 +9710,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -9677,7 +9727,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_195
+              - !Parameter &ref_197
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -9690,7 +9740,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9703,7 +9753,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_195
+              - *ref_197
             language: !Languages 
               default:
                 name: ''
@@ -9727,21 +9777,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_196
+                    schema: *ref_198
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling'
                   - !HttpHeader 
-                    schema: *ref_197
+                    schema: *ref_199
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling'
                   - !HttpHeader 
-                    schema: *ref_198
+                    schema: *ref_200
                     header: Retry-After
                     language:
                       default:
@@ -9751,7 +9801,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9783,12 +9833,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -9800,7 +9850,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_199
+              - !Parameter &ref_201
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -9813,7 +9863,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9826,7 +9876,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_199
+              - *ref_201
             language: !Languages 
               default:
                 name: ''
@@ -9851,21 +9901,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_200
+                    schema: *ref_202
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_201
+                    schema: *ref_203
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_202
+                    schema: *ref_204
                     header: Retry-After
                     language:
                       default:
@@ -9878,7 +9928,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -9904,12 +9954,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -9921,7 +9971,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_203
+              - !Parameter &ref_205
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -9934,7 +9984,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -9947,7 +9997,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_203
+              - *ref_205
             language: !Languages 
               default:
                 name: ''
@@ -9990,7 +10040,7 @@ operationGroups:
                   - '201'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -10016,12 +10066,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -10033,7 +10083,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_204
+              - !Parameter &ref_206
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -10046,7 +10096,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -10059,7 +10109,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_204
+              - *ref_206
             language: !Languages 
               default:
                 name: ''
@@ -10083,14 +10133,14 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_205
+                    schema: *ref_207
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/customheader/post/202/retry/200'
                   - !HttpHeader 
-                    schema: *ref_206
+                    schema: *ref_208
                     header: Retry-After
                     language:
                       default:
@@ -10100,7 +10150,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''
@@ -10126,12 +10176,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_24
+          - *ref_26
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_25
+                schema: *ref_27
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -10143,7 +10193,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_207
+              - !Parameter &ref_209
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -10156,7 +10206,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_26
+                schema: *ref_28
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -10169,7 +10219,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_207
+              - *ref_209
             language: !Languages 
               default:
                 name: ''
@@ -10193,21 +10243,21 @@ operationGroups:
               http: !HttpResponse 
                 headers:
                   - !HttpHeader 
-                    schema: *ref_208
+                    schema: *ref_210
                     header: Azure-AsyncOperation
                     language:
                       default:
                         name: AzureAsyncOperation
                         description: 'Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_209
+                    schema: *ref_211
                     header: Location
                     language:
                       default:
                         name: Location
                         description: 'Location to poll for result status: will be set to /lro/customheader/putasync/retry/succeeded/operationResults/200'
                   - !HttpHeader 
-                    schema: *ref_210
+                    schema: *ref_212
                     header: Retry-After
                     language:
                       default:
@@ -10217,7 +10267,7 @@ operationGroups:
                   - '202'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_28
+            schema: *ref_30
             language: !Languages 
               default:
                 name: ''

--- a/test/TestServerProjectsLowLevel/lro/Generated/LRORetrysClient.cs
+++ b/test/TestServerProjectsLowLevel/lro/Generated/LRORetrysClient.cs
@@ -60,8 +60,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -72,8 +74,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -131,8 +135,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -143,8 +149,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -217,8 +225,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -229,8 +239,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -287,8 +299,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -299,8 +313,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -372,8 +388,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -430,8 +448,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -707,8 +727,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -765,8 +787,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -838,8 +862,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -896,8 +922,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 

--- a/test/TestServerProjectsLowLevel/lro/Generated/LROsClient.cs
+++ b/test/TestServerProjectsLowLevel/lro/Generated/LROsClient.cs
@@ -60,8 +60,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -72,8 +74,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -131,8 +135,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -143,8 +149,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -217,8 +225,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -229,8 +239,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -287,8 +299,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -299,8 +313,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -372,8 +388,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -384,8 +402,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -442,8 +462,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -454,8 +476,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -527,8 +551,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -585,8 +611,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -656,8 +684,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -668,8 +698,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -726,8 +758,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -738,8 +772,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -811,8 +847,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -823,8 +861,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -881,8 +921,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -893,8 +935,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -966,8 +1010,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -978,8 +1024,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1037,8 +1085,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1049,8 +1099,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1123,8 +1175,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1135,8 +1189,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1193,8 +1249,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1205,8 +1263,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1278,8 +1338,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1290,8 +1352,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1349,8 +1413,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1361,8 +1427,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1435,8 +1503,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1447,8 +1517,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1505,8 +1577,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1517,8 +1591,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1590,8 +1666,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1602,8 +1680,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1660,8 +1740,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1672,8 +1754,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1745,8 +1829,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1757,8 +1843,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1815,8 +1903,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1827,8 +1917,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1900,8 +1992,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1912,8 +2006,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1970,8 +2066,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1982,8 +2080,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2055,8 +2155,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2067,8 +2169,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2125,8 +2229,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2137,8 +2243,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2210,8 +2318,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2222,8 +2332,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2280,8 +2392,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2292,8 +2406,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2365,8 +2481,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2377,8 +2495,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2435,8 +2555,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2447,8 +2569,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2786,16 +2910,20 @@ namespace lro_LowLevel
         /// Schema for <c>Request Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
         /// Schema for <c>Response Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2848,16 +2976,20 @@ namespace lro_LowLevel
         /// Schema for <c>Request Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
         /// Schema for <c>Response Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2925,16 +3057,20 @@ namespace lro_LowLevel
         /// Schema for <c>Request Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
         /// Schema for <c>Response Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2987,16 +3123,20 @@ namespace lro_LowLevel
         /// Schema for <c>Request Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
         /// Schema for <c>Response Body</c>:
         /// <code>{
         ///   id: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3068,8 +3208,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3126,8 +3268,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3197,8 +3341,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3255,8 +3401,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3326,8 +3474,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3384,8 +3534,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3558,8 +3710,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3616,8 +3770,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3687,8 +3843,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3745,8 +3903,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4557,8 +4717,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4615,8 +4777,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4688,8 +4852,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4700,8 +4866,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4758,8 +4926,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4770,8 +4940,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4843,8 +5015,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4900,8 +5074,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -4970,8 +5146,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5027,8 +5205,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5097,8 +5277,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5154,8 +5336,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5224,8 +5408,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5236,8 +5422,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5295,8 +5483,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5307,8 +5497,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5381,8 +5573,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5393,8 +5587,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5452,8 +5648,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5464,8 +5662,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5538,8 +5738,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5596,8 +5798,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5669,8 +5873,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -5727,8 +5933,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 

--- a/test/TestServerProjectsLowLevel/lro/Generated/LROsCustomHeaderClient.cs
+++ b/test/TestServerProjectsLowLevel/lro/Generated/LROsCustomHeaderClient.cs
@@ -60,8 +60,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -72,8 +74,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -130,8 +134,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -142,8 +148,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -215,8 +223,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -227,8 +237,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -286,8 +298,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -298,8 +312,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -372,8 +388,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -430,8 +448,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -503,8 +523,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -561,8 +583,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 

--- a/test/TestServerProjectsLowLevel/lro/Generated/LrosaDsClient.cs
+++ b/test/TestServerProjectsLowLevel/lro/Generated/LrosaDsClient.cs
@@ -60,8 +60,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -72,8 +74,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -131,8 +135,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -143,8 +149,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -217,8 +225,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -229,8 +239,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -288,8 +300,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -300,8 +314,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -374,8 +390,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -386,8 +404,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -445,8 +465,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -457,8 +479,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -531,8 +555,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -543,8 +569,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -601,8 +629,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -613,8 +643,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -995,8 +1027,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1053,8 +1087,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1126,8 +1162,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1184,8 +1222,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1257,8 +1297,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1315,8 +1357,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1388,8 +1432,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1400,8 +1446,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1459,8 +1507,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1471,8 +1521,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1545,8 +1597,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1557,8 +1611,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1615,8 +1671,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1627,8 +1685,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1700,8 +1760,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1712,8 +1774,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1770,8 +1834,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -1782,8 +1848,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2061,8 +2129,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2119,8 +2189,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2192,8 +2264,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2250,8 +2324,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2323,8 +2399,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2335,8 +2413,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2394,8 +2474,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2406,8 +2488,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2480,8 +2564,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2492,8 +2578,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2550,8 +2638,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2562,8 +2652,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2635,8 +2727,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2647,8 +2741,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2705,8 +2801,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -2717,8 +2815,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3099,8 +3199,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3157,8 +3259,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3230,8 +3334,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3288,8 +3394,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3361,8 +3469,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 
@@ -3419,8 +3529,10 @@ namespace lro_LowLevel
         ///   tags: Dictionary&lt;string, string&gt;,
         ///   location: string,
         ///   name: string,
-        ///   provisioningState: string,
-        ///   provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   properties: {
+        ///     provisioningState: string,
+        ///     provisioningStateValues: &quot;Succeeded&quot; | &quot;Failed&quot; | &quot;canceled&quot; | &quot;Accepted&quot; | &quot;Creating&quot; | &quot;Created&quot; | &quot;Updating&quot; | &quot;Updated&quot; | &quot;Deleting&quot; | &quot;Deleted&quot; | &quot;OK&quot;
+        ///   }
         /// }
         /// </code>
         /// 


### PR DESCRIPTION
Flatting and Grouping are two AutoRest features which cause parameters
to move around from their write locations. Since LLC's goal is to is
to not do these sort of transforms, we disable them in our AutoRest
configuration.

Since the generated code wasn't using this information, none of the
actual code changes. However, we were using schemas for the operations
(which had already been flatted/grouped) for generating documentation,
so there are some slight tweaks to the generated docs (and they now
correctly reflect the service payload).

Fixes #1316