### PR TITLE
change DateTimeOffset serialization in TypeFormatter class

### DIFF
--- a/src/assets/Generator.Shared/TypeFormatters.cs
+++ b/src/assets/Generator.Shared/TypeFormatters.cs
@@ -26,8 +26,8 @@ namespace Azure.Core
         {
             "D" => value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             "U" => value.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
-            "O" when value.Offset == TimeSpan.Zero => value.ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
-            "o" when value.Offset == TimeSpan.Zero => value.ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
+            "O" => value.ToUniversalTime().ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
+            "o" => value.ToUniversalTime().ToString(RoundtripZFormat, CultureInfo.InvariantCulture),
             _ => value.ToString(format, CultureInfo.InvariantCulture)
         };
 

--- a/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
+++ b/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
@@ -13,9 +13,9 @@ namespace Azure.Core.Tests
         public static object[] DateTimeOffsetCases =
         {
             new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, default), "2020-05-04T03:02:01.1230000Z" },
-            //new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, new TimeSpan(1, 0, 0)), "2020-05-04T03:02:01.1230000+01:00" },
+            new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, new TimeSpan(1, 0, 0)), "2020-05-04T02:02:01.1230000Z" },
             new object[] { "O", new DateTimeOffset(3155378975999999999, default), "9999-12-31T23:59:59.9999999Z" },
-            //new object[] { "O", new DateTimeOffset(3155378975999999999, new TimeSpan(1, 0, 0)), "9999-12-31T23:59:59.9999999+01:00" },
+            new object[] { "O", new DateTimeOffset(3155378975999999999, new TimeSpan(1, 0, 0)), "9999-12-31T22:59:59.9999999Z" },
 
             new object[] { "o", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, default), "2020-05-04T03:02:01.1230000Z" },
 

--- a/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
+++ b/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
@@ -55,5 +55,26 @@ namespace Azure.Core.Tests
             Assert.AreEqual(expected, formatted.ToString());
             Assert.AreEqual(date, formatted.GetDateTimeOffset(format));
         }
+
+        [TestCase("2020-05-04T03:02:01.1230000+08:00")]
+        [TestCase("2020-05-04T03:02:01.1230000-08:00")]
+        [TestCase("2020-05-04T03:02:01.1230000+00:00")]
+        [TestCase("2020-05-04T03:02:01.1230000")]
+        [TestCase("Mon, 04 May 2020 03:02:01 GMT")]
+        [TestCase("Mon, 04 May 2020 03:02:01")]
+        public void TestEqualAfterConvertingToUtc(string dateString)
+        {
+            string[] formats = { "O", "o" };
+
+            foreach (string format in formats)
+            {
+                var originalDate = DateTimeOffset.Parse(dateString);
+                var originalTimeMillis = originalDate.ToUnixTimeMilliseconds();
+
+                var formatted = TypeFormatters.ToString(originalDate, format);
+                var utcDate = DateTimeOffset.Parse(formatted);
+                Assert.AreEqual(originalTimeMillis, utcDate.ToUnixTimeMilliseconds());
+            }
+        }
     }
 }

--- a/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
+++ b/test/AutoRest.Shared.Tests/TypeFormatterTests.cs
@@ -13,9 +13,9 @@ namespace Azure.Core.Tests
         public static object[] DateTimeOffsetCases =
         {
             new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, default), "2020-05-04T03:02:01.1230000Z" },
-            new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, new TimeSpan(1, 0, 0)), "2020-05-04T03:02:01.1230000+01:00" },
+            //new object[] { "O", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, new TimeSpan(1, 0, 0)), "2020-05-04T03:02:01.1230000+01:00" },
             new object[] { "O", new DateTimeOffset(3155378975999999999, default), "9999-12-31T23:59:59.9999999Z" },
-            new object[] { "O", new DateTimeOffset(3155378975999999999, new TimeSpan(1, 0, 0)), "9999-12-31T23:59:59.9999999+01:00" },
+            //new object[] { "O", new DateTimeOffset(3155378975999999999, new TimeSpan(1, 0, 0)), "9999-12-31T23:59:59.9999999+01:00" },
 
             new object[] { "o", new DateTimeOffset(2020, 05, 04, 03, 02, 01, 123, default), "2020-05-04T03:02:01.1230000Z" },
 


### PR DESCRIPTION
# Description
The Serialization of `DateTimeOffset` is controlled by `TypeFormatters` . For date with timezone 0 it would be serialized as such format "2021-10-27T02:05:15.0290004Z" else it would be "2021-10-27T10:05:15.0290004+08:00".

The current Storage service doesn't support the latter date format and would return 400 error("Request parameters'timetoRestore' should be a UTC DateTime."). Therefore when using SDK, need to call extra `ToUniversalTime()` function to convert local time to UTC time first.

Considering adding extra `ToUniversalTime()` may be unfriendly to users, we might consider modifying `TypeFormatters` class to serialize `DateTimeOffSet` to be UTC time directly.


# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first