### PR TITLE
Improve OperationInternalBase

### DIFF
--- a/src/assets/Azure.Core.Shared/OperationInternalBase.cs
+++ b/src/assets/Azure.Core.Shared/OperationInternalBase.cs
@@ -137,6 +137,10 @@ namespace Azure.Core
         /// <exception cref="RequestFailedException">Thrown if there's been any issues during the connection, or if the operation has completed with failures.</exception>
         public virtual async ValueTask<Response> WaitForCompletionResponseAsync(TimeSpan pollingInterval, CancellationToken cancellationToken)
         {
+            if (HasCompleted)
+            {
+                return RawResponse;
+            }
             while (true)
             {
                 Response response = await UpdateStatusAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
As we provide the customer with the method `WaitForCompletion` and `WaitForCompletionResponse`, it might make unnecessary API call and cause serialization failure when the customer sets the parameter `waitForCompletion` to `true` but still calls `WaitForCompletion` by themselves.

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first