### PR TITLE
Refine CodeWriter to omit namespace if we could determine current namespace is the same

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriter.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriter.cs
@@ -290,9 +290,12 @@ namespace AutoRest.CSharp.Generation.Writers
             {
                 UseNamespace(type.Namespace);
 
-                AppendRaw("global::");
-                AppendRaw(type.Namespace);
-                AppendRaw(".");
+                if (_currentNamespace != type.Namespace)
+                {
+                    AppendRaw("global::");
+                    AppendRaw(type.Namespace);
+                    AppendRaw(".");
+                }
                 AppendRaw(type.Name);
             }
             else


### PR DESCRIPTION
# Description

When we are writing `CSharpType` using `CodeWriter`, it will always write the full qualified name. This PR makes it to omit the namespace if we find the namespace of the writing type is the same as our `_currentNamespace`.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first