### PR TITLE
now we find resource in LRO and Fake-LRO from request path instead of using resource data

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/LongRunningOperationExtensions.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AutoRest.CSharp.Common.Output.Models;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
+using AutoRest.CSharp.Mgmt.Output;
 using AutoRest.CSharp.Output.Models.Types;
 
 namespace AutoRest.CSharp.Mgmt.Decorator
@@ -33,18 +35,24 @@ namespace AutoRest.CSharp.Mgmt.Decorator
         /// <param name="resultType">Result type of the LRO.</param>
         /// <param name="context"></param>
         /// <returns></returns>
-        public static bool ShouldWrapResultType(this Operation operation, CSharpType? resultType, BuildContext<MgmtOutputLibrary> context)
+        public static bool ShouldWrapResultType(this Operation operation, CSharpType? resultType, BuildContext<MgmtOutputLibrary> context, [MaybeNullWhen(false)] out Resource resource)
         {
+            resource = null;
             var httpRequest = operation.GetHttpRequest();
             if (resultType != null && httpRequest != null
                 && (httpRequest.Method == HttpMethod.Put || httpRequest.Method == HttpMethod.Patch))
             {
-                // need to check result type is [Resource]Data because:
-                // 1. some PUT operation returns differently and we don't want to wrap that with [Resource]
-                // 2. some operations belong to non-resource
-                if (context.Library.TryGetResourceData(operation.GetHttpPath(), out var resourceData))
+                var requestPath = operation.GetRequestPath(context);
+                // first we should ensure this request path corresponds to a resource data (which is potentially a resource)
+                if (!context.Library.TryGetResourceData(requestPath, out var resourceData))
+                    return false;
+                // then we ensure the return type is this resource data
+                if (!resultType.Name.Equals(resourceData.Type.Name))
+                    return false;
+                // try to get the resource corresponds to the request path of this operation, and ensure the resource data of this resource is the same one if any
+                if (context.Library.TryGetArmResource(requestPath, out resource))
                 {
-                    return resultType.Name.Equals(resourceData.Type.Name);
+                    return resourceData == resource.ResourceData;
                 }
             }
             return false;

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtLongRunningOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtLongRunningOperation.cs
@@ -22,9 +22,9 @@ namespace AutoRest.CSharp.Mgmt.Output
             : base(operation, context, lroInfo, lroInfo.ClientPrefix.ToSingular() + operation.CSharpName() + "Operation")
         {
             DefaultNamespace = $"{context.DefaultNamespace}.Models";
-            if (operation.ShouldWrapResultType(ResultType, context))
+            if (operation.ShouldWrapResultType(ResultType, context, out var resource))
             {
-                WrapperType = context.Library.GetArmResource(operation.GetHttpPath()).Type;
+                WrapperType = resource.Type;
             }
         }
 

--- a/src/AutoRest.CSharp/Mgmt/Output/NonLongRunningOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/NonLongRunningOperation.cs
@@ -33,10 +33,10 @@ namespace AutoRest.CSharp.Mgmt.Output
                 ResultType = TypeFactory.GetOutputType(context.TypeFactory.CreateType(responseSchema, false));
             }
 
-            if (operation.ShouldWrapResultType(ResultType, context))
+            if (operation.ShouldWrapResultType(ResultType, context, out var resource))
             {
-                ResultType = context.Library.GetArmResource(operation.GetHttpPath()).Type;
-                ResultDataType = context.Library.GetResourceData(operation.GetHttpPath()).Type;
+                ResultType = resource.Type;
+                ResultDataType = resource.ResourceData.Type;
             }
 
             DefaultName = lroInfo.ClientPrefix.ToSingular() + operation.CSharpName() + "Operation";


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/1680

# Description

Previously we have a functionality that if a LRO or a fake LRO is returning a resource data, we would check if it corresponds to a resource, if it does, we replace the return type of this LRO or fake LRO.

But we get quite a few cases in other RPs that multiple resources shares the same resource data, the above algorithm cannot determine which resource this LRO or fake LRO belongs.

This PR changes the algorithm to use request path to find its corresponding resource, which solves the above situation.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first