### PR TITLE
[Mgmt] Move the test case of IEnumerable from TestProjectTests to OutputLibraryTests

### DIFF
--- a/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
@@ -501,23 +501,5 @@ namespace AutoRest.TestServer.Tests.Mgmt.TestProjects
                 Assert.AreEqual(paramTypes[i], parameters[i].ParameterType);
             }
         }
-
-        [Test]
-        [Ignore("The current implementation of list-exception is using request path instead of resource collection name, therefore we have to skip this check to ensure test could pass. Will fix this later")]
-        public void VerifiyEnumerable()
-        {
-            foreach (var collection in FindAllCollections())
-            {
-                if (ListExceptions.Contains(collection.Name))
-                    continue;
-                Assert.NotNull(collection.GetInterface("IEnumerable"), $"{collection.Name} did not implement IEnumerable");
-                Assert.NotNull(collection.GetInterface("IEnumerable`1"), $"{collection.Name} did not implement IEnumerable<T>");
-                var pageable = typeof(Pageable<>);
-                if (collection.GetMethod("GetAll").ReturnType.Name == pageable.Name)
-                {
-                    Assert.NotNull(collection.GetInterface("IAsyncEnumerable`1"), $"{collection.Name} did not implement IAsyncEnumerable<T>");
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
# Description

This test was once disabled since in TestProjectTests we do not have a way to get the request path from the generated code (it was in the comments). Now I bring it back but in OutputLibraryTests, here we have the full information of the output library therefore we have a way to fetch the request paths of a resource or resource collection.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first