### PR TITLE
[Mgmt] Support multiple RestClient corresponding to the same request path

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationExtensions.cs
@@ -14,7 +14,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
     {
         public static LongRunningOperationInfo FindLongRunningOperationInfo(this Operation operation, BuildContext<MgmtOutputLibrary> context)
         {
-            var mgmtRestClient = context.Library.GetRestClient(operation.GetHttpPath());
+            var mgmtRestClient = context.Library.GetRestClient(operation);
 
             var nextOperationMethod = operation?.Language?.Default?.Paging != null
                 ? mgmtRestClient.GetNextOperationMethod(operation.Requests.Single())

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtExtensions.cs
@@ -36,7 +36,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             return _allOperations.Select(operation => MgmtClientOperation.FromOperation(
                 new MgmtRestOperation(
                     _context.Library.RestClientMethods[operation],
-                    _context.Library.GetRestClient(operation.GetHttpPath()),
+                    _context.Library.GetRestClient(operation),
                     operation.GetRequestPath(_context),
                     ContextualPath,
                     GetOperationName(operation, ResourceName))));

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
@@ -61,7 +61,7 @@ namespace AutoRest.CSharp.Mgmt.Output
         /// <returns></returns>
         protected virtual string GetOperationName(Operation operation, string clientResourceName)
         {
-            var operationGroup = _context.Library.GetRestClient(operation.GetHttpPath()).OperationGroup;
+            var operationGroup = _context.Library.GetRestClient(operation).OperationGroup;
             if (operationGroup.Key == clientResourceName)
             {
                 return operation.MgmtCSharpName(false);

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -73,7 +73,7 @@ namespace AutoRest.CSharp.Mgmt.Output
                     var requestPath = operation.GetRequestPath(_context);
                     var clientOperation = new MgmtRestOperation(
                         _context.Library.RestClientMethods[operation],
-                        _context.Library.GetRestClient(operation.GetHttpPath()),
+                        _context.Library.GetRestClient(operation),
                         requestPath,
                         GetContextualPath(operationSet, requestPath),
                         name);
@@ -223,7 +223,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             foreach ((var operationSet, var operations) in _allOperationMap)
             {
                 var resourceRequestPath = operationSet.GetRequestPath(_context);
-                var resourceRestClient = _context.Library.GetRestClient(resourceRequestPath);
+                var resourceRestClient = _context.Library.GetRestClient(operationSet.First());
                 // iterate over all the operations under this operationSet to get their diff between the corresponding contextual path
                 foreach (var operation in operations)
                 {
@@ -260,7 +260,7 @@ namespace AutoRest.CSharp.Mgmt.Output
                     // get the MgmtRestOperation with a proper name
                     var restOperation = new MgmtRestOperation(
                         _context.Library.RestClientMethods[operation],
-                        _context.Library.GetRestClient(operation.GetHttpPath()),
+                        _context.Library.GetRestClient(operation),
                         requestPath,
                         contextualPath,
                         methodName);
@@ -314,7 +314,7 @@ namespace AutoRest.CSharp.Mgmt.Output
         private IEnumerable<MgmtRestClient> EnsureRestClients()
         {
             var childRestClients = ClientOperations.SelectMany(clientOperation => clientOperation.Select(restOperation => restOperation.RestClient)).Distinct();
-            var resourceRestClients = OperationSets.Select(operationSet => _context.Library.GetRestClient(operationSet.RequestPath)).Distinct();
+            var resourceRestClients = OperationSets.SelectMany(operationSet => operationSet.Select(operation => _context.Library.GetRestClient(operation))).Distinct();
 
             return resourceRestClients.Concat(childRestClients).Distinct();
         }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/1693

# Description

We have met a case in one RP that we have multiple operation groups under the same request path, therefore this PR adds support for that

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first