### PR TITLE
Return back EXPERIMENTAL for LowLevelOperationHelpers

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
@@ -134,6 +134,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 }
             }
 
+            generatedCodeProject = generatedCodeProject.WithParseOptions(new CSharpParseOptions(preprocessorSymbols: new[] { "EXPERIMENTAL" }));
             return new GeneratedCodeWorkspace(generatedCodeProject);
         }
 

--- a/src/assets/Generator.Shared/LowLevelOperationHelpers.cs
+++ b/src/assets/Generator.Shared/LowLevelOperationHelpers.cs
@@ -11,6 +11,7 @@ using Azure.Core.Pipeline;
 
 namespace Azure.Core
 {
+#if EXPERIMENTAL
     internal static class LowLevelOperationHelpers
     {
         public static async ValueTask<Operation<BinaryData>> ProcessMessageAsync(HttpPipeline pipeline, HttpMessage message, ClientDiagnostics clientDiagnostics, string scopeName, OperationFinalStateVia finalStateVia, RequestContext? requestContext, bool waitForCompletion)
@@ -57,4 +58,5 @@ namespace Azure.Core
             return operation;
         }
     }
+#endif
 }


### PR DESCRIPTION
`LowLevelOperationHelpers` depends on `Operation<T>.WaitForCompletion` that isn't released yet.

Also add EXPERIMENTAL preprocessor symbol to `generatedCodeProject` to help `Simplifier.ReduceAsync` correctly handle namespaces.