### PR TITLE
Fix create result failure when consuming same content twice

### DIFF
--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/BlobRestoreStatusOperationSource.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/BlobRestoreStatusOperationSource.cs
@@ -18,14 +18,28 @@ namespace Azure.Management.Storage
     {
         BlobRestoreStatus IOperationSource<BlobRestoreStatus>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return BlobRestoreStatus.DeserializeBlobRestoreStatus(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return BlobRestoreStatus.DeserializeBlobRestoreStatus(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<BlobRestoreStatus> IOperationSource<BlobRestoreStatus>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return BlobRestoreStatus.DeserializeBlobRestoreStatus(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return BlobRestoreStatus.DeserializeBlobRestoreStatus(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageAccountOperationSource.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageAccountOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.Management.Storage
 
         StorageAccount IOperationSource<StorageAccount>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = StorageAccountData.DeserializeStorageAccountData(document.RootElement);
-            return new StorageAccount(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = StorageAccountData.DeserializeStorageAccountData(document.RootElement);
+                return new StorageAccount(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<StorageAccount> IOperationSource<StorageAccount>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = StorageAccountData.DeserializeStorageAccountData(document.RootElement);
-            return new StorageAccount(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = StorageAccountData.DeserializeStorageAccountData(document.RootElement);
+                return new StorageAccount(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/DedicatedHostOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/DedicatedHostOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         DedicatedHost IOperationSource<DedicatedHost>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
-            return new DedicatedHost(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+                return new DedicatedHost(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<DedicatedHost> IOperationSource<DedicatedHost>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
-            return new DedicatedHost(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+                return new DedicatedHost(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/ImageOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/ImageOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         Image IOperationSource<Image>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = ImageData.DeserializeImageData(document.RootElement);
-            return new Image(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = ImageData.DeserializeImageData(document.RootElement);
+                return new Image(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Image> IOperationSource<Image>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = ImageData.DeserializeImageData(document.RootElement);
-            return new Image(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = ImageData.DeserializeImageData(document.RootElement);
+                return new Image(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/LogAnalyticsOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/LogAnalyticsOperationSource.cs
@@ -18,14 +18,28 @@ namespace Azure.ResourceManager.Sample
     {
         LogAnalytics IOperationSource<LogAnalytics>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<LogAnalytics> IOperationSource<LogAnalytics>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineAssessPatchesResultOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineAssessPatchesResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace Azure.ResourceManager.Sample
     {
         VirtualMachineAssessPatchesResult IOperationSource<VirtualMachineAssessPatchesResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineAssessPatchesResult> IOperationSource<VirtualMachineAssessPatchesResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineCaptureResultOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineCaptureResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace Azure.ResourceManager.Sample
     {
         VirtualMachineCaptureResult IOperationSource<VirtualMachineCaptureResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineCaptureResult> IOperationSource<VirtualMachineCaptureResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineExtensionOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineExtensionOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         VirtualMachineExtension IOperationSource<VirtualMachineExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
-            return new VirtualMachineExtension(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+                return new VirtualMachineExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineExtension> IOperationSource<VirtualMachineExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
-            return new VirtualMachineExtension(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+                return new VirtualMachineExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         VirtualMachine IOperationSource<VirtualMachine>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
-            return new VirtualMachine(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+                return new VirtualMachine(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachine> IOperationSource<VirtualMachine>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
-            return new VirtualMachine(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+                return new VirtualMachine(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetExtensionOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetExtensionOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         VirtualMachineScaleSetExtension IOperationSource<VirtualMachineScaleSetExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
-            return new VirtualMachineScaleSetExtension(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
+                return new VirtualMachineScaleSetExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSetExtension> IOperationSource<VirtualMachineScaleSetExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
-            return new VirtualMachineScaleSetExtension(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
+                return new VirtualMachineScaleSetExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         VirtualMachineScaleSet IOperationSource<VirtualMachineScaleSet>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
-            return new VirtualMachineScaleSet(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+                return new VirtualMachineScaleSet(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSet> IOperationSource<VirtualMachineScaleSet>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
-            return new VirtualMachineScaleSet(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+                return new VirtualMachineScaleSet(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetVMOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetVMOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         VirtualMachineScaleSetVM IOperationSource<VirtualMachineScaleSetVM>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetVMData.DeserializeVirtualMachineScaleSetVMData(document.RootElement);
-            return new VirtualMachineScaleSetVM(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetVMData.DeserializeVirtualMachineScaleSetVMData(document.RootElement);
+                return new VirtualMachineScaleSetVM(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSetVM> IOperationSource<VirtualMachineScaleSetVM>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetVMData.DeserializeVirtualMachineScaleSetVMData(document.RootElement);
-            return new VirtualMachineScaleSetVM(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetVMData.DeserializeVirtualMachineScaleSetVMData(document.RootElement);
+                return new VirtualMachineScaleSetVM(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetVirtualMachineExtensionOperationSource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/VirtualMachineScaleSetVirtualMachineExtensionOperationSource.cs
@@ -25,16 +25,30 @@ namespace Azure.ResourceManager.Sample
 
         VirtualMachineScaleSetVirtualMachineExtension IOperationSource<VirtualMachineScaleSetVirtualMachineExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
-            return new VirtualMachineScaleSetVirtualMachineExtension(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+                return new VirtualMachineScaleSetVirtualMachineExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSetVirtualMachineExtension> IOperationSource<VirtualMachineScaleSetVirtualMachineExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
-            return new VirtualMachineScaleSetVirtualMachineExtension(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineExtensionData.DeserializeVirtualMachineExtensionData(document.RootElement);
+                return new VirtualMachineScaleSetVirtualMachineExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
@@ -138,13 +138,27 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
             using (_writer.Scope($"{_opSource.ReturnType} {_opSource.Interface}.CreateResult({typeof(Response)} {responseVariable:D}, {typeof(CancellationToken)} cancellationToken)"))
             {
-                _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, false, valueCallback, responseVariable);
+                using (_writer.Scope($"try"))
+                {
+                    _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, false, valueCallback, responseVariable);
+                }
+                using (_writer.Scope($"finally"))
+                {
+                    _writer.Line($"{responseVariable:D}.ContentStream.Position = 0;");
+                }
             }
             _writer.Line();
 
             using (_writer.Scope($"async {new CSharpType(typeof(ValueTask<>), _opSource.ReturnType)} {_opSource.Interface}.CreateResultAsync({typeof(Response)} {responseVariable:D}, {typeof(CancellationToken)} cancellationToken)"))
             {
-                _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, true, valueCallback, responseVariable);
+                using (_writer.Scope($"try"))
+                {
+                    _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, true, valueCallback, responseVariable);
+                }
+                using (_writer.Scope($"finally"))
+                {
+                    _writer.Line($"{responseVariable:D}.ContentStream.Position = 0;");
+                }
             }
         }
 

--- a/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/ManagedHsmOperationSource.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/ManagedHsmOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtKeyvault
 
         ManagedHsm IOperationSource<ManagedHsm>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = ManagedHsmData.DeserializeManagedHsmData(document.RootElement);
-            return new ManagedHsm(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = ManagedHsmData.DeserializeManagedHsmData(document.RootElement);
+                return new ManagedHsm(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<ManagedHsm> IOperationSource<ManagedHsm>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = ManagedHsmData.DeserializeManagedHsmData(document.RootElement);
-            return new ManagedHsm(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = ManagedHsmData.DeserializeManagedHsmData(document.RootElement);
+                return new ManagedHsm(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/MhsmPrivateEndpointConnectionOperationSource.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/MhsmPrivateEndpointConnectionOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtKeyvault
 
         MhsmPrivateEndpointConnection IOperationSource<MhsmPrivateEndpointConnection>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = MhsmPrivateEndpointConnectionData.DeserializeMhsmPrivateEndpointConnectionData(document.RootElement);
-            return new MhsmPrivateEndpointConnection(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = MhsmPrivateEndpointConnectionData.DeserializeMhsmPrivateEndpointConnectionData(document.RootElement);
+                return new MhsmPrivateEndpointConnection(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<MhsmPrivateEndpointConnection> IOperationSource<MhsmPrivateEndpointConnection>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = MhsmPrivateEndpointConnectionData.DeserializeMhsmPrivateEndpointConnectionData(document.RootElement);
-            return new MhsmPrivateEndpointConnection(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = MhsmPrivateEndpointConnectionData.DeserializeMhsmPrivateEndpointConnectionData(document.RootElement);
+                return new MhsmPrivateEndpointConnection(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/PrivateEndpointConnectionOperationSource.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/PrivateEndpointConnectionOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtKeyvault
 
         PrivateEndpointConnection IOperationSource<PrivateEndpointConnection>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = PrivateEndpointConnectionData.DeserializePrivateEndpointConnectionData(document.RootElement);
-            return new PrivateEndpointConnection(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = PrivateEndpointConnectionData.DeserializePrivateEndpointConnectionData(document.RootElement);
+                return new PrivateEndpointConnection(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<PrivateEndpointConnection> IOperationSource<PrivateEndpointConnection>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = PrivateEndpointConnectionData.DeserializePrivateEndpointConnectionData(document.RootElement);
-            return new PrivateEndpointConnection(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = PrivateEndpointConnectionData.DeserializePrivateEndpointConnectionData(document.RootElement);
+                return new PrivateEndpointConnection(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/VaultOperationSource.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/VaultOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtKeyvault
 
         Vault IOperationSource<Vault>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VaultData.DeserializeVaultData(document.RootElement);
-            return new Vault(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VaultData.DeserializeVaultData(document.RootElement);
+                return new Vault(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Vault> IOperationSource<Vault>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VaultData.DeserializeVaultData(document.RootElement);
-            return new Vault(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VaultData.DeserializeVaultData(document.RootElement);
+                return new Vault(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/BarOperationSource.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/BarOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtLRO
 
         Bar IOperationSource<Bar>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = BarData.DeserializeBarData(document.RootElement);
-            return new Bar(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = BarData.DeserializeBarData(document.RootElement);
+                return new Bar(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Bar> IOperationSource<Bar>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = BarData.DeserializeBarData(document.RootElement);
-            return new Bar(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = BarData.DeserializeBarData(document.RootElement);
+                return new Bar(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/FakeOperationSource.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/FakeOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtLRO
 
         Fake IOperationSource<Fake>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = FakeData.DeserializeFakeData(document.RootElement);
-            return new Fake(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = FakeData.DeserializeFakeData(document.RootElement);
+                return new Fake(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Fake> IOperationSource<Fake>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = FakeData.DeserializeFakeData(document.RootElement);
-            return new Fake(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = FakeData.DeserializeFakeData(document.RootElement);
+                return new Fake(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/FakePostResultOperationSource.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/FakePostResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtLRO
     {
         FakePostResult IOperationSource<FakePostResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return FakePostResult.DeserializeFakePostResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return FakePostResult.DeserializeFakePostResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<FakePostResult> IOperationSource<FakePostResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return FakePostResult.DeserializeFakePostResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return FakePostResult.DeserializeFakePostResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/TenantTestOperationSource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/TenantTestOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtListMethods
 
         TenantTest IOperationSource<TenantTest>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = TenantTestData.DeserializeTenantTestData(document.RootElement);
-            return new TenantTest(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = TenantTestData.DeserializeTenantTestData(document.RootElement);
+                return new TenantTest(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<TenantTest> IOperationSource<TenantTest>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = TenantTestData.DeserializeTenantTestData(document.RootElement);
-            return new TenantTest(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = TenantTestData.DeserializeTenantTestData(document.RootElement);
+                return new TenantTest(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/AnotherParentChildOperationSource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/AnotherParentChildOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtMultipleParentResource
 
         AnotherParentChild IOperationSource<AnotherParentChild>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
-            return new AnotherParentChild(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
+                return new AnotherParentChild(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<AnotherParentChild> IOperationSource<AnotherParentChild>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
-            return new AnotherParentChild(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
+                return new AnotherParentChild(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/AnotherParentOperationSource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/AnotherParentOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtMultipleParentResource
 
         AnotherParent IOperationSource<AnotherParent>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = AnotherParentData.DeserializeAnotherParentData(document.RootElement);
-            return new AnotherParent(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = AnotherParentData.DeserializeAnotherParentData(document.RootElement);
+                return new AnotherParent(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<AnotherParent> IOperationSource<AnotherParent>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = AnotherParentData.DeserializeAnotherParentData(document.RootElement);
-            return new AnotherParent(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = AnotherParentData.DeserializeAnotherParentData(document.RootElement);
+                return new AnotherParent(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/SubParentOperationSource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/SubParentOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtMultipleParentResource
 
         SubParent IOperationSource<SubParent>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = SubParentData.DeserializeSubParentData(document.RootElement);
-            return new SubParent(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = SubParentData.DeserializeSubParentData(document.RootElement);
+                return new SubParent(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<SubParent> IOperationSource<SubParent>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = SubParentData.DeserializeSubParentData(document.RootElement);
-            return new SubParent(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = SubParentData.DeserializeSubParentData(document.RootElement);
+                return new SubParent(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/TheParentOperationSource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/TheParentOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtMultipleParentResource
 
         TheParent IOperationSource<TheParent>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = TheParentData.DeserializeTheParentData(document.RootElement);
-            return new TheParent(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = TheParentData.DeserializeTheParentData(document.RootElement);
+                return new TheParent(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<TheParent> IOperationSource<TheParent>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = TheParentData.DeserializeTheParentData(document.RootElement);
-            return new TheParent(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = TheParentData.DeserializeTheParentData(document.RootElement);
+                return new TheParent(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/TheParentSubParentChildOperationSource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/TheParentSubParentChildOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtMultipleParentResource
 
         TheParentSubParentChild IOperationSource<TheParentSubParentChild>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
-            return new TheParentSubParentChild(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
+                return new TheParentSubParentChild(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<TheParentSubParentChild> IOperationSource<TheParentSubParentChild>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
-            return new TheParentSubParentChild(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = ChildBodyData.DeserializeChildBodyData(document.RootElement);
+                return new TheParentSubParentChild(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/BarOperationSource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/BarOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtNonStringPathVariable
 
         Bar IOperationSource<Bar>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = BarData.DeserializeBarData(document.RootElement);
-            return new Bar(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = BarData.DeserializeBarData(document.RootElement);
+                return new Bar(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Bar> IOperationSource<Bar>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = BarData.DeserializeBarData(document.RootElement);
-            return new Bar(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = BarData.DeserializeBarData(document.RootElement);
+                return new Bar(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/FakeOperationSource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/FakeOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtNonStringPathVariable
 
         Fake IOperationSource<Fake>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = FakeData.DeserializeFakeData(document.RootElement);
-            return new Fake(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = FakeData.DeserializeFakeData(document.RootElement);
+                return new Fake(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Fake> IOperationSource<Fake>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = FakeData.DeserializeFakeData(document.RootElement);
-            return new Fake(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = FakeData.DeserializeFakeData(document.RootElement);
+                return new Fake(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/ConnectionSharedKeyOperationSource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/ConnectionSharedKeyOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtOperations
     {
         ConnectionSharedKey IOperationSource<ConnectionSharedKey>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return ConnectionSharedKey.DeserializeConnectionSharedKey(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return ConnectionSharedKey.DeserializeConnectionSharedKey(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<ConnectionSharedKey> IOperationSource<ConnectionSharedKey>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return ConnectionSharedKey.DeserializeConnectionSharedKey(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return ConnectionSharedKey.DeserializeConnectionSharedKey(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/TestAvailabilitySetOperationSource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/TestAvailabilitySetOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtOperations
     {
         TestAvailabilitySet IOperationSource<TestAvailabilitySet>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return TestAvailabilitySet.DeserializeTestAvailabilitySet(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return TestAvailabilitySet.DeserializeTestAvailabilitySet(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<TestAvailabilitySet> IOperationSource<TestAvailabilitySet>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return TestAvailabilitySet.DeserializeTestAvailabilitySet(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return TestAvailabilitySet.DeserializeTestAvailabilitySet(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/DedicatedHostOperationSource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/DedicatedHostOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtParamOrdering
 
         DedicatedHost IOperationSource<DedicatedHost>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
-            return new DedicatedHost(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+                return new DedicatedHost(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<DedicatedHost> IOperationSource<DedicatedHost>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
-            return new DedicatedHost(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+                return new DedicatedHost(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/VirtualMachineScaleSetOperationSource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/VirtualMachineScaleSetOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtParamOrdering
 
         VirtualMachineScaleSet IOperationSource<VirtualMachineScaleSet>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
-            return new VirtualMachineScaleSet(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+                return new VirtualMachineScaleSet(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSet> IOperationSource<VirtualMachineScaleSet>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
-            return new VirtualMachineScaleSet(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+                return new VirtualMachineScaleSet(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/WorkspaceOperationSource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/WorkspaceOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtParamOrdering
 
         Workspace IOperationSource<Workspace>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = WorkspaceData.DeserializeWorkspaceData(document.RootElement);
-            return new Workspace(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = WorkspaceData.DeserializeWorkspaceData(document.RootElement);
+                return new Workspace(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Workspace> IOperationSource<Workspace>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = WorkspaceData.DeserializeWorkspaceData(document.RootElement);
-            return new Workspace(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = WorkspaceData.DeserializeWorkspaceData(document.RootElement);
+                return new Workspace(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtParent/Generated/LongRunningOperation/DedicatedHostOperationSource.cs
+++ b/test/TestProjects/MgmtParent/Generated/LongRunningOperation/DedicatedHostOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtParent
 
         DedicatedHost IOperationSource<DedicatedHost>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
-            return new DedicatedHost(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+                return new DedicatedHost(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<DedicatedHost> IOperationSource<DedicatedHost>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
-            return new DedicatedHost(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = DedicatedHostData.DeserializeDedicatedHostData(document.RootElement);
+                return new DedicatedHost(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/VirtualMachineOperationSource.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/VirtualMachineOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtPropertyChooser
 
         VirtualMachine IOperationSource<VirtualMachine>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
-            return new VirtualMachine(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+                return new VirtualMachine(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachine> IOperationSource<VirtualMachine>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
-            return new VirtualMachine(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+                return new VirtualMachine(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/ImageOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/ImageOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtRenameRules
 
         Image IOperationSource<Image>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = ImageData.DeserializeImageData(document.RootElement);
-            return new Image(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = ImageData.DeserializeImageData(document.RootElement);
+                return new Image(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Image> IOperationSource<Image>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = ImageData.DeserializeImageData(document.RootElement);
-            return new Image(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = ImageData.DeserializeImageData(document.RootElement);
+                return new Image(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/LogAnalyticsOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/LogAnalyticsOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtRenameRules
     {
         LogAnalytics IOperationSource<LogAnalytics>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<LogAnalytics> IOperationSource<LogAnalytics>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return LogAnalytics.DeserializeLogAnalytics(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineAssessPatchesResultOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineAssessPatchesResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtRenameRules
     {
         VirtualMachineAssessPatchesResult IOperationSource<VirtualMachineAssessPatchesResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineAssessPatchesResult> IOperationSource<VirtualMachineAssessPatchesResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return VirtualMachineAssessPatchesResult.DeserializeVirtualMachineAssessPatchesResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineCaptureResultOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineCaptureResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtRenameRules
     {
         VirtualMachineCaptureResult IOperationSource<VirtualMachineCaptureResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineCaptureResult> IOperationSource<VirtualMachineCaptureResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return VirtualMachineCaptureResult.DeserializeVirtualMachineCaptureResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtRenameRules
 
         VirtualMachine IOperationSource<VirtualMachine>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
-            return new VirtualMachine(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+                return new VirtualMachine(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachine> IOperationSource<VirtualMachine>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
-            return new VirtualMachine(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineData.DeserializeVirtualMachineData(document.RootElement);
+                return new VirtualMachine(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineScaleSetExtensionOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineScaleSetExtensionOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtRenameRules
 
         VirtualMachineScaleSetExtension IOperationSource<VirtualMachineScaleSetExtension>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
-            return new VirtualMachineScaleSetExtension(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
+                return new VirtualMachineScaleSetExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSetExtension> IOperationSource<VirtualMachineScaleSetExtension>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
-            return new VirtualMachineScaleSetExtension(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetExtensionData.DeserializeVirtualMachineScaleSetExtensionData(document.RootElement);
+                return new VirtualMachineScaleSetExtension(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineScaleSetOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineScaleSetOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtRenameRules
 
         VirtualMachineScaleSet IOperationSource<VirtualMachineScaleSet>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
-            return new VirtualMachineScaleSet(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+                return new VirtualMachineScaleSet(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSet> IOperationSource<VirtualMachineScaleSet>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
-            return new VirtualMachineScaleSet(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetData.DeserializeVirtualMachineScaleSetData(document.RootElement);
+                return new VirtualMachineScaleSet(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineScaleSetVmOperationSource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/VirtualMachineScaleSetVmOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtRenameRules
 
         VirtualMachineScaleSetVm IOperationSource<VirtualMachineScaleSetVm>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = VirtualMachineScaleSetVmData.DeserializeVirtualMachineScaleSetVmData(document.RootElement);
-            return new VirtualMachineScaleSetVm(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = VirtualMachineScaleSetVmData.DeserializeVirtualMachineScaleSetVmData(document.RootElement);
+                return new VirtualMachineScaleSetVm(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<VirtualMachineScaleSetVm> IOperationSource<VirtualMachineScaleSetVm>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = VirtualMachineScaleSetVmData.DeserializeVirtualMachineScaleSetVmData(document.RootElement);
-            return new VirtualMachineScaleSetVm(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = VirtualMachineScaleSetVmData.DeserializeVirtualMachineScaleSetVmData(document.RootElement);
+                return new VirtualMachineScaleSetVm(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/DeploymentExtendedOperationSource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/DeploymentExtendedOperationSource.cs
@@ -25,16 +25,30 @@ namespace MgmtScopeResource
 
         DeploymentExtended IOperationSource<DeploymentExtended>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = DeploymentExtendedData.DeserializeDeploymentExtendedData(document.RootElement);
-            return new DeploymentExtended(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = DeploymentExtendedData.DeserializeDeploymentExtendedData(document.RootElement);
+                return new DeploymentExtended(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<DeploymentExtended> IOperationSource<DeploymentExtended>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = DeploymentExtendedData.DeserializeDeploymentExtendedData(document.RootElement);
-            return new DeploymentExtended(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = DeploymentExtendedData.DeserializeDeploymentExtendedData(document.RootElement);
+                return new DeploymentExtended(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/DeploymentValidateResultOperationSource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/DeploymentValidateResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtScopeResource
     {
         DeploymentValidateResult IOperationSource<DeploymentValidateResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return DeploymentValidateResult.DeserializeDeploymentValidateResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return DeploymentValidateResult.DeserializeDeploymentValidateResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<DeploymentValidateResult> IOperationSource<DeploymentValidateResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return DeploymentValidateResult.DeserializeDeploymentValidateResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return DeploymentValidateResult.DeserializeDeploymentValidateResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/WhatIfOperationResultOperationSource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/WhatIfOperationResultOperationSource.cs
@@ -18,14 +18,28 @@ namespace MgmtScopeResource
     {
         WhatIfOperationResult IOperationSource<WhatIfOperationResult>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            return WhatIfOperationResult.DeserializeWhatIfOperationResult(document.RootElement);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                return WhatIfOperationResult.DeserializeWhatIfOperationResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<WhatIfOperationResult> IOperationSource<WhatIfOperationResult>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            return WhatIfOperationResult.DeserializeWhatIfOperationResult(document.RootElement);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                return WhatIfOperationResult.DeserializeWhatIfOperationResult(document.RootElement);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/OvenOperationSource.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/OvenOperationSource.cs
@@ -25,16 +25,30 @@ namespace SubscriptionExtensions
 
         Oven IOperationSource<Oven>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = OvenData.DeserializeOvenData(document.RootElement);
-            return new Oven(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = OvenData.DeserializeOvenData(document.RootElement);
+                return new Oven(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<Oven> IOperationSource<Oven>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = OvenData.DeserializeOvenData(document.RootElement);
-            return new Oven(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = OvenData.DeserializeOvenData(document.RootElement);
+                return new Oven(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }

--- a/test/TestProjects/TenantOnly/Generated/LongRunningOperation/BillingAccountOperationSource.cs
+++ b/test/TestProjects/TenantOnly/Generated/LongRunningOperation/BillingAccountOperationSource.cs
@@ -25,16 +25,30 @@ namespace TenantOnly
 
         BillingAccount IOperationSource<BillingAccount>.CreateResult(Response response, CancellationToken cancellationToken)
         {
-            using var document = JsonDocument.Parse(response.ContentStream);
-            var data = BillingAccountData.DeserializeBillingAccountData(document.RootElement);
-            return new BillingAccount(_client, data);
+            try
+            {
+                using var document = JsonDocument.Parse(response.ContentStream);
+                var data = BillingAccountData.DeserializeBillingAccountData(document.RootElement);
+                return new BillingAccount(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
 
         async ValueTask<BillingAccount> IOperationSource<BillingAccount>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
-            using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-            var data = BillingAccountData.DeserializeBillingAccountData(document.RootElement);
-            return new BillingAccount(_client, data);
+            try
+            {
+                using var document = await JsonDocument.ParseAsync(response.ContentStream, default, cancellationToken).ConfigureAwait(false);
+                var data = BillingAccountData.DeserializeBillingAccountData(document.RootElement);
+                return new BillingAccount(_client, data);
+            }
+            finally
+            {
+                response.ContentStream.Position = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
Current implementation of method `CreateResult` will have json serialization failure when the customer sets the `waitForCompletion` parameter to true but still call the method `WaitForCompletion` by themselves. The reason is that some lro operations like `Vault Update` will directly return 200 and so the `CreateResult` consumes same content twice. This PR is going to reset the position of the content back to 0 to avoid this failure.

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first