### PR TITLE
returns failure when there is a failure

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/PluginProcessor.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/PluginProcessor.cs
@@ -34,8 +34,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                     Console.Error.WriteLine("Attempting to attach debugger.");
                     System.Diagnostics.Debugger.Launch();
                 }
-                await plugin.Execute(autoRest);
-                return true;
+                return await plugin.Execute(autoRest);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
# Description

Current implementation we are discarding the return value of `CSharpgen.Execute`, and only return false when there is an exception. But we already caught all the exceptions in the [`CSharpgen.Execute` function](https://github.com/Azure/autorest.csharp/blob/e3e152899878d14e8ccedc9ff36ca756c90ea695/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs#L107), therefore we will never report a failure in our executions.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first