### PR TITLE
Support multi collectionFormat in queryParams by honoring CodeModel's explode

### DIFF
--- a/samples/CognitiveSearch/Generated/DocumentsRestClient.cs
+++ b/samples/CognitiveSearch/Generated/DocumentsRestClient.cs
@@ -145,9 +145,9 @@ namespace CognitiveSearch
             {
                 uri.AppendQuery("queryType", searchOptions.QueryType.Value.ToSerialString(), true);
             }
-            foreach (var param in searchOptions.ScoringParameters)
+            foreach (var param0 in searchOptions.ScoringParameters)
             {
-                uri.AppendQuery("scoringParameter", param, true);
+                uri.AppendQuery("scoringParameter", param0, true);
             }
             if (searchOptions?.ScoringProfile != null)
             {

--- a/samples/CognitiveSearch/Generated/DocumentsRestClient.cs
+++ b/samples/CognitiveSearch/Generated/DocumentsRestClient.cs
@@ -119,7 +119,10 @@ namespace CognitiveSearch
             {
                 uri.AppendQuery("$count", searchOptions.IncludeTotalResultCount.Value, true);
             }
-            uri.AppendQueryDelimited("facet", searchOptions.Facets, ",", true);
+            foreach (var param in searchOptions.Facets)
+            {
+                uri.AppendQuery("facet", param, true);
+            }
             if (searchOptions?.Filter != null)
             {
                 uri.AppendQuery("$filter", searchOptions.Filter, true);
@@ -142,7 +145,10 @@ namespace CognitiveSearch
             {
                 uri.AppendQuery("queryType", searchOptions.QueryType.Value.ToSerialString(), true);
             }
-            uri.AppendQueryDelimited("scoringParameter", searchOptions.ScoringParameters, ",", true);
+            foreach (var param in searchOptions.ScoringParameters)
+            {
+                uri.AppendQuery("scoringParameter", param, true);
+            }
             if (searchOptions?.ScoringProfile != null)
             {
                 uri.AppendQuery("scoringProfile", searchOptions.ScoringProfile, true);

--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -334,21 +334,36 @@ namespace AutoRest.CSharp.Generation.Writers
         private static void WriteQueryParameter(CodeWriter writer, CodeWriterDeclaration uri, QueryParameter queryParameter)
         {
             string? delimiter = GetSerializationStyleDelimiter(queryParameter.SerializationStyle);
-            string method = delimiter != null
+            bool explode = queryParameter.Explode;
+            string method = delimiter != null && !explode
                 ? nameof(RequestUriBuilderExtensions.AppendQueryDelimited)
                 : nameof(RequestUriBuilderExtensions.AppendQuery);
 
             ReferenceOrConstant value = queryParameter.Value;
             using (WriteValueNullCheck(writer, value))
             {
-                writer.Append($"{uri}.{method}({queryParameter.Name:L}, ");
-                WriteConstantOrParameter(writer, value, enumAsString: true);
-                if (delimiter != null)
+                if (explode)
                 {
-                    writer.Append($", {delimiter:L}");
+                    writer.Line($"foreach(var param in {queryParameter.Name})");
+                    using (writer.Scope())
+                    {
+                        writer.Append($"{uri}.{method}({queryParameter.Name:L}, ");
+                        WriteConstantOrParameter(writer, new Reference("param", value.Type.Arguments.Length > 0 ? value.Type.Arguments[0]: value.Type), enumAsString: true);
+                        WriteSerializationFormat(writer, queryParameter.SerializationFormat);
+                        writer.Line($", {queryParameter.Escape:L});");
+                    }
                 }
-                WriteSerializationFormat(writer, queryParameter.SerializationFormat);
-                writer.Line($", {queryParameter.Escape:L});");
+                else
+                {
+                    writer.Append($"{uri}.{method}({queryParameter.Name:L}, ");
+                    WriteConstantOrParameter(writer, value, enumAsString: true);
+                    if (delimiter != null)
+                    {
+                        writer.Append($", {delimiter:L}");
+                    }
+                    WriteSerializationFormat(writer, queryParameter.SerializationFormat);
+                    writer.Line($", {queryParameter.Escape:L});");
+                }
             }
         }
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -344,7 +344,9 @@ namespace AutoRest.CSharp.Generation.Writers
             {
                 if (explode)
                 {
-                    writer.Line($"foreach(var param in {queryParameter.Name})");
+                    writer.Append($"foreach(var param in ");
+                    WriteConstantOrParameter(writer, value, enumAsString: true);
+                    writer.Line($")");
                     using (writer.Scope())
                     {
                         writer.Append($"{uri}.{method}({queryParameter.Name:L}, ");

--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -351,7 +351,7 @@ namespace AutoRest.CSharp.Generation.Writers
                     using (writer.Scope())
                     {
                         writer.Append($"{uri}.{method}({queryParameter.Name:L}, ");
-                        WriteConstantOrParameter(writer, new Reference("param", value.Type.Arguments.Length > 0 ? value.Type.Arguments[0]: value.Type), enumAsString: true);
+                        WriteConstantOrParameter(writer, new Reference(paramVariable.ActualName, value.Type.Arguments.Length > 0 ? value.Type.Arguments[0]: value.Type), enumAsString: true);
                         WriteSerializationFormat(writer, queryParameter.SerializationFormat);
                         writer.Line($", {queryParameter.Escape:L});");
                     }

--- a/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/RequestWriterHelpers.cs
@@ -344,7 +344,8 @@ namespace AutoRest.CSharp.Generation.Writers
             {
                 if (explode)
                 {
-                    writer.Append($"foreach(var param in ");
+                    var paramVariable = new CodeWriterDeclaration("param");
+                    writer.Append($"foreach(var {paramVariable:D} in ");
                     WriteConstantOrParameter(writer, value, enumAsString: true);
                     writer.Line($")");
                     using (writer.Scope())

--- a/src/AutoRest.CSharp/Common/Output/Models/Requests/QueryParameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Requests/QueryParameter.cs
@@ -7,13 +7,14 @@ namespace AutoRest.CSharp.Output.Models.Requests
 {
     internal class QueryParameter
     {
-        public QueryParameter(string name, ReferenceOrConstant value, RequestParameterSerializationStyle serializationStyle, bool escape, SerializationFormat serializationFormat)
+        public QueryParameter(string name, ReferenceOrConstant value, RequestParameterSerializationStyle serializationStyle, bool escape, SerializationFormat serializationFormat, bool explode)
         {
             Name = name;
             Value = value;
             SerializationStyle = serializationStyle;
             Escape = escape;
             SerializationFormat = serializationFormat;
+            Explode = explode;
         }
 
         public string Name { get; }
@@ -21,5 +22,6 @@ namespace AutoRest.CSharp.Output.Models.Requests
         public RequestParameterSerializationStyle SerializationStyle { get; }
         public SerializationFormat SerializationFormat { get; }
         public bool Escape { get; }
+        public bool Explode { get; }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -457,11 +457,7 @@ namespace AutoRest.CSharp.Output.Models
             }
         }
 
-        private static bool GetExplode(RequestParameter requestParameter)
-        {
-            var httpParameter = requestParameter.Protocol.Http as HttpParameter;
-            return httpParameter?.Explode ?? false;
-        }
+        private static bool GetExplode(RequestParameter requestParameter) => requestParameter.Protocol.Http is HttpParameter httpParameter && httpParameter.Explode == true;
 
         private static Schema GetValueSchema(RequestParameter requestParameter)
         {

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -232,7 +232,9 @@ namespace AutoRest.CSharp.Output.Models
                         reference,
                         GetSerializationStyle(requestParameter),
                         !requestParameter.Extensions!.SkipEncoding,
-                        GetSerializationFormat(requestParameter)));
+                        GetSerializationFormat(requestParameter),
+                        GetExplode(requestParameter)
+                    ));
                 }
             }
 
@@ -453,6 +455,12 @@ namespace AutoRest.CSharp.Output.Models
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        private static bool GetExplode(RequestParameter requestParameter)
+        {
+            var httpParameter = requestParameter.Protocol.Http as HttpParameter;
+            return httpParameter?.Explode ?? false;
         }
 
         private static Schema GetValueSchema(RequestParameter requestParameter)

--- a/test/AutoRest.TestServer.Tests/url-query.cs
+++ b/test/AutoRest.TestServer.Tests/url-query.cs
@@ -121,7 +121,6 @@ namespace AutoRest.TestServer.Tests
         public Task UrlQueriesArrayMultiNull() => TestStatus(async (host, pipeline) => await new url_multi_collectionFormat.QueriesClient(ClientDiagnostics, pipeline, host).ArrayStringMultiNullAsync( null));
 
         [Test]
-        [Ignore("https://github.com/Azure/autorest.csharp/issues/1161")]
         public Task UrlQueriesArrayMultiEmpty() => TestStatus(async (host, pipeline) => await new url_multi_collectionFormat.QueriesClient(ClientDiagnostics, pipeline, host).ArrayStringMultiEmptyAsync( new string[] { }));
 
         [Test]

--- a/test/TestProjects/BodyAndPath-LowLevel/Generated/BodyAndPathRestClient.cs
+++ b/test/TestProjects/BodyAndPath-LowLevel/Generated/BodyAndPathRestClient.cs
@@ -130,7 +130,10 @@ namespace BodyAndPath_LowLevel
             uri.AppendPath(itemNameStream, true);
             if (excluded != null)
             {
-                uri.AppendQueryDelimited("excluded", excluded, ",", true);
+                foreach (var param in excluded)
+                {
+                    uri.AppendQuery("excluded", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Content-Type", contentType.ToString());

--- a/test/TestServerProjects/url-multi-collectionFormat/Generated/QueriesRestClient.cs
+++ b/test/TestServerProjects/url-multi-collectionFormat/Generated/QueriesRestClient.cs
@@ -42,7 +42,10 @@ namespace url_multi_collectionFormat
             uri.AppendPath("/queries/array/multi/string/null", false);
             if (arrayQuery != null)
             {
-                uri.AppendQueryDelimited("arrayQuery", arrayQuery, ",", true);
+                foreach (var param in arrayQuery)
+                {
+                    uri.AppendQuery("arrayQuery", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -91,7 +94,10 @@ namespace url_multi_collectionFormat
             uri.AppendPath("/queries/array/multi/string/empty", false);
             if (arrayQuery != null)
             {
-                uri.AppendQueryDelimited("arrayQuery", arrayQuery, ",", true);
+                foreach (var param in arrayQuery)
+                {
+                    uri.AppendQuery("arrayQuery", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -140,7 +146,10 @@ namespace url_multi_collectionFormat
             uri.AppendPath("/queries/array/multi/string/valid", false);
             if (arrayQuery != null)
             {
-                uri.AppendQueryDelimited("arrayQuery", arrayQuery, ",", true);
+                foreach (var param in arrayQuery)
+                {
+                    uri.AppendQuery("arrayQuery", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");

--- a/test/TestServerProjectsLowLevel/url-multi-collectionFormat/Generated/QueriesRestClient.cs
+++ b/test/TestServerProjectsLowLevel/url-multi-collectionFormat/Generated/QueriesRestClient.cs
@@ -42,7 +42,10 @@ namespace url_multi_collectionFormat_LowLevel
             uri.AppendPath("/queries/array/multi/string/null", false);
             if (arrayQuery != null)
             {
-                uri.AppendQueryDelimited("arrayQuery", arrayQuery, ",", true);
+                foreach (var param in arrayQuery)
+                {
+                    uri.AppendQuery("arrayQuery", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -109,7 +112,10 @@ namespace url_multi_collectionFormat_LowLevel
             uri.AppendPath("/queries/array/multi/string/empty", false);
             if (arrayQuery != null)
             {
-                uri.AppendQueryDelimited("arrayQuery", arrayQuery, ",", true);
+                foreach (var param in arrayQuery)
+                {
+                    uri.AppendQuery("arrayQuery", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
@@ -176,7 +182,10 @@ namespace url_multi_collectionFormat_LowLevel
             uri.AppendPath("/queries/array/multi/string/valid", false);
             if (arrayQuery != null)
             {
-                uri.AppendQueryDelimited("arrayQuery", arrayQuery, ",", true);
+                foreach (var param in arrayQuery)
+                {
+                    uri.AppendQuery("arrayQuery", param, true);
+                }
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");


### PR DESCRIPTION
# Description
Fixes #1161 and https://github.com/Azure/autorest.csharp/issues/1230. 

According to swagger's QueryParameters behavior outlined https://swagger.io/docs/specification/serialization/, explode will be set to true in the code model, when collectionFormat will be set to multi (as described in [OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#fixed-fields-7)), which should result in a valid multiple query parameters generated as in `/users?id=3&id=4&id=5`. As mentioned in #1230, current behavior doesn't honor the present explode and incorrectly generates comma-delimitered value within single param: `/users?id=3,4,5`. Our service (defined at [route.json](https://github.com/Azure/azure-rest-api-specs/blob/9b489ff217acd3bd6d62b2932e42d3c08ed4d08c/specification/maps/data-plane/Route/preview/1.0/route.json#L284)) doesn't unfortunately support the later, and thus results in bad request on multiple such parameters passed:

![Screen Shot 2021-09-23 at 3 25 49 AM](https://user-images.githubusercontent.com/14032724/134426715-00205233-0eb7-4eab-908c-d9f906e287ac.png)

This PR resolves it with a following codegen change (when explode is set):

[from](https://github.com/ambientlight/azure-sdk-for-net/blob/d05ffa60fa639e3c756958fa0ba9058b5d433390/sdk/maps/Azure.Maps.Route/src/Generated/RouteRestClient.cs#L120): 

```csharp
uri.AppendQueryDelimited("avoid", avoid, ",", true);
```

[to](https://github.com/ambientlight/azure-sdk-for-net/blob/d6c30746eb7bd0ffa19e341d31082699f9723d83/sdk/maps/Azure.Maps.Route/src/Generated/RouteRestClient.cs#L114-L117):

```csharp
foreach (var param in avoid)
{
     uri.AppendQuery("avoid", param.ToString(), true);
}
```

Similar update has been recently merged in java sdk at https://github.com/Azure/autorest.java/pull/1161

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [x] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first