### PR TITLE
Use 1ES Windows VM for CI

### DIFF
--- a/eng/PublishRelease.ps1
+++ b/eng/PublishRelease.ps1
@@ -17,7 +17,7 @@ try {
 
     Write-Host "Publishing $file on GitHub!"
     
-    cmd /c ""npx -q publish-release --token $GitHubToken --repo autorest.csharp --owner azure --name $name --tag v$devVersion --notes=prerelease-build --prerelease --editRelease false --assets $file --target_commitish $Sha 2>&1""
+    npx -q publish-release --token $GitHubToken --repo autorest.csharp --owner azure --name $name --tag v$devVersion --notes=prerelease-build --prerelease --editRelease false --assets $file --target_commitish $Sha 2>&1
 
     $filePath = Join-Path $WorkingDirectory '.npmrc'
     $env:NPM_TOKEN = $NpmToken

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -34,10 +34,17 @@ stages:
       - job: Build
         timeoutInMinutes: 120
         pool:
-          vmImage: windows-2022
+          name: azsdk-pool-mms-win-2019-general
+          vmImage: MMS2019
         steps:
           - checkout: self
           - checkout: azure-sdk-tools
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core SDK'
+            retryCountOnTaskFailure: 3
+            inputs:
+              useGlobalJson: true
+              performMultiLevelLookup: true
           - task: NodeTool@0
             displayName: "Install Node 16.x"
             inputs:

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -21,13 +21,13 @@
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Include="Azure.ResourceManager" Version="1.0.0-alpha.20220104.6" />
     <PackageReference Include="Humanizer.Core" Version="2.13.14" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0-1.final" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
   <!-- Enable SourceLink  -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoRest.CSharp/DataPlane/Generation/DataPlaneClientWriter.cs
+++ b/src/AutoRest.CSharp/DataPlane/Generation/DataPlaneClientWriter.cs
@@ -456,14 +456,15 @@ namespace AutoRest.CSharp.Generation.Writers
                 obj switch
                 {
                     AzureKeySecurityScheme azure => HashCode.Combine(azure.Type, azure.HeaderName),
-                    AADTokenSecurityScheme aad => HashCode.Combine(aad.Type, GetHashCode(aad.Scopes)),
+                    AADTokenSecurityScheme aad => GetAADTokenSecurityHashCode(aad),
                     _ => HashCode.Combine(obj.Type)
                 };
 
-            private static int GetHashCode(IEnumerable<string> values)
+            private static int GetAADTokenSecurityHashCode(AADTokenSecurityScheme aad)
             {
                 var hashCode = new HashCode();
-                foreach (var value in values)
+                hashCode.Add(aad.Type);
+                foreach (var value in aad.Scopes)
                 {
                     hashCode.Add(value);
                 }

--- a/src/assets/Management.Shared/SharedExtensions.cs
+++ b/src/assets/Management.Shared/SharedExtensions.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;


### PR DESCRIPTION
Current [OOM issue](https://github.com/Azure/autorest.csharp/issues/1817) prevents most of the PR's to succeed in CI. As a temporary measure, we need to switch to VMs that have more RAM.

Since https://github.com/Azure/azure-sdk-tools/issues/2497 is fixed, we can use Windows VM.