### PR TITLE
[LLC] Use GetAll<ResourceName> for list method if ResourceName has the same plural and sigular form

### DIFF
--- a/src/AutoRest.CSharp/LowLevel/AutoRest/LowLevelOutputLibrary.cs
+++ b/src/AutoRest.CSharp/LowLevel/AutoRest/LowLevelOutputLibrary.cs
@@ -41,7 +41,8 @@ namespace AutoRest.CSharp.Output.Models.Types
             {
                 foreach (var operation in operationGroup.Operations)
                 {
-                    operation.Language.Default.Name = operation.Language.Default.Name.RenameListToGet(operationGroup.Key.IsNullOrEmpty() ? _codeModel.Language.Default.Name.ReplaceLast("Client", "") : operationGroup.Key);
+                    var resourceName = operationGroup.Key.IsNullOrEmpty() ? _codeModel.Language.Default.Name.ReplaceLast("Client", "") : operationGroup.Key;
+                    operation.Language.Default.Name = operation.Language.Default.Name.RenameGetMethod(resourceName).RenameListToGet(resourceName);
                 }
             }
         }

--- a/test/AutoRest.TestServer.Tests/Common/StringExtensionsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/StringExtensionsTests.cs
@@ -21,6 +21,7 @@ namespace AutoRest.CSharp.Utilities
         [TestCase("sheep", "sheep")]
         [TestCase("people", "people", false)]
         [TestCase("child", "children")]
+        [TestCase("data", "data", false)]
         public void ValidatePluralize(string noun, string expected, bool inputIsKnownToBeSingle = true)
         {
             var plural = noun.ToPlural(inputIsKnownToBeSingle);
@@ -43,10 +44,11 @@ namespace AutoRest.CSharp.Utilities
         [TestCase("sheep", "sheep")]
         [TestCase("people", "person")]
         [TestCase("children", "child")]
+        [TestCase("data", "data", false)]
         public void ValidateSingularize(string noun, string expected, bool inputIsKnownToBePlural = true)
         {
-            var plural = noun.ToSingular(inputIsKnownToBePlural);
-            Assert.AreEqual(expected, plural);
+            var singular = noun.ToSingular(inputIsKnownToBePlural);
+            Assert.AreEqual(expected, singular);
         }
 
         [TestCase("CamelCase", new[] { "Camel", "Case" })]
@@ -86,9 +88,19 @@ namespace AutoRest.CSharp.Utilities
         [TestCase("ListTermsByGlossaryName", "Glossary", "GetTermsByGlossaryName")]
         [TestCase("ListMyListings", "Glossary", "GetMyListings")]
         [TestCase("ListBlobContainerBlob", "StorageBlob", "GetBlobContainerBlobs")]
+        [TestCase("List", "ApplicationData", "GetAllApplicationData")]
+        [TestCase("ListByFarmerId", "ApplicationData", "GetAllApplicationDataByFarmerId")]
         public void ValidateRenameListToGet(string methodName, string resourceName, string expected)
         {
             var result = methodName.RenameListToGet(resourceName);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("Get", "ApplicationData", "GetApplicationData")]
+        [TestCase("GetMyData", "ApplicationData", "GetMyData")]
+        public void ValidateRenameGetMethod(string methodName, string resourceName, string expected)
+        {
+            var result = methodName.RenameGetMethod(resourceName);
             Assert.AreEqual(expected, result);
         }
 


### PR DESCRIPTION
This PR also renames `Get` to `Get<ResourceName>`.

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first