### PR TITLE
Bundle autorest

### DIFF
--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -55,16 +55,13 @@
       <_SourceRoot>$([System.String]::Copy('%(SourceRoot.SourceLinkUrl)').Replace('*', ''))</_SourceRoot>
       <_RawUrl>$(_SourceRoot)$(_RelativePath.Replace('\', '/'))/*</_RawUrl>
       <_ReadmeMdPath>$(_RepoRoot)readme.md</_ReadmeMdPath>
-      <_PackageJsonPath>$(_RepoRoot)package.json</_PackageJsonPath>
       <_GeneratedPropsFilePath>$(IntermediateOutputPath)/Microsoft.Azure.AutoRest.CSharp.props</_GeneratedPropsFilePath>
 
       <_ReadmeMdLines>$([System.IO.File]::ReadAllText($(_ReadmeMdPath)))</_ReadmeMdLines>
-      <_PackageJsonLines>$([System.IO.File]::ReadAllText($(_PackageJsonPath)))</_PackageJsonLines>
     </PropertyGroup>
 
     <PropertyGroup>
       <_CoreVersion>$([System.Text.RegularExpressions.Regex]::Match('$(_ReadmeMdLines)', 'version: ([\.\d]+)').get_Groups().get_Item(1))</_CoreVersion>
-      <_AutorestVersion>$([System.Text.RegularExpressions.Regex]::Match('$(_PackageJsonLines)', '"autorest": "(.*?)"').get_Groups().get_Item(1))</_AutorestVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -13,6 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <RollForward>Minor</RollForward>
     <DefineConstants>$(DefineConstants);EXPERIMENTAL</DefineConstants>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,8 @@
   <ItemGroup>
     <Compile Include="../../src/assets/**/*.cs" />
     <TfmSpecificPackageFile Include="../../src/assets/" PackagePath="content" />
+
+    <Content Include="../../node_modules/autorest/**/*" PackagePath="tools\autorest" />
 
     <Content Include="build\CodeGeneration.targets" PackagePath="build\Microsoft.Azure.AutoRest.CSharp.targets" />
     <Content Include="build\CodeGeneration.targets" PackagePath="buildMultiTargeting\Microsoft.Azure.AutoRest.CSharp.targets" />
@@ -70,7 +73,6 @@
       <_GeneratedPropsFileLines Include="&lt;SourceRoot Include=&quot;%24([System.IO.Path]::GetFullPath('%24(MSBuildThisFileDirectory)..\contentFiles\any\$(TargetFramework)\'))&quot; SourceLinkUrl=&quot;$(_RawUrl)&quot;/&gt;" />
       <_GeneratedPropsFileLines Include="&lt;/ItemGroup&gt;" />
       <_GeneratedPropsFileLines Include="&lt;PropertyGroup&gt;" />
-      <_GeneratedPropsFileLines Include="&lt;AutoRestVersion&gt;$(_AutorestVersion)&lt;/AutoRestVersion&gt;" />
       <_GeneratedPropsFileLines Include="&lt;AutoRestCoreVersion&gt;$(_CoreVersion)&lt;/AutoRestCoreVersion&gt;" />
       <_GeneratedPropsFileLines Include="&lt;/PropertyGroup&gt;" />
       <_GeneratedPropsFileLines Include="&lt;/Project&gt;" />

--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutoRestInput Condition="'$(AutoRestInput)' == ''">$(_DefaultInputName)</AutoRestInput>
+    <AutoRestEntryPoint Condition="'$(AutoRestEntryPoint)' == ''">$(MSBuildThisFileDirectory)../tools/autorest/entrypoints/app.js</AutoRestEntryPoint>
     <!--
       <AutoRestAdditionalParameters></AutoRestAdditionalParameters>
      
@@ -31,7 +32,7 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="node $(MSBuildThisFileDirectory)../tools/autorest/entrypoints/app.js --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --output-folder=$(MSBuildProjectDirectory)/Generated --clear-output-folder=true --namespace=$(RootNamespace) --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;" />
+    <Exec Command="node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --output-folder=$(MSBuildProjectDirectory)/Generated --clear-output-folder=true --namespace=$(RootNamespace) --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;" />
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -31,7 +31,7 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="npx autorest@$(AutoRestVersion) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --output-folder=$(MSBuildProjectDirectory)/Generated --clear-output-folder=true --namespace=$(RootNamespace) --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;" />
+    <Exec Command="node $(MSBuildThisFileDirectory)../tools/autorest/entrypoints/app.js --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --output-folder=$(MSBuildProjectDirectory)/Generated --clear-output-folder=true --namespace=$(RootNamespace) --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;" />
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">


### PR DESCRIPTION
Bundle the autorest CLI in the nuget package. Get rid of npx invocation.

npx is slow and causes file conflicts when the same package is executed in parallel.

Every version of Autorest.CSharp is pinned to the particular autorest version so instead of installing autorest every time we can bundle it and run it directly.