### PR TITLE
[LLC] Add new constructors and implicit operator for operation-related classes

### DIFF
--- a/src/assets/Generator.Shared/LowLevelFuncOperation.cs
+++ b/src/assets/Generator.Shared/LowLevelFuncOperation.cs
@@ -60,9 +60,9 @@ namespace Azure.Core
 
         ValueTask<T> IOperationSource<T>.CreateResultAsync(Response response, CancellationToken cancellationToken) => new ValueTask<T>(_resultSelector(response));
 
-        public static implicit operator LowLevelFuncOperation<T>(LowLevelFuncOperation<BinaryData> operation)
+        public static implicit operator OperationInternals(LowLevelFuncOperation<T> operation)
         {
-            return new LowLevelFuncOperation<T>((OperationInternals)(operation._operation), r => (T)(object)r);
+            return (OperationInternals)operation._operation;
         }
     }
 }

--- a/src/assets/Generator.Shared/LowLevelFuncOperation.cs
+++ b/src/assets/Generator.Shared/LowLevelFuncOperation.cs
@@ -23,6 +23,12 @@ namespace Azure.Core
             _resultSelector = resultSelector;
         }
 
+        internal LowLevelFuncOperation(OperationInternals op, Func<Response, T> resultSelector)
+        {
+            _operation = new OperationInternals<T>(this, op);
+            _resultSelector = resultSelector;
+        }
+
         /// <inheritdoc />
         public override string Id => _operation.Id;
 
@@ -53,5 +59,10 @@ namespace Azure.Core
         T IOperationSource<T>.CreateResult(Response response, CancellationToken cancellationToken) => _resultSelector(response);
 
         ValueTask<T> IOperationSource<T>.CreateResultAsync(Response response, CancellationToken cancellationToken) => new ValueTask<T>(_resultSelector(response));
+
+        public static implicit operator LowLevelFuncOperation<T>(LowLevelFuncOperation<BinaryData> operation)
+        {
+            return new LowLevelFuncOperation<T>((OperationInternals)(operation._operation), r => (T)(object)r);
+        }
     }
 }

--- a/src/assets/Generator.Shared/OperationInternals.cs
+++ b/src/assets/Generator.Shared/OperationInternals.cs
@@ -62,6 +62,19 @@ namespace Azure.Core
             _shouldPoll = _headerFrom != HeaderFrom.None;
         }
 
+        public OperationInternals(OperationInternals op)
+        {
+            _rawResponse = op._rawResponse;
+            _requestMethod = op._requestMethod;
+            _originalUri = op._originalUri;
+            _finalStateVia = op._finalStateVia;
+            InitializeScenarioInfo();
+            _pipeline = op._pipeline;
+            _clientDiagnostics = op._clientDiagnostics;
+            _scopeName = op._scopeName;
+            _shouldPoll = op._shouldPoll;
+        }
+
         public Response GetRawResponse() => _rawResponse;
 
         public ValueTask<Response> WaitForCompletionResponseAsync(CancellationToken cancellationToken = default)

--- a/src/assets/Generator.Shared/OperationInternalsOfT.cs
+++ b/src/assets/Generator.Shared/OperationInternalsOfT.cs
@@ -41,6 +41,14 @@ namespace Azure.Core
             _source = source;
         }
 
+        public OperationInternals(
+            IOperationSource<T> source,
+            OperationInternals op)
+            : base(op)
+        {
+            _source = source;
+        }
+
         public ValueTask<Response<T>> WaitForCompletionAsync(CancellationToken cancellationToken = default)
         {
             return WaitForCompletionAsync(DefaultPollingInterval, cancellationToken);


### PR DESCRIPTION
This PR targets to support converting `LowLevelFuncOperation<BinaryData>` to `LowLevelFuncOperation<T>` where T is an output model, which is tested in https://github.com/Azure/azure-sdk-for-net/pull/24978

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first