### PR TITLE
Not run Mgmt.OutputLibrary tests in parallel to improve test performance

### DIFF
--- a/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OutputLibraryTestBase.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/OutputLibrary/OutputLibraryTestBase.cs
@@ -20,7 +20,7 @@ using NUnit.Framework;
 
 namespace AutoRest.TestServer.Tests.Mgmt.OutputLibrary
 {
-    [Parallelizable(ParallelScope.All)]
+    [NonParallelizable]
     internal abstract class OutputLibraryTestBase
     {
         private string _projectName;


### PR DESCRIPTION
Test in my machine:
Duration 5.2 mins -> 2.9 mins
Memory 13 GB -> 8 GB