### PR TITLE
Fix CSharpType Equals and GetHashCode

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using AutoRest.CSharp.Generation.Writers;
@@ -91,12 +92,30 @@ namespace AutoRest.CSharp.Generation.Types
 
         public bool EqualsIgnoreNullable(CSharpType other) => Equals(other, ignoreNullable: true);
 
-        public bool Equals(Type type)
+        public bool Equals(Type type) =>
+            IsFrameworkType && FrameworkType.IsGenericTypeDefinition
+                ? type.GetGenericTypeDefinition() == FrameworkType && ArgumentsEquals(type.GetGenericArguments())
+                : type == FrameworkType;
+
+        private bool ArgumentsEquals(Type[] genericArguments)
         {
-            return IsFrameworkType && type == FrameworkType;
+            if (Arguments.Length != genericArguments.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Arguments.Length; i++)
+            {
+                if (!Arguments[i].Equals(genericArguments[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        public override int GetHashCode() => HashCode.Combine(_implementation, _type, HashCode.Combine(Arguments));
+        public override int GetHashCode() => HashCode.Combine(_implementation, _type, ((System.Collections.IStructuralEquatable)Arguments).GetHashCode(EqualityComparer<CSharpType>.Default));
 
         public bool IsGenericType => Arguments.Length > 0;
 

--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -93,7 +93,7 @@ namespace AutoRest.CSharp.Generation.Types
         public bool EqualsIgnoreNullable(CSharpType other) => Equals(other, ignoreNullable: true);
 
         public bool Equals(Type type) =>
-            IsFrameworkType && (FrameworkType.IsGenericTypeDefinition ? type.GetGenericTypeDefinition() == FrameworkType && ArgumentsEquals(type.GetGenericArguments()) : type == FrameworkType);
+            IsFrameworkType && (type.IsGenericType ? type.GetGenericTypeDefinition() == FrameworkType && ArgumentsEquals(type.GetGenericArguments()) : type == FrameworkType);
 
         private bool ArgumentsEquals(Type[] genericArguments)
         {

--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -93,9 +93,7 @@ namespace AutoRest.CSharp.Generation.Types
         public bool EqualsIgnoreNullable(CSharpType other) => Equals(other, ignoreNullable: true);
 
         public bool Equals(Type type) =>
-            IsFrameworkType && FrameworkType.IsGenericTypeDefinition
-                ? type.GetGenericTypeDefinition() == FrameworkType && ArgumentsEquals(type.GetGenericArguments())
-                : type == FrameworkType;
+            IsFrameworkType && (FrameworkType.IsGenericTypeDefinition ? type.GetGenericTypeDefinition() == FrameworkType && ArgumentsEquals(type.GetGenericArguments()) : type == FrameworkType);
 
         private bool ArgumentsEquals(Type[] genericArguments)
         {

--- a/test/AutoRest.TestServer.Tests/Common/Generation/Types/CSharpTypeTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/Generation/Types/CSharpTypeTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using AutoRest.CSharp.Generation.Types;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class CSharpTypeTests
+    {
+        [TestCase(typeof(int))]
+        [TestCase(typeof(IList<>))]
+        [TestCase(typeof(IList<int>))]
+        [TestCase(typeof(IDictionary<,>))]
+        [TestCase(typeof(IDictionary<int, int>))]
+        [TestCase(typeof(IDictionary<string, int>))]
+        public void TypesAreEqual(Type type)
+        {
+            var cst1 = new CSharpType(type);
+            var cst2 = new CSharpType(type);
+            Assert.IsTrue(cst1.Equals(cst2));
+        }
+
+        [TestCase(typeof(int))]
+        [TestCase(typeof(IList<>))]
+        [TestCase(typeof(IList<int>))]
+        [TestCase(typeof(IDictionary<,>))]
+        [TestCase(typeof(IDictionary<int, int>))]
+        [TestCase(typeof(IDictionary<string, int>))]
+        public void EqualToFrameworkType(Type type)
+        {
+            var cst = new CSharpType(type);
+            Assert.IsTrue(cst.Equals(type));
+        }
+
+        [TestCase(typeof(int))]
+        [TestCase(typeof(IList<>))]
+        [TestCase(typeof(IList<int>))]
+        [TestCase(typeof(IDictionary<,>))]
+        [TestCase(typeof(IDictionary<int, int>))]
+        [TestCase(typeof(IDictionary<string, int>))]
+        public void HashCodesAreEqual(Type type)
+        {
+            var cst1 = new CSharpType(type);
+            var cst2 = new CSharpType(type);
+            Assert.AreEqual(cst1.GetHashCode(), cst2.GetHashCode());
+        }
+
+        [TestCase(typeof(int), typeof(string))]
+        [TestCase(typeof(IList<int>), typeof(IList<>))]
+        [TestCase(typeof(IList<int>), typeof(IList<string>))]
+        [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
+        [TestCase(typeof(Tuple<>), typeof(Tuple<,>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<,>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, int>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(IDictionary<string, int>))]
+        public void TypesAreNotEqual(Type type1, Type type2)
+        {
+            var cst1 = new CSharpType(type1);
+            var cst2 = new CSharpType(type2);
+            Assert.IsFalse(cst1.Equals(cst2));
+        }
+
+        [TestCase(typeof(int), typeof(string))]
+        [TestCase(typeof(IList<int>), typeof(IList<>))]
+        [TestCase(typeof(IList<int>), typeof(IList<string>))]
+        [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(IDictionary<string, int>))]
+        public void NotEqualToFrameworkType(Type type1, Type type2)
+        {
+            var cst = new CSharpType(type1);
+            Assert.IsFalse(cst.Equals(type2));
+        }
+
+        [TestCase(typeof(int), typeof(string))]
+        [TestCase(typeof(IList<int>), typeof(IList<>))]
+        [TestCase(typeof(IList<int>), typeof(IList<string>))]
+        [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
+        [TestCase(typeof(IDictionary<int, string>), typeof(IDictionary<string, int>))]
+        public void HashCodesAreNotEqual(Type type1, Type type2)
+        {
+            var cst1 = new CSharpType(type1);
+            var cst2 = new CSharpType(type2);
+            Assert.AreNotEqual(cst1.GetHashCode(), cst2.GetHashCode());
+        }
+    }
+}

--- a/test/AutoRest.TestServer.Tests/Common/Generation/Types/CSharpTypeTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/Generation/Types/CSharpTypeTests.cs
@@ -49,7 +49,12 @@ namespace Azure.Core.Tests
         }
 
         [TestCase(typeof(int), typeof(string))]
+        [TestCase(typeof(int), typeof(IList<>))]
+        [TestCase(typeof(IList<>), typeof(int))]
+        [TestCase(typeof(int), typeof(IList<int>))]
+        [TestCase(typeof(IList<int>), typeof(int))]
         [TestCase(typeof(IList<int>), typeof(IList<>))]
+        [TestCase(typeof(IList<>), typeof(IList<int>))]
         [TestCase(typeof(IList<int>), typeof(IList<string>))]
         [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
         [TestCase(typeof(Tuple<>), typeof(Tuple<,>))]
@@ -65,7 +70,12 @@ namespace Azure.Core.Tests
         }
 
         [TestCase(typeof(int), typeof(string))]
+        [TestCase(typeof(int), typeof(IList<>))]
+        [TestCase(typeof(IList<>), typeof(int))]
+        [TestCase(typeof(int), typeof(IList<int>))]
+        [TestCase(typeof(IList<int>), typeof(int))]
         [TestCase(typeof(IList<int>), typeof(IList<>))]
+        [TestCase(typeof(IList<>), typeof(IList<int>))]
         [TestCase(typeof(IList<int>), typeof(IList<string>))]
         [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
@@ -77,7 +87,12 @@ namespace Azure.Core.Tests
         }
 
         [TestCase(typeof(int), typeof(string))]
+        [TestCase(typeof(int), typeof(IList<>))]
+        [TestCase(typeof(IList<>), typeof(int))]
+        [TestCase(typeof(int), typeof(IList<int>))]
+        [TestCase(typeof(IList<int>), typeof(int))]
         [TestCase(typeof(IList<int>), typeof(IList<>))]
+        [TestCase(typeof(IList<>), typeof(IList<int>))]
         [TestCase(typeof(IList<int>), typeof(IList<string>))]
         [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]

--- a/test/AutoRest.TestServer.Tests/Common/Generation/Types/CSharpTypeTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/Generation/Types/CSharpTypeTests.cs
@@ -16,6 +16,7 @@ namespace Azure.Core.Tests
         [TestCase(typeof(IDictionary<,>))]
         [TestCase(typeof(IDictionary<int, int>))]
         [TestCase(typeof(IDictionary<string, int>))]
+        [TestCase(typeof(IDictionary<IDictionary<int, string>, IDictionary<string, int>>))]
         public void TypesAreEqual(Type type)
         {
             var cst1 = new CSharpType(type);
@@ -29,6 +30,7 @@ namespace Azure.Core.Tests
         [TestCase(typeof(IDictionary<,>))]
         [TestCase(typeof(IDictionary<int, int>))]
         [TestCase(typeof(IDictionary<string, int>))]
+        [TestCase(typeof(IDictionary<IDictionary<int, string>, IDictionary<string, int>>))]
         public void EqualToFrameworkType(Type type)
         {
             var cst = new CSharpType(type);
@@ -41,6 +43,7 @@ namespace Azure.Core.Tests
         [TestCase(typeof(IDictionary<,>))]
         [TestCase(typeof(IDictionary<int, int>))]
         [TestCase(typeof(IDictionary<string, int>))]
+        [TestCase(typeof(IDictionary<IDictionary<int, string>, IDictionary<string, int>>))]
         public void HashCodesAreEqual(Type type)
         {
             var cst1 = new CSharpType(type);
@@ -62,6 +65,7 @@ namespace Azure.Core.Tests
         [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, int>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(IDictionary<string, int>))]
+        [TestCase(typeof(IDictionary<IDictionary<int, string>, IDictionary<string, int>>), typeof(IDictionary<IDictionary<string, int>, IDictionary<string, int>>))]
         public void TypesAreNotEqual(Type type1, Type type2)
         {
             var cst1 = new CSharpType(type1);
@@ -80,6 +84,7 @@ namespace Azure.Core.Tests
         [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(IDictionary<string, int>))]
+        [TestCase(typeof(IDictionary<IDictionary<int, string>, IDictionary<string, int>>), typeof(IDictionary<IDictionary<string, int>, IDictionary<string, int>>))]
         public void NotEqualToFrameworkType(Type type1, Type type2)
         {
             var cst = new CSharpType(type1);
@@ -97,6 +102,7 @@ namespace Azure.Core.Tests
         [TestCase(typeof(IList<int>), typeof(ICollection<int>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(Dictionary<int, string>))]
         [TestCase(typeof(IDictionary<int, string>), typeof(IDictionary<string, int>))]
+        [TestCase(typeof(IDictionary<IDictionary<int, string>, IDictionary<string, int>>), typeof(IDictionary<IDictionary<string, int>, IDictionary<string, int>>))]
         public void HashCodesAreNotEqual(Type type1, Type type2)
         {
             var cst1 = new CSharpType(type1);


### PR DESCRIPTION
- Fixes several bugs in `CSharpType.Equals` and `CSharpType.GetHashCode` related to generic arguments
- Adds tests