### PR TITLE
Update CodeGeneration.targets so Azure.ResourceManager can use namespace and output-folder values from autorest.md

### DIFF
--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -17,6 +17,7 @@
     <ManagementSharedCodeDirectory>$(MSBuildThisFileDirectory)../content/Management.Shared/</ManagementSharedCodeDirectory>
 
     <_GenerateCode Condition="'$(AutoRestInput)' != ''">true</_GenerateCode>
+    <BaseCommand>node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --clear-output-folder=true --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;</BaseCommand>
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
@@ -32,7 +33,8 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --output-folder=$(MSBuildProjectDirectory)/Generated --clear-output-folder=true --namespace=$(RootNamespace) --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;" />
+    <Exec Command="$(BaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(RootNamespace)' != 'Azure.ResourceManager'"/>
+    <Exec Command="$(BaseCommand)" Condition="'$(RootNamespace)' == 'Azure.ResourceManager'"/>
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -17,7 +17,7 @@
     <ManagementSharedCodeDirectory>$(MSBuildThisFileDirectory)../content/Management.Shared/</ManagementSharedCodeDirectory>
 
     <_GenerateCode Condition="'$(AutoRestInput)' != ''">true</_GenerateCode>
-    <BaseCommand>node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --clear-output-folder=true --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;</BaseCommand>
+    <AutoRestBaseCommand>node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --clear-output-folder=true --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;</AutoRestBaseCommand>
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
@@ -33,8 +33,8 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="$(BaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(RootNamespace)' != 'Azure.ResourceManager'"/>
-    <Exec Command="$(BaseCommand)" Condition="'$(RootNamespace)' == 'Azure.ResourceManager'"/>
+    <Exec Command="$(AutoRestBaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(IsMgmtCoreLibrary)' != 'true'"/>
+    <Exec Command="$(AutoRestBaseCommand)" Condition="'$(IsMgmtCoreLibrary)' == 'true'"/>
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -33,8 +33,8 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="$(AutoRestBaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(IsMgmtCoreLibrary)' != 'true'"/>
-    <Exec Command="$(AutoRestBaseCommand)" Condition="'$(IsMgmtCoreLibrary)' == 'true'"/>
+    <Exec Command="$(AutoRestBaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(NoDefaultNamespaceAndOutputFolder)' != 'true'"/>
+    <Exec Command="$(AutoRestBaseCommand)" Condition="'$(NoDefaultNamespaceAndOutputFolder)' == 'true'"/>
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -17,6 +17,7 @@
     <ManagementSharedCodeDirectory>$(MSBuildThisFileDirectory)../content/Management.Shared/</ManagementSharedCodeDirectory>
 
     <_GenerateCode Condition="'$(AutoRestInput)' != ''">true</_GenerateCode>
+    <UseDefaultNamespaceAndOutputFolder Condition="'$(UseDefaultNamespaceAndOutputFolder)' == ''">true</UseDefaultNamespaceAndOutputFolder>
     <AutoRestBaseCommand>node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --clear-output-folder=true --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;</AutoRestBaseCommand>
   </PropertyGroup>
 
@@ -33,8 +34,8 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="$(AutoRestBaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(NoDefaultNamespaceAndOutputFolder)' != 'true'"/>
-    <Exec Command="$(AutoRestBaseCommand)" Condition="'$(NoDefaultNamespaceAndOutputFolder)' == 'true'"/>
+    <Exec Command="$(AutoRestBaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(UseDefaultNamespaceAndOutputFolder)' == 'true'"/>
+    <Exec Command="$(AutoRestBaseCommand)" Condition="'$(UseDefaultNamespaceAndOutputFolder)' == 'false'"/>
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -18,7 +18,8 @@
 
     <_GenerateCode Condition="'$(AutoRestInput)' != ''">true</_GenerateCode>
     <UseDefaultNamespaceAndOutputFolder Condition="'$(UseDefaultNamespaceAndOutputFolder)' == ''">true</UseDefaultNamespaceAndOutputFolder>
-    <AutoRestBaseCommand>node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --clear-output-folder=true --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;</AutoRestBaseCommand>
+    <_AutoRestCommand>node $(AutoRestEntryPoint) --max-memory-size=8192 --skip-csproj --skip-upgrade-check --version=$(AutoRestCoreVersion) $(AutoRestInput) $(AutoRestAdditionalParameters) --use=$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/any/ --clear-output-folder=true --shared-source-folders=&quot;$(AzureCoreSharedCodeDirectory);$(AutoRestSharedCodeDirectory)&quot;</_AutoRestCommand>
+    <_AutoRestCommand Condition="'$(UseDefaultNamespaceAndOutputFolder)' == 'true'">$(_AutoRestCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)"</_AutoRestCommand>
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
@@ -34,8 +35,7 @@
 
     <Error Text="Following GitHub URLs do not contain commit hash: @(GithubUrlsWithoutHash) please use permalinks for code generation inputs (see https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) " Condition="'@(GithubUrlsWithoutHash)' != ''" />
 
-    <Exec Command="$(AutoRestBaseCommand) --output-folder=$(MSBuildProjectDirectory)/Generated --namespace=$(RootNamespace)" Condition="'$(UseDefaultNamespaceAndOutputFolder)' == 'true'"/>
-    <Exec Command="$(AutoRestBaseCommand)" Condition="'$(UseDefaultNamespaceAndOutputFolder)' == 'false'"/>
+    <Exec Command="$(_AutoRestCommand)"/>
   </Target>
 
   <PropertyGroup Condition="'$(_GenerateCode)' == 'true'">


### PR DESCRIPTION
I drafted a [PR](https://github.com/Azure/azure-sdk-for-net/pull/25318) to autogen code for ResourceManager where batch tasks in [autorest.md](https://github.com/Azure/azure-sdk-for-net/blob/dd90d84da112ca4a2b3c53cca213b02c3af781e0/sdk/resourcemanager/Azure.ResourceManager/src/autorest.md) is used to generate swaggers for resources in different namespaces and folders.

However, when building the package with `dotnet build /t:GenerateCode`, the GenerateCode target provides values for `--namespace` and `--output-folder`, which override the corresponding values in `autorest.md`. So all generation in ResourceManager end up with the same namespace and generate code in the same `Generated` folder.

Originally I intended to fix the issue by removing these 2 autorest CLI options in `CodeGeneration.targets` and fix the autorest.md files that lack these values, but I found there are too many dataplane packages do not provide these 2 values in autorest.md. So I just added conditional check for `UseDefaultNamespaceAndOutputFolder` whenn running autorest command, and remove the 2 options if it's false. I'm setting the property for resourcemanager in https://github.com/Azure/azure-sdk-for-net/pull/25488. This has no impact with existing package generations and can avoid surprises if the target is used somewhere we're not aware of.


# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first