### PR TITLE
Mark orphan models `internal`

### DIFF
--- a/samples/Azure.Management.Storage/Generated/Models/FileServiceItems.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/FileServiceItems.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.Management.Storage;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class FileServiceItems
+    internal partial class FileServiceItems
     {
         internal static FileServiceItems DeserializeFileServiceItems(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/FileServiceItems.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/FileServiceItems.cs
@@ -12,7 +12,7 @@ using Azure.Management.Storage;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The FileServiceItems. </summary>
-    public partial class FileServiceItems
+    internal partial class FileServiceItems
     {
         /// <summary> Initializes a new instance of FileServiceItems. </summary>
         internal FileServiceItems()

--- a/samples/Azure.Management.Storage/Generated/Models/FileShareItem.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/FileShareItem.Serialization.cs
@@ -13,7 +13,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class FileShareItem : IUtf8JsonSerializable
+    internal partial class FileShareItem : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/FileShareItem.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/FileShareItem.cs
@@ -13,7 +13,7 @@ using Azure.ResourceManager.Models;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The file share properties be listed out. </summary>
-    public partial class FileShareItem : AzureEntityResource
+    internal partial class FileShareItem : AzureEntityResource
     {
         /// <summary> Initializes a new instance of FileShareItem. </summary>
         public FileShareItem()

--- a/samples/Azure.Management.Storage/Generated/Models/ListContainerItem.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ListContainerItem.Serialization.cs
@@ -13,7 +13,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class ListContainerItem : IUtf8JsonSerializable
+    internal partial class ListContainerItem : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/ListContainerItem.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ListContainerItem.cs
@@ -13,7 +13,7 @@ using Azure.ResourceManager.Models;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The blob container properties be listed out. </summary>
-    public partial class ListContainerItem : AzureEntityResource
+    internal partial class ListContainerItem : AzureEntityResource
     {
         /// <summary> Initializes a new instance of ListContainerItem. </summary>
         public ListContainerItem()

--- a/samples/Azure.Management.Storage/Generated/Models/PrivateLinkResourceListResult.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/PrivateLinkResourceListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Management.Storage.Models
 {
-    public partial class PrivateLinkResourceListResult
+    internal partial class PrivateLinkResourceListResult
     {
         internal static PrivateLinkResourceListResult DeserializePrivateLinkResourceListResult(JsonElement element)
         {

--- a/samples/Azure.Management.Storage/Generated/Models/PrivateLinkResourceListResult.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/PrivateLinkResourceListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> A list of private link resources. </summary>
-    public partial class PrivateLinkResourceListResult
+    internal partial class PrivateLinkResourceListResult
     {
         /// <summary> Initializes a new instance of PrivateLinkResourceListResult. </summary>
         internal PrivateLinkResourceListResult()

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/ProximityPlacementGroupUpdateOptions.Serialization.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/ProximityPlacementGroupUpdateOptions.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.Sample.Models
 {
-    public partial class ProximityPlacementGroupUpdateOptions : IUtf8JsonSerializable
+    internal partial class ProximityPlacementGroupUpdateOptions : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/ProximityPlacementGroupUpdateOptions.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/ProximityPlacementGroupUpdateOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.ResourceManager.Sample.Models
 {
     /// <summary> Specifies information about the proximity placement group. </summary>
-    public partial class ProximityPlacementGroupUpdateOptions : UpdateResource
+    internal partial class ProximityPlacementGroupUpdateOptions : UpdateResource
     {
         /// <summary> Initializes a new instance of ProximityPlacementGroupUpdateOptions. </summary>
         public ProximityPlacementGroupUpdateOptions()

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineExtensionsListResult.Serialization.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineExtensionsListResult.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Sample;
 
 namespace Azure.ResourceManager.Sample.Models
 {
-    public partial class VirtualMachineExtensionsListResult
+    internal partial class VirtualMachineExtensionsListResult
     {
         internal static VirtualMachineExtensionsListResult DeserializeVirtualMachineExtensionsListResult(JsonElement element)
         {

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineExtensionsListResult.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineExtensionsListResult.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Sample;
 namespace Azure.ResourceManager.Sample.Models
 {
     /// <summary> The List Extension operation response. </summary>
-    public partial class VirtualMachineExtensionsListResult
+    internal partial class VirtualMachineExtensionsListResult
     {
         /// <summary> Initializes a new instance of VirtualMachineExtensionsListResult. </summary>
         internal VirtualMachineExtensionsListResult()

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/TypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/TypeProvider.cs
@@ -10,6 +10,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 {
     internal abstract class TypeProvider
     {
+        protected bool _dirty = false;
         private readonly Lazy<INamedTypeSymbol?> _existingType;
         private TypeDeclarationOptions? _type;
 
@@ -20,7 +21,15 @@ namespace AutoRest.CSharp.Output.Models.Types
         }
 
         public CSharpType Type => new(this, TypeKind is TypeKind.Struct or TypeKind.Enum);
-        public TypeDeclarationOptions Declaration => _type ??= BuildType();
+        public TypeDeclarationOptions Declaration
+        {
+            get
+            {
+                if (_type == null || _dirty)
+                    _type = BuildType();
+                return _type;
+            }
+        }
 
         internal BuildContext Context { get; private set; }
         protected abstract string DefaultName { get; }
@@ -33,6 +42,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         private TypeDeclarationOptions BuildType()
         {
+            _dirty = false;
             return BuilderHelpers.CreateTypeAttributes(
                 DefaultName,
                 DefaultNamespace,
@@ -70,7 +80,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(DefaultName, DefaultNamespace, DefaultAccessibility, TypeKind);
+            return HashCode.Combine(DefaultName, DefaultNamespace, TypeKind);
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -863,11 +863,16 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
                 .Append(TenantExtensions);
             var clientOperations = mgmtTypeProviders.SelectMany(provider => provider.AllOperations).Distinct();
             var restOperations = clientOperations.SelectMany(operation => operation).Distinct();
-            var queue = new Queue<MgmtObjectType>(restOperations.SelectMany(operation => GetTypeProvidersFromRestOperation(operation)).Distinct());
+            var modelsFromOperations = restOperations.SelectMany(operation => GetTypeProvidersFromRestOperation(operation)).Distinct();
+            var queue = new Queue<MgmtObjectType>(modelsFromOperations.Concat(ResourceData));
+            var visited = new HashSet<MgmtObjectType>();
             // recursively mark find everything referenced
             while (queue.Count > 0)
             {
                 var mgmtObjectType = queue.Dequeue();
+                if (visited.Contains(mgmtObjectType))
+                    continue;
+                visited.Add(mgmtObjectType);
                 // add this to the result
                 mgmtObjectType.MarkPublic();
                 // add the models referenced by this to public as well

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -58,7 +58,7 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
         private CachedDictionary<string, ResourceData> RawRequestPathToResourceData { get; }
 
         /// <summary>
-        /// This is a map from request path to the <see cref="ResourceObjectAssociation"/> which consists from <see cref="ResourceTypeSegment"/>, <see cref="Output.ResourceData"/>, <see cref="Resource"/> and <see cref="ResouColl"/>
+        /// This is a map from request path to the <see cref="ResourceObjectAssociation"/> which consists from <see cref="ResourceTypeSegment"/>, <see cref="Output.ResourceData"/>, <see cref="Resource"/> and <see cref="ResourceCollection"/>
         /// </summary>
         private CachedDictionary<RequestPath, ResourceObjectAssociation> RequestPathToResources { get; }
 
@@ -363,7 +363,7 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
         public IEnumerable<Resource> ArmResources => _armResources ??= RequestPathToResources.Values.Select(bag => bag.Resource).Distinct();
 
         private Dictionary<CSharpType, Resource>? _csharpTypeToResource;
-        public Dictionary<CSharpType, Resource> CsharpTypeToResource => _csharpTypeToResource ??= ArmResources.ToDictionary(resource => resource.Type, resource => resource);
+        public Dictionary<CSharpType, Resource> CSharpTypeToResource => _csharpTypeToResource ??= ArmResources.ToDictionary(resource => resource.Type, resource => resource);
 
         private IEnumerable<ResourceCollection>? _resourceCollections;
         public IEnumerable<ResourceCollection> ResourceCollections => _resourceCollections ??= RequestPathToResources.Values.Select(bag => bag.ResourceCollection).WhereNotNull().Distinct();

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -54,6 +54,13 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             var serializeWriter = new SerializationWriter();
             var isArmCore = MgmtContext.MgmtConfiguration.IsArmCore;
 
+            // Experimental code
+            if (isArmCore)
+                MarkEverythingPublic();
+            else
+                MarkUsedModelsPublic();
+            // End of experimental code
+
             if (!isArmCore)
             {
                 var utilCodeWriter = new CodeWriter();
@@ -61,10 +68,6 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 staticUtilWriter.Write();
                 AddGeneratedFile(project, $"ProviderConstants.cs", utilCodeWriter.ToString());
             }
-
-            // Experimental code
-            MakeUsedModelsPublic();
-            // End of experimental code
 
             foreach (var model in MgmtContext.Library.Models)
             {
@@ -192,7 +195,16 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             AddGeneratedFile(project, $"Extensions/{extensionWriter.FileName}.cs", extensionWriter.ToString());
         }
 
-        private static void MakeUsedModelsPublic()
+        private static void MarkEverythingPublic()
+        {
+            foreach (var model in MgmtContext.Library.Models)
+            {
+                if (model is MgmtObjectType mgmtObjectType)
+                    mgmtObjectType.MarkPublic();
+            }
+        }
+
+        private static void MarkUsedModelsPublic()
         {
             var mgmtTypeProviders = MgmtContext.Library.ArmResources.Cast<MgmtTypeProvider>()
                 .Concat(MgmtContext.Library.ResourceCollections)

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -63,11 +63,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             }
 
             // Experimental code
-            var typesNeedToBePublic = MakeUsedModelsPublic();
-            foreach (var type in typesNeedToBePublic)
-            {
-                type.MarkPublic();
-            }
+            MakeUsedModelsPublic();
             // End of experimental code
 
             foreach (var model in MgmtContext.Library.Models)
@@ -196,9 +192,8 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             AddGeneratedFile(project, $"Extensions/{extensionWriter.FileName}.cs", extensionWriter.ToString());
         }
 
-        private static IEnumerable<MgmtObjectType> MakeUsedModelsPublic()
+        private static void MakeUsedModelsPublic()
         {
-            var result = new HashSet<MgmtObjectType>();
             var mgmtTypeProviders = MgmtContext.Library.ArmResources.Cast<MgmtTypeProvider>()
                 .Concat(MgmtContext.Library.ResourceCollections)
                 .Append(MgmtContext.Library.ArmClientExtensions)
@@ -215,7 +210,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             {
                 var mgmtObjectType = queue.Dequeue();
                 // add this to the result
-                result.Add(mgmtObjectType);
+                mgmtObjectType.MarkPublic();
                 // add the models referenced by this to public as well
                 if (mgmtObjectType.Inherits != null && TryGetMgmtObjectType(mgmtObjectType.Inherits, out var baseType))
                 {
@@ -229,8 +224,6 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                     }
                 }
             }
-
-            return result;
         }
 
         private static bool TryGetMgmtObjectType(CSharpType type, [MaybeNullWhen(false)] out MgmtObjectType mgmtObject)

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -55,9 +55,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             var isArmCore = MgmtContext.MgmtConfiguration.IsArmCore;
 
             // Experimental code
-            if (isArmCore)
-                MarkEverythingPublic();
-            else
+            if (!isArmCore)
                 MarkUsedModelsPublic();
             // End of experimental code
 
@@ -193,15 +191,6 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         {
             extensionWriter.Write();
             AddGeneratedFile(project, $"Extensions/{extensionWriter.FileName}.cs", extensionWriter.ToString());
-        }
-
-        private static void MarkEverythingPublic()
-        {
-            foreach (var model in MgmtContext.Library.Models)
-            {
-                if (model is MgmtObjectType mgmtObjectType)
-                    mgmtObjectType.MarkPublic();
-            }
         }
 
         private static void MarkUsedModelsPublic()

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -3,15 +3,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Generation.Writers;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Input.Source;
 using AutoRest.CSharp.Mgmt.AutoRest;
 using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Mgmt.Generation;
+using AutoRest.CSharp.Mgmt.Models;
 using AutoRest.CSharp.Mgmt.Output;
 using AutoRest.CSharp.Output.Models.Types;
+using AutoRest.CSharp.Utilities;
 
 namespace AutoRest.CSharp.AutoRest.Plugins
 {
@@ -57,6 +61,14 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 staticUtilWriter.Write();
                 AddGeneratedFile(project, $"ProviderConstants.cs", utilCodeWriter.ToString());
             }
+
+            // Experimental code
+            var typesNeedToBePublic = MakeUsedModelsPublic();
+            foreach (var type in typesNeedToBePublic)
+            {
+                type.MarkPublic();
+            }
+            // End of experimental code
 
             foreach (var model in MgmtContext.Library.Models)
             {
@@ -182,6 +194,79 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         {
             extensionWriter.Write();
             AddGeneratedFile(project, $"Extensions/{extensionWriter.FileName}.cs", extensionWriter.ToString());
+        }
+
+        private static IEnumerable<MgmtObjectType> MakeUsedModelsPublic()
+        {
+            var result = new HashSet<MgmtObjectType>();
+            var mgmtTypeProviders = MgmtContext.Library.ArmResources.Cast<MgmtTypeProvider>()
+                .Concat(MgmtContext.Library.ResourceCollections)
+                .Append(MgmtContext.Library.ArmClientExtensions)
+                .Append(MgmtContext.Library.ArmResourceExtensions)
+                .Append(MgmtContext.Library.ManagementGroupExtensions)
+                .Append(MgmtContext.Library.ResourceGroupExtensions)
+                .Append(MgmtContext.Library.SubscriptionExtensions)
+                .Append(MgmtContext.Library.TenantExtensions);
+            var clientOperations = mgmtTypeProviders.SelectMany(provider => provider.AllOperations).Distinct();
+            var restOperations = clientOperations.SelectMany(operation => operation).Distinct();
+            var queue = new Queue<MgmtObjectType>(restOperations.SelectMany(operation => GetTypeProvidersFromRestOperation(operation)).Distinct());
+            // recursively mark find everything referenced
+            while (queue.Count > 0)
+            {
+                var mgmtObjectType = queue.Dequeue();
+                // add this to the result
+                result.Add(mgmtObjectType);
+                // add the models referenced by this to public as well
+                if (mgmtObjectType.Inherits != null && TryGetMgmtObjectType(mgmtObjectType.Inherits, out var baseType))
+                {
+                    queue.Enqueue(baseType);
+                }
+                foreach (var property in mgmtObjectType.Properties)
+                {
+                    if (TryGetMgmtObjectType(property.ValueType, out var propertyType))
+                    {
+                        queue.Enqueue(propertyType);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static bool TryGetMgmtObjectType(CSharpType type, [MaybeNullWhen(false)] out MgmtObjectType mgmtObject)
+        {
+            mgmtObject = null;
+            if (!type.IsGenericType)
+            {
+                if (type.IsFrameworkType)
+                    return false;
+                if (MgmtContext.Library.TryGetTypeProvider(type.Name, out var provider))
+                {
+                    mgmtObject = provider as MgmtObjectType;
+                    return mgmtObject != null;
+                }
+
+                return false;
+            }
+            // take the last type argument if the type is generic
+            var lastTypeArgument = type.Arguments.Last();
+            return TryGetMgmtObjectType(lastTypeArgument, out mgmtObject);
+        }
+
+        private static IEnumerable<MgmtObjectType> GetTypeProvidersFromRestOperation(MgmtRestOperation operation)
+        {
+            foreach (var parameter in operation.Parameters)
+            {
+                if (TryGetMgmtObjectType(parameter.Type, out var mgmtObjectType))
+                    yield return mgmtObjectType;
+            }
+            // also add response types
+            if (operation.OriginalReturnType != null)
+            {
+                var returnType = operation.ReturnType;
+                if (TryGetMgmtObjectType(returnType, out var mgmtObjectType))
+                    yield return mgmtObjectType;
+            }
         }
 
         private static bool ShouldSkipModelGeneration(TypeProvider model)

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -780,7 +780,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 if (operation.OperationSource is not null)
                 {
                     _writer.Append($"new {operation.OperationSource.TypeName}(");
-                    if (MgmtContext.Library.CsharpTypeToResource.ContainsKey(operation.MgmtReturnType!))
+                    if (MgmtContext.Library.CSharpTypeToResource.ContainsKey(operation.MgmtReturnType!))
                         _writer.Append($"{ArmClientReference}");
                     _writer.Append($"), ");
                 }

--- a/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
@@ -31,7 +31,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
         {
             _writer = new CodeWriter();
             _opSource = opSource;
-            _isReturningResource = MgmtContext.Library.CsharpTypeToResource.ContainsKey(_opSource.ReturnType);
+            _isReturningResource = MgmtContext.Library.CSharpTypeToResource.ContainsKey(_opSource.ReturnType);
             if (_opSource.Resource is not null && MgmtContext.MgmtConfiguration.OperationIdMappings.TryGetValue(_opSource.Resource.Type.Name, out var mappings))
                 _operationIdMappings = mappings;
         }

--- a/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
@@ -155,7 +155,7 @@ namespace AutoRest.CSharp.Mgmt.Models
 
             if (!MgmtContext.Library.CSharpTypeToOperationSource.TryGetValue(MgmtReturnType, out var operationSource))
             {
-                MgmtContext.Library.CsharpTypeToResource.TryGetValue(MgmtReturnType, out var resourceBeingReturned);
+                MgmtContext.Library.CSharpTypeToResource.TryGetValue(MgmtReturnType, out var resourceBeingReturned);
                 operationSource = new OperationSource(MgmtReturnType, resourceBeingReturned, FinalResponseSchema!);
                 MgmtContext.Library.CSharpTypeToOperationSource.Add(MgmtReturnType, operationSource);
             }

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -36,7 +36,7 @@ namespace AutoRest.CSharp.Mgmt.Output
         private string? _defaultNamespace;
         protected override string DefaultNamespace => _defaultNamespace ??= GetDefaultNamespace(Context, ObjectSchema, IsResourceType);
 
-        protected override string DefaultAccessibility => _accessibility;
+        protected override string DefaultAccessibility => MgmtContext.MgmtConfiguration.IsArmCore ? base.DefaultAccessibility : _accessibility;
 
         internal ObjectTypeProperty[] MyProperties => _myProperties ??= BuildMyProperties().ToArray();
 

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -15,6 +15,7 @@ namespace AutoRest.CSharp.Mgmt.Output
 {
     internal class MgmtObjectType : SchemaObjectType
     {
+        private string _accessibility = "internal";
         private ObjectTypeProperty[]? _myProperties;
 
         public MgmtObjectType(ObjectSchema objectSchema)
@@ -35,7 +36,15 @@ namespace AutoRest.CSharp.Mgmt.Output
         private string? _defaultNamespace;
         protected override string DefaultNamespace => _defaultNamespace ??= GetDefaultNamespace(Context, ObjectSchema, IsResourceType);
 
+        protected override string DefaultAccessibility => _accessibility;
+
         internal ObjectTypeProperty[] MyProperties => _myProperties ??= BuildMyProperties().ToArray();
+
+        internal void MarkPublic()
+        {
+            _dirty = true;
+            _accessibility = "public";
+        }
 
         private static string GetDefaultName(ObjectSchema objectSchema, bool isResourceType)
         {

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceData.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceData.cs
@@ -26,6 +26,8 @@ namespace AutoRest.CSharp.Mgmt.Output
             Description = BuilderHelpers.EscapeXmlDescription(CreateDescription(schema.Name));
         }
 
+        protected override string DefaultAccessibility => "public";
+
         protected override bool IsResourceType => true;
 
         protected string CreateDescription(string clientPrefix)

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel1ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel1ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using ExactMatchFlattenInheritance;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class AzureResourceFlattenModel1ListResult
+    internal partial class AzureResourceFlattenModel1ListResult
     {
         internal static AzureResourceFlattenModel1ListResult DeserializeAzureResourceFlattenModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel1ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel1ListResult.cs
@@ -12,7 +12,7 @@ using ExactMatchFlattenInheritance;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class AzureResourceFlattenModel1ListResult
+    internal partial class AzureResourceFlattenModel1ListResult
     {
         /// <summary> Initializes a new instance of AzureResourceFlattenModel1ListResult. </summary>
         internal AzureResourceFlattenModel1ListResult()

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel2ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel2ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class AzureResourceFlattenModel2ListResult
+    internal partial class AzureResourceFlattenModel2ListResult
     {
         internal static AzureResourceFlattenModel2ListResult DeserializeAzureResourceFlattenModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel2ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel2ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class AzureResourceFlattenModel2ListResult
+    internal partial class AzureResourceFlattenModel2ListResult
     {
         /// <summary> Initializes a new instance of AzureResourceFlattenModel2ListResult. </summary>
         internal AzureResourceFlattenModel2ListResult()

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel3ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel3ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class AzureResourceFlattenModel3ListResult
+    internal partial class AzureResourceFlattenModel3ListResult
     {
         internal static AzureResourceFlattenModel3ListResult DeserializeAzureResourceFlattenModel3ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel3ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel3ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class AzureResourceFlattenModel3ListResult
+    internal partial class AzureResourceFlattenModel3ListResult
     {
         /// <summary> Initializes a new instance of AzureResourceFlattenModel3ListResult. </summary>
         internal AzureResourceFlattenModel3ListResult()

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel4ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel4ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class AzureResourceFlattenModel4ListResult
+    internal partial class AzureResourceFlattenModel4ListResult
     {
         internal static AzureResourceFlattenModel4ListResult DeserializeAzureResourceFlattenModel4ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel4ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel4ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class AzureResourceFlattenModel4ListResult
+    internal partial class AzureResourceFlattenModel4ListResult
     {
         /// <summary> Initializes a new instance of AzureResourceFlattenModel4ListResult. </summary>
         internal AzureResourceFlattenModel4ListResult()

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel5ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel5ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class AzureResourceFlattenModel5ListResult
+    internal partial class AzureResourceFlattenModel5ListResult
     {
         internal static AzureResourceFlattenModel5ListResult DeserializeAzureResourceFlattenModel5ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel5ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/AzureResourceFlattenModel5ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class AzureResourceFlattenModel5ListResult
+    internal partial class AzureResourceFlattenModel5ListResult
     {
         /// <summary> Initializes a new instance of AzureResourceFlattenModel5ListResult. </summary>
         internal AzureResourceFlattenModel5ListResult()

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel2ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel2ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using ExactMatchFlattenInheritance;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class CustomModel2ListResult
+    internal partial class CustomModel2ListResult
     {
         internal static CustomModel2ListResult DeserializeCustomModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel2ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel2ListResult.cs
@@ -12,7 +12,7 @@ using ExactMatchFlattenInheritance;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class CustomModel2ListResult
+    internal partial class CustomModel2ListResult
     {
         /// <summary> Initializes a new instance of CustomModel2ListResult. </summary>
         internal CustomModel2ListResult()

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel3ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel3ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using ExactMatchFlattenInheritance;
 
 namespace ExactMatchFlattenInheritance.Models
 {
-    public partial class CustomModel3ListResult
+    internal partial class CustomModel3ListResult
     {
         internal static CustomModel3ListResult DeserializeCustomModel3ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel3ListResult.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/Models/CustomModel3ListResult.cs
@@ -12,7 +12,7 @@ using ExactMatchFlattenInheritance;
 namespace ExactMatchFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class CustomModel3ListResult
+    internal partial class CustomModel3ListResult
     {
         /// <summary> Initializes a new instance of CustomModel3ListResult. </summary>
         internal CustomModel3ListResult()

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel11.Serialization.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel11.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace ExactMatchInheritance.Models
 {
-    public partial class ExactMatchModel11 : IUtf8JsonSerializable
+    internal partial class ExactMatchModel11 : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel11.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel11.cs
@@ -8,7 +8,7 @@
 namespace ExactMatchInheritance.Models
 {
     /// <summary> The ExactMatchModel11. </summary>
-    public partial class ExactMatchModel11
+    internal partial class ExactMatchModel11
     {
         /// <summary> Initializes a new instance of ExactMatchModel11. </summary>
         public ExactMatchModel11()

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel1ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel1ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using ExactMatchInheritance;
 
 namespace ExactMatchInheritance.Models
 {
-    public partial class ExactMatchModel1ListResult
+    internal partial class ExactMatchModel1ListResult
     {
         internal static ExactMatchModel1ListResult DeserializeExactMatchModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel1ListResult.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel1ListResult.cs
@@ -12,7 +12,7 @@ using ExactMatchInheritance;
 namespace ExactMatchInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class ExactMatchModel1ListResult
+    internal partial class ExactMatchModel1ListResult
     {
         /// <summary> Initializes a new instance of ExactMatchModel1ListResult. </summary>
         internal ExactMatchModel1ListResult()

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel3ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel3ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace ExactMatchInheritance.Models
 {
-    public partial class ExactMatchModel3ListResult
+    internal partial class ExactMatchModel3ListResult
     {
         internal static ExactMatchModel3ListResult DeserializeExactMatchModel3ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel3ListResult.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel3ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace ExactMatchInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class ExactMatchModel3ListResult
+    internal partial class ExactMatchModel3ListResult
     {
         /// <summary> Initializes a new instance of ExactMatchModel3ListResult. </summary>
         internal ExactMatchModel3ListResult()

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel5ListResult.Serialization.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel5ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using ExactMatchInheritance;
 
 namespace ExactMatchInheritance.Models
 {
-    public partial class ExactMatchModel5ListResult
+    internal partial class ExactMatchModel5ListResult
     {
         internal static ExactMatchModel5ListResult DeserializeExactMatchModel5ListResult(JsonElement element)
         {

--- a/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel5ListResult.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/Models/ExactMatchModel5ListResult.cs
@@ -12,7 +12,7 @@ using ExactMatchInheritance;
 namespace ExactMatchInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class ExactMatchModel5ListResult
+    internal partial class ExactMatchModel5ListResult
     {
         /// <summary> Initializes a new instance of ExactMatchModel5ListResult. </summary>
         internal ExactMatchModel5ListResult()

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/SubResource.Serialization.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/SubResource.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtExpandResourceTypes.Models
 {
-    public partial class SubResource : IUtf8JsonSerializable
+    internal partial class SubResource : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/SubResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/SubResource.cs
@@ -8,7 +8,7 @@
 namespace MgmtExpandResourceTypes.Models
 {
     /// <summary> A reference to a another resource. </summary>
-    public partial class SubResource
+    internal partial class SubResource
     {
         /// <summary> Initializes a new instance of SubResource. </summary>
         public SubResource()

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/ZoneUpdateOptions.Serialization.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/ZoneUpdateOptions.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtExpandResourceTypes.Models
 {
-    public partial class ZoneUpdateOptions : IUtf8JsonSerializable
+    internal partial class ZoneUpdateOptions : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/ZoneUpdateOptions.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/ZoneUpdateOptions.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtExpandResourceTypes.Models
 {
     /// <summary> Describes a request to update a DNS zone. </summary>
-    public partial class ZoneUpdateOptions
+    internal partial class ZoneUpdateOptions
     {
         /// <summary> Initializes a new instance of ZoneUpdateOptions. </summary>
         public ZoneUpdateOptions()

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeOneListResult.Serialization.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeOneListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtExtensionCommonRestOperation;
 
 namespace MgmtExtensionCommonRestOperation.Models
 {
-    public partial class TypeOneListResult
+    internal partial class TypeOneListResult
     {
         internal static TypeOneListResult DeserializeTypeOneListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeOneListResult.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeOneListResult.cs
@@ -13,7 +13,7 @@ using MgmtExtensionCommonRestOperation;
 namespace MgmtExtensionCommonRestOperation.Models
 {
     /// <summary> The TypeOneListResult. </summary>
-    public partial class TypeOneListResult
+    internal partial class TypeOneListResult
     {
         /// <summary> Initializes a new instance of TypeOneListResult. </summary>
         /// <param name="value"> The list of of typeones. </param>

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeTwoListResult.Serialization.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeTwoListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtExtensionCommonRestOperation;
 
 namespace MgmtExtensionCommonRestOperation.Models
 {
-    public partial class TypeTwoListResult
+    internal partial class TypeTwoListResult
     {
         internal static TypeTwoListResult DeserializeTypeTwoListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeTwoListResult.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/Models/TypeTwoListResult.cs
@@ -13,7 +13,7 @@ using MgmtExtensionCommonRestOperation;
 namespace MgmtExtensionCommonRestOperation.Models
 {
     /// <summary> The TypeTwoListResult. </summary>
-    public partial class TypeTwoListResult
+    internal partial class TypeTwoListResult
     {
         /// <summary> Initializes a new instance of TypeTwoListResult. </summary>
         /// <param name="value"> The list of of type twos. </param>

--- a/test/TestProjects/MgmtKeyvault/src/Generated/Models/MhsmPrivateLinkResourceListResult.Serialization.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/Models/MhsmPrivateLinkResourceListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace MgmtKeyvault.Models
 {
-    public partial class MhsmPrivateLinkResourceListResult
+    internal partial class MhsmPrivateLinkResourceListResult
     {
         internal static MhsmPrivateLinkResourceListResult DeserializeMhsmPrivateLinkResourceListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtKeyvault/src/Generated/Models/MhsmPrivateLinkResourceListResult.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/Models/MhsmPrivateLinkResourceListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtKeyvault.Models
 {
     /// <summary> A list of private link resources. </summary>
-    public partial class MhsmPrivateLinkResourceListResult
+    internal partial class MhsmPrivateLinkResourceListResult
     {
         /// <summary> Initializes a new instance of MhsmPrivateLinkResourceListResult. </summary>
         internal MhsmPrivateLinkResourceListResult()

--- a/test/TestProjects/MgmtKeyvault/src/Generated/Models/PrivateLinkResourceListResult.Serialization.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/Models/PrivateLinkResourceListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace MgmtKeyvault.Models
 {
-    public partial class PrivateLinkResourceListResult
+    internal partial class PrivateLinkResourceListResult
     {
         internal static PrivateLinkResourceListResult DeserializePrivateLinkResourceListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtKeyvault/src/Generated/Models/PrivateLinkResourceListResult.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/Models/PrivateLinkResourceListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtKeyvault.Models
 {
     /// <summary> A list of private link resources. </summary>
-    public partial class PrivateLinkResourceListResult
+    internal partial class PrivateLinkResourceListResult
     {
         /// <summary> Initializes a new instance of PrivateLinkResourceListResult. </summary>
         internal PrivateLinkResourceListResult()

--- a/test/TestProjects/MgmtLRO/Generated/Models/BarListResult.Serialization.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/BarListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtLRO;
 
 namespace MgmtLRO.Models
 {
-    public partial class BarListResult
+    internal partial class BarListResult
     {
         internal static BarListResult DeserializeBarListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtLRO/Generated/Models/BarListResult.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/BarListResult.cs
@@ -13,7 +13,7 @@ using MgmtLRO;
 namespace MgmtLRO.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class BarListResult
+    internal partial class BarListResult
     {
         /// <summary> Initializes a new instance of BarListResult. </summary>
         /// <param name="value"> The list of bars. </param>

--- a/test/TestProjects/MgmtLRO/Generated/Models/FakeListResult.Serialization.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/FakeListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtLRO;
 
 namespace MgmtLRO.Models
 {
-    public partial class FakeListResult
+    internal partial class FakeListResult
     {
         internal static FakeListResult DeserializeFakeListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtLRO/Generated/Models/FakeListResult.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/FakeListResult.cs
@@ -13,7 +13,7 @@ using MgmtLRO;
 namespace MgmtLRO.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class FakeListResult
+    internal partial class FakeListResult
     {
         /// <summary> Initializes a new instance of FakeListResult. </summary>
         /// <param name="value"> The list of fakes. </param>

--- a/test/TestProjects/MgmtListMethods/Generated/Models/NonResourceChildListResult.Serialization.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/NonResourceChildListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace MgmtListMethods.Models
 {
-    public partial class NonResourceChildListResult
+    internal partial class NonResourceChildListResult
     {
         internal static NonResourceChildListResult DeserializeNonResourceChildListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtListMethods/Generated/Models/NonResourceChildListResult.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/NonResourceChildListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtListMethods.Models
 {
     /// <summary> The List of Non Resource Child operation response. </summary>
-    public partial class NonResourceChildListResult
+    internal partial class NonResourceChildListResult
     {
         /// <summary> Initializes a new instance of NonResourceChildListResult. </summary>
         internal NonResourceChildListResult()

--- a/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentListResult.Serialization.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtListMethods;
 
 namespace MgmtListMethods.Models
 {
-    public partial class ResGrpParentListResult
+    internal partial class ResGrpParentListResult
     {
         internal static ResGrpParentListResult DeserializeResGrpParentListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentListResult.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentListResult.cs
@@ -13,7 +13,7 @@ using MgmtListMethods;
 namespace MgmtListMethods.Models
 {
     /// <summary> The List operation response. </summary>
-    public partial class ResGrpParentListResult
+    internal partial class ResGrpParentListResult
     {
         /// <summary> Initializes a new instance of ResGrpParentListResult. </summary>
         /// <param name="value"> List. </param>

--- a/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentWithAncestorListResult.Serialization.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentWithAncestorListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtListMethods;
 
 namespace MgmtListMethods.Models
 {
-    public partial class ResGrpParentWithAncestorListResult
+    internal partial class ResGrpParentWithAncestorListResult
     {
         internal static ResGrpParentWithAncestorListResult DeserializeResGrpParentWithAncestorListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentWithAncestorListResult.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/ResGrpParentWithAncestorListResult.cs
@@ -13,7 +13,7 @@ using MgmtListMethods;
 namespace MgmtListMethods.Models
 {
     /// <summary> The List operation response. </summary>
-    public partial class ResGrpParentWithAncestorListResult
+    internal partial class ResGrpParentWithAncestorListResult
     {
         /// <summary> Initializes a new instance of ResGrpParentWithAncestorListResult. </summary>
         /// <param name="value"> List. </param>

--- a/test/TestProjects/MgmtListMethods/Generated/Models/UpdateWorkspaceQuotasResult.Serialization.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/UpdateWorkspaceQuotasResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace MgmtListMethods.Models
 {
-    public partial class UpdateWorkspaceQuotasResult
+    internal partial class UpdateWorkspaceQuotasResult
     {
         internal static UpdateWorkspaceQuotasResult DeserializeUpdateWorkspaceQuotasResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtListMethods/Generated/Models/UpdateWorkspaceQuotasResult.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/UpdateWorkspaceQuotasResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtListMethods.Models
 {
     /// <summary> The result of update workspace quota. </summary>
-    public partial class UpdateWorkspaceQuotasResult
+    internal partial class UpdateWorkspaceQuotasResult
     {
         /// <summary> Initializes a new instance of UpdateWorkspaceQuotasResult. </summary>
         internal UpdateWorkspaceQuotasResult()

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/FakeListResult.Serialization.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/FakeListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtNonStringPathVariable;
 
 namespace MgmtNonStringPathVariable.Models
 {
-    public partial class FakeListResult
+    internal partial class FakeListResult
     {
         internal static FakeListResult DeserializeFakeListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/FakeListResult.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/FakeListResult.cs
@@ -13,7 +13,7 @@ using MgmtNonStringPathVariable;
 namespace MgmtNonStringPathVariable.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class FakeListResult
+    internal partial class FakeListResult
     {
         /// <summary> Initializes a new instance of FakeListResult. </summary>
         /// <param name="value"> The list of fakes. </param>

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetChildListResult.Serialization.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetChildListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtOperations;
 
 namespace MgmtOperations.Models
 {
-    public partial class AvailabilitySetChildListResult
+    internal partial class AvailabilitySetChildListResult
     {
         internal static AvailabilitySetChildListResult DeserializeAvailabilitySetChildListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetChildListResult.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetChildListResult.cs
@@ -13,7 +13,7 @@ using MgmtOperations;
 namespace MgmtOperations.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class AvailabilitySetChildListResult
+    internal partial class AvailabilitySetChildListResult
     {
         /// <summary> Initializes a new instance of AvailabilitySetChildListResult. </summary>
         /// <param name="value"> The list of availability sets. </param>

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetGrandChildListResult.Serialization.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetGrandChildListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtOperations;
 
 namespace MgmtOperations.Models
 {
-    public partial class AvailabilitySetGrandChildListResult
+    internal partial class AvailabilitySetGrandChildListResult
     {
         internal static AvailabilitySetGrandChildListResult DeserializeAvailabilitySetGrandChildListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetGrandChildListResult.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetGrandChildListResult.cs
@@ -13,7 +13,7 @@ using MgmtOperations;
 namespace MgmtOperations.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class AvailabilitySetGrandChildListResult
+    internal partial class AvailabilitySetGrandChildListResult
     {
         /// <summary> Initializes a new instance of AvailabilitySetGrandChildListResult. </summary>
         /// <param name="value"> The list of availability sets. </param>

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetListResult.Serialization.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtOperations;
 
 namespace MgmtOperations.Models
 {
-    public partial class AvailabilitySetListResult
+    internal partial class AvailabilitySetListResult
     {
         internal static AvailabilitySetListResult DeserializeAvailabilitySetListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetListResult.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetListResult.cs
@@ -13,7 +13,7 @@ using MgmtOperations;
 namespace MgmtOperations.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class AvailabilitySetListResult
+    internal partial class AvailabilitySetListResult
     {
         /// <summary> Initializes a new instance of AvailabilitySetListResult. </summary>
         /// <param name="value"> The list of availability sets. </param>

--- a/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceListResult.Serialization.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtOperations;
 
 namespace MgmtOperations.Models
 {
-    public partial class UnpatchableResourceListResult
+    internal partial class UnpatchableResourceListResult
     {
         internal static UnpatchableResourceListResult DeserializeUnpatchableResourceListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceListResult.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceListResult.cs
@@ -12,7 +12,7 @@ using MgmtOperations;
 namespace MgmtOperations.Models
 {
     /// <summary> The UnpatchableResourceListResult. </summary>
-    public partial class UnpatchableResourceListResult
+    internal partial class UnpatchableResourceListResult
     {
         /// <summary> Initializes a new instance of UnpatchableResourceListResult. </summary>
         internal UnpatchableResourceListResult()

--- a/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceUpdateOptions.Serialization.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceUpdateOptions.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtOperations.Models
 {
-    public partial class UnpatchableResourceUpdateOptions : IUtf8JsonSerializable
+    internal partial class UnpatchableResourceUpdateOptions : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceUpdateOptions.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourceUpdateOptions.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtOperations.Models
 {
     /// <summary> The update content of unpatchable resource. </summary>
-    public partial class UnpatchableResourceUpdateOptions
+    internal partial class UnpatchableResourceUpdateOptions
     {
         /// <summary> Initializes a new instance of UnpatchableResourceUpdateOptions. </summary>
         public UnpatchableResourceUpdateOptions()

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostGroupListResult.Serialization.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostGroupListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtParamOrdering;
 
 namespace MgmtParamOrdering.Models
 {
-    public partial class DedicatedHostGroupListResult
+    internal partial class DedicatedHostGroupListResult
     {
         internal static DedicatedHostGroupListResult DeserializeDedicatedHostGroupListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostGroupListResult.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostGroupListResult.cs
@@ -13,7 +13,7 @@ using MgmtParamOrdering;
 namespace MgmtParamOrdering.Models
 {
     /// <summary> The list dedicated host operation response. </summary>
-    public partial class DedicatedHostGroupListResult
+    internal partial class DedicatedHostGroupListResult
     {
         /// <summary> Initializes a new instance of DedicatedHostGroupListResult. </summary>
         /// <param name="value"> The list of dedicated hosts. </param>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/EnvironmentContainerResourceListResult.Serialization.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/EnvironmentContainerResourceListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtParamOrdering;
 
 namespace MgmtParamOrdering.Models
 {
-    public partial class EnvironmentContainerResourceListResult
+    internal partial class EnvironmentContainerResourceListResult
     {
         internal static EnvironmentContainerResourceListResult DeserializeEnvironmentContainerResourceListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/EnvironmentContainerResourceListResult.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/EnvironmentContainerResourceListResult.cs
@@ -13,7 +13,7 @@ using MgmtParamOrdering;
 namespace MgmtParamOrdering.Models
 {
     /// <summary> The list dedicated host operation response. </summary>
-    public partial class EnvironmentContainerResourceListResult
+    internal partial class EnvironmentContainerResourceListResult
     {
         /// <summary> Initializes a new instance of EnvironmentContainerResourceListResult. </summary>
         /// <param name="value"> The list of dedicated hosts. </param>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVM.Serialization.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVM.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace MgmtParamOrdering.Models
 {
-    public partial class VirtualMachineScaleSetVM : IUtf8JsonSerializable
+    internal partial class VirtualMachineScaleSetVM : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVM.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVM.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Models;
 namespace MgmtParamOrdering.Models
 {
     /// <summary> Describes a virtual machine scale set virtual machine. </summary>
-    public partial class VirtualMachineScaleSetVM : TrackedResourceData
+    internal partial class VirtualMachineScaleSetVM : TrackedResourceData
     {
         /// <summary> Initializes a new instance of VirtualMachineScaleSetVM. </summary>
         /// <param name="location"> The location. </param>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceListResult.Serialization.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtParamOrdering;
 
 namespace MgmtParamOrdering.Models
 {
-    public partial class WorkspaceListResult
+    internal partial class WorkspaceListResult
     {
         internal static WorkspaceListResult DeserializeWorkspaceListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceListResult.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceListResult.cs
@@ -13,7 +13,7 @@ using MgmtParamOrdering;
 namespace MgmtParamOrdering.Models
 {
     /// <summary> The list dedicated host operation response. </summary>
-    public partial class WorkspaceListResult
+    internal partial class WorkspaceListResult
     {
         /// <summary> Initializes a new instance of WorkspaceListResult. </summary>
         /// <param name="value"> The list of dedicated hosts. </param>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceUpdateOptions.Serialization.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceUpdateOptions.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtParamOrdering.Models
 {
-    public partial class WorkspaceUpdateOptions : IUtf8JsonSerializable
+    internal partial class WorkspaceUpdateOptions : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceUpdateOptions.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspaceUpdateOptions.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace MgmtParamOrdering.Models
 {
     /// <summary> The parameters for updating a machine learning workspace. </summary>
-    public partial class WorkspaceUpdateOptions
+    internal partial class WorkspaceUpdateOptions
     {
         /// <summary> Initializes a new instance of WorkspaceUpdateOptions. </summary>
         public WorkspaceUpdateOptions()

--- a/test/TestProjects/MgmtPropertyChooser/Generated/Models/VirtualMachineListResult.Serialization.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/Models/VirtualMachineListResult.Serialization.cs
@@ -12,7 +12,7 @@ using MgmtPropertyChooser;
 
 namespace MgmtPropertyChooser.Models
 {
-    public partial class VirtualMachineListResult
+    internal partial class VirtualMachineListResult
     {
         internal static VirtualMachineListResult DeserializeVirtualMachineListResult(JsonElement element)
         {

--- a/test/TestProjects/MgmtPropertyChooser/Generated/Models/VirtualMachineListResult.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/Models/VirtualMachineListResult.cs
@@ -13,7 +13,7 @@ using MgmtPropertyChooser;
 namespace MgmtPropertyChooser.Models
 {
     /// <summary> The List Virtual Machine operation response. </summary>
-    public partial class VirtualMachineListResult
+    internal partial class VirtualMachineListResult
     {
         /// <summary> Initializes a new instance of VirtualMachineListResult. </summary>
         /// <param name="value"> The list of virtual machines. </param>

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/AutomaticOSUpgradeProperties.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/AutomaticOSUpgradeProperties.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class AutomaticOSUpgradeProperties : IUtf8JsonSerializable
+    internal partial class AutomaticOSUpgradeProperties : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/AutomaticOSUpgradeProperties.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/AutomaticOSUpgradeProperties.cs
@@ -8,7 +8,7 @@
 namespace MgmtRenameRules.Models
 {
     /// <summary> Describes automatic OS upgrade properties on the image. </summary>
-    public partial class AutomaticOSUpgradeProperties
+    internal partial class AutomaticOSUpgradeProperties
     {
         /// <summary> Initializes a new instance of AutomaticOSUpgradeProperties. </summary>
         /// <param name="automaticOSUpgradeSupported"> Specifies whether automatic OS upgrade is supported on the image. </param>

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/DataDiskImage.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/DataDiskImage.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class DataDiskImage : IUtf8JsonSerializable
+    internal partial class DataDiskImage : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/DataDiskImage.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/DataDiskImage.cs
@@ -8,7 +8,7 @@
 namespace MgmtRenameRules.Models
 {
     /// <summary> Contains the data disk images information. </summary>
-    public partial class DataDiskImage
+    internal partial class DataDiskImage
     {
         /// <summary> Initializes a new instance of DataDiskImage. </summary>
         public DataDiskImage()

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/DisallowedConfiguration.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/DisallowedConfiguration.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class DisallowedConfiguration : IUtf8JsonSerializable
+    internal partial class DisallowedConfiguration : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/DisallowedConfiguration.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/DisallowedConfiguration.cs
@@ -8,7 +8,7 @@
 namespace MgmtRenameRules.Models
 {
     /// <summary> Specifies the disallowed configuration for a virtual machine image. </summary>
-    public partial class DisallowedConfiguration
+    internal partial class DisallowedConfiguration
     {
         /// <summary> Initializes a new instance of DisallowedConfiguration. </summary>
         public DisallowedConfiguration()

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/OSDiskImage.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/OSDiskImage.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class OSDiskImage : IUtf8JsonSerializable
+    internal partial class OSDiskImage : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/OSDiskImage.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/OSDiskImage.cs
@@ -8,7 +8,7 @@
 namespace MgmtRenameRules.Models
 {
     /// <summary> Contains the os disk image information. </summary>
-    public partial class OSDiskImage
+    internal partial class OSDiskImage
     {
         /// <summary> Initializes a new instance of OSDiskImage. </summary>
         /// <param name="operatingSystem"> The operating system of the osDiskImage. </param>

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/PurchasePlan.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/PurchasePlan.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class PurchasePlan : IUtf8JsonSerializable
+    internal partial class PurchasePlan : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/PurchasePlan.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/PurchasePlan.cs
@@ -10,7 +10,7 @@ using System;
 namespace MgmtRenameRules.Models
 {
     /// <summary> Used for establishing the purchase context of any 3rd Party artifact through MarketPlace. </summary>
-    public partial class PurchasePlan
+    internal partial class PurchasePlan
     {
         /// <summary> Initializes a new instance of PurchasePlan. </summary>
         /// <param name="publisher"> The publisher ID. </param>

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/SubResourceWithColocationStatus.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/SubResourceWithColocationStatus.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class SubResourceWithColocationStatus : IUtf8JsonSerializable
+    internal partial class SubResourceWithColocationStatus : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/SubResourceWithColocationStatus.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/SubResourceWithColocationStatus.cs
@@ -8,7 +8,7 @@
 namespace MgmtRenameRules.Models
 {
     /// <summary> The SubResourceWithColocationStatus. </summary>
-    public partial class SubResourceWithColocationStatus : SubResource
+    internal partial class SubResourceWithColocationStatus : SubResource
     {
         /// <summary> Initializes a new instance of SubResourceWithColocationStatus. </summary>
         public SubResourceWithColocationStatus()

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineExtensionImage.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineExtensionImage.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class VirtualMachineExtensionImage : IUtf8JsonSerializable
+    internal partial class VirtualMachineExtensionImage : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineExtensionImage.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineExtensionImage.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Models;
 namespace MgmtRenameRules.Models
 {
     /// <summary> Describes a Virtual Machine Extension Image. </summary>
-    public partial class VirtualMachineExtensionImage : TrackedResourceData
+    internal partial class VirtualMachineExtensionImage : TrackedResourceData
     {
         /// <summary> Initializes a new instance of VirtualMachineExtensionImage. </summary>
         /// <param name="location"> The location. </param>

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImage.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImage.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class VirtualMachineImage : IUtf8JsonSerializable
+    internal partial class VirtualMachineImage : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImage.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImage.cs
@@ -12,7 +12,7 @@ using Azure.Core;
 namespace MgmtRenameRules.Models
 {
     /// <summary> Describes a Virtual Machine Image. </summary>
-    public partial class VirtualMachineImage : VirtualMachineImageResource
+    internal partial class VirtualMachineImage : VirtualMachineImageResource
     {
         /// <summary> Initializes a new instance of VirtualMachineImage. </summary>
         /// <param name="name"> The name of the resource. </param>

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImageResource.Serialization.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImageResource.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace MgmtRenameRules.Models
 {
-    public partial class VirtualMachineImageResource : IUtf8JsonSerializable
+    internal partial class VirtualMachineImageResource : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImageResource.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineImageResource.cs
@@ -12,7 +12,7 @@ using Azure.Core;
 namespace MgmtRenameRules.Models
 {
     /// <summary> Virtual machine image resource information. </summary>
-    public partial class VirtualMachineImageResource : SubResource
+    internal partial class VirtualMachineImageResource : SubResource
     {
         /// <summary> Initializes a new instance of VirtualMachineImageResource. </summary>
         /// <param name="name"> The name of the resource. </param>

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/Models/TrackedResource.Serialization.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/Models/TrackedResource.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace MgmtSubscriptionNameParameter.Models
 {
-    public partial class TrackedResource : IUtf8JsonSerializable
+    internal partial class TrackedResource : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/Models/TrackedResource.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/Models/TrackedResource.cs
@@ -13,7 +13,7 @@ using Azure.ResourceManager.Models;
 namespace MgmtSubscriptionNameParameter.Models
 {
     /// <summary> The Resource definition. </summary>
-    public partial class TrackedResource : ResourceData
+    internal partial class TrackedResource : ResourceData
     {
         /// <summary> Initializes a new instance of TrackedResource. </summary>
         /// <param name="location"> The Geo-location where the resource lives. </param>

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel1ListResult.Serialization.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel1ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using NoTypeReplacement;
 
 namespace NoTypeReplacement.Models
 {
-    public partial class NoTypeReplacementModel1ListResult
+    internal partial class NoTypeReplacementModel1ListResult
     {
         internal static NoTypeReplacementModel1ListResult DeserializeNoTypeReplacementModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel1ListResult.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel1ListResult.cs
@@ -12,7 +12,7 @@ using NoTypeReplacement;
 namespace NoTypeReplacement.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class NoTypeReplacementModel1ListResult
+    internal partial class NoTypeReplacementModel1ListResult
     {
         /// <summary> Initializes a new instance of NoTypeReplacementModel1ListResult. </summary>
         internal NoTypeReplacementModel1ListResult()

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel2ListResult.Serialization.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel2ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using NoTypeReplacement;
 
 namespace NoTypeReplacement.Models
 {
-    public partial class NoTypeReplacementModel2ListResult
+    internal partial class NoTypeReplacementModel2ListResult
     {
         internal static NoTypeReplacementModel2ListResult DeserializeNoTypeReplacementModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel2ListResult.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel2ListResult.cs
@@ -12,7 +12,7 @@ using NoTypeReplacement;
 namespace NoTypeReplacement.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class NoTypeReplacementModel2ListResult
+    internal partial class NoTypeReplacementModel2ListResult
     {
         /// <summary> Initializes a new instance of NoTypeReplacementModel2ListResult. </summary>
         internal NoTypeReplacementModel2ListResult()

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel3ListResult.Serialization.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel3ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using NoTypeReplacement;
 
 namespace NoTypeReplacement.Models
 {
-    public partial class NoTypeReplacementModel3ListResult
+    internal partial class NoTypeReplacementModel3ListResult
     {
         internal static NoTypeReplacementModel3ListResult DeserializeNoTypeReplacementModel3ListResult(JsonElement element)
         {

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel3ListResult.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/NoTypeReplacementModel3ListResult.cs
@@ -12,7 +12,7 @@ using NoTypeReplacement;
 namespace NoTypeReplacement.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class NoTypeReplacementModel3ListResult
+    internal partial class NoTypeReplacementModel3ListResult
     {
         /// <summary> Initializes a new instance of NoTypeReplacementModel3ListResult. </summary>
         internal NoTypeReplacementModel3ListResult()

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/SubResourceModel.Serialization.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/SubResourceModel.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace NoTypeReplacement.Models
 {
-    public partial class SubResourceModel : IUtf8JsonSerializable
+    internal partial class SubResourceModel : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/NoTypeReplacement/Generated/Models/SubResourceModel.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/Models/SubResourceModel.cs
@@ -8,7 +8,7 @@
 namespace NoTypeReplacement.Models
 {
     /// <summary> The SubResourceModel. </summary>
-    public partial class SubResourceModel
+    internal partial class SubResourceModel
     {
         /// <summary> Initializes a new instance of SubResourceModel. </summary>
         public SubResourceModel()

--- a/test/TestProjects/OmitOperationGroups/Generated/Models/Model2ListResult.Serialization.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/Models/Model2ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using OmitOperationGroups;
 
 namespace OmitOperationGroups.Models
 {
-    public partial class Model2ListResult
+    internal partial class Model2ListResult
     {
         internal static Model2ListResult DeserializeModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/OmitOperationGroups/Generated/Models/Model2ListResult.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/Models/Model2ListResult.cs
@@ -12,7 +12,7 @@ using OmitOperationGroups;
 namespace OmitOperationGroups.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class Model2ListResult
+    internal partial class Model2ListResult
     {
         /// <summary> Initializes a new instance of Model2ListResult. </summary>
         internal Model2ListResult()

--- a/test/TestProjects/OmitOperationGroups/Generated/Models/Model5ListResult.Serialization.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/Models/Model5ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace OmitOperationGroups.Models
 {
-    public partial class Model5ListResult
+    internal partial class Model5ListResult
     {
         internal static Model5ListResult DeserializeModel5ListResult(JsonElement element)
         {

--- a/test/TestProjects/OmitOperationGroups/Generated/Models/Model5ListResult.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/Models/Model5ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace OmitOperationGroups.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class Model5ListResult
+    internal partial class Model5ListResult
     {
         /// <summary> Initializes a new instance of Model5ListResult. </summary>
         internal Model5ListResult()

--- a/test/TestProjects/ReferenceTypes/Generated/Models/ResourceNon.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/ResourceNon.cs
@@ -8,7 +8,7 @@
 namespace ReferenceTypes.Models
 {
     /// <summary> Common fields that are returned in the response for all Azure Resource Manager resources. </summary>
-    public partial class ResourceNon
+    internal partial class ResourceNon
     {
         /// <summary> Initializes a new instance of ResourceNon. </summary>
         internal ResourceNon()

--- a/test/TestProjects/ReferenceTypes/Generated/Models/ResourceNon.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/ResourceNon.cs
@@ -8,7 +8,7 @@
 namespace ReferenceTypes.Models
 {
     /// <summary> Common fields that are returned in the response for all Azure Resource Manager resources. </summary>
-    internal partial class ResourceNon
+    public partial class ResourceNon
     {
         /// <summary> Initializes a new instance of ResourceNon. </summary>
         internal ResourceNon()

--- a/test/TestProjects/ResourceRename/Generated/CodeModel.yaml
+++ b/test/TestProjects/ResourceRename/Generated/CodeModel.yaml
@@ -160,7 +160,7 @@ schemas: !Schemas
                       name: name
                       description: ''
                   protocol: !Protocols {}
-                - !Property &ref_20
+                - !Property 
                   schema: !ObjectSchema &ref_8
                     type: object
                     apiVersions:
@@ -374,7 +374,7 @@ operationGroups:
             version: '2020-06-01'
         parameters:
           - *ref_12
-          - !Parameter &ref_22
+          - !Parameter &ref_20
             schema: *ref_10
             implementation: Method
             required: true
@@ -386,7 +386,7 @@ operationGroups:
             protocol: !Protocols 
               http: !HttpParameter 
                 in: path
-          - !Parameter &ref_23
+          - !Parameter &ref_21
             schema: *ref_10
             implementation: Method
             required: true
@@ -418,7 +418,6 @@ operationGroups:
                     in: header
               - !Parameter &ref_19
                 schema: *ref_7
-                flattened: true
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -442,19 +441,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !VirtualParameter &ref_21
-                schema: *ref_8
-                implementation: Method
-                originalParameter: *ref_19
-                pathToProperty: []
-                targetProperty: *ref_20
-                language: !Languages 
-                  default:
-                    name: properties
-                    description: Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
-                protocol: !Protocols {}
             signatureParameters:
-              - *ref_21
+              - *ref_19
             language: !Languages 
               default:
                 name: ''
@@ -468,8 +456,8 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         signatureParameters:
-          - *ref_22
-          - *ref_23
+          - *ref_20
+          - *ref_21
         responses:
           - !SchemaResponse 
             schema: *ref_7
@@ -508,7 +496,7 @@ operationGroups:
             version: '2020-06-01'
         parameters:
           - *ref_12
-          - !Parameter &ref_24
+          - !Parameter &ref_22
             schema: *ref_10
             implementation: Method
             required: true
@@ -520,7 +508,7 @@ operationGroups:
             protocol: !Protocols 
               http: !HttpParameter 
                 in: path
-          - !Parameter &ref_25
+          - !Parameter &ref_23
             schema: *ref_10
             implementation: Method
             required: true
@@ -546,8 +534,8 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_24
-          - *ref_25
+          - *ref_22
+          - *ref_23
         responses:
           - !Response 
             language: !Languages 
@@ -578,7 +566,7 @@ operationGroups:
             version: '2020-06-01'
         parameters:
           - *ref_12
-          - !Parameter &ref_26
+          - !Parameter &ref_24
             schema: *ref_10
             implementation: Method
             required: true
@@ -590,7 +578,7 @@ operationGroups:
             protocol: !Protocols 
               http: !HttpParameter 
                 in: path
-          - !Parameter &ref_27
+          - !Parameter &ref_25
             schema: *ref_10
             implementation: Method
             required: true
@@ -631,8 +619,8 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_26
-          - *ref_27
+          - *ref_24
+          - *ref_25
         responses:
           - !SchemaResponse 
             schema: *ref_7

--- a/test/TestProjects/ResourceRename/Generated/RestOperations/SshPublicKeysRestOperations.cs
+++ b/test/TestProjects/ResourceRename/Generated/RestOperations/SshPublicKeysRestOperations.cs
@@ -126,7 +126,7 @@ namespace ResourceRename
             }
         }
 
-        internal HttpMessage CreateCreateRequest(string subscriptionId, string resourceGroupName, string sshPublicKeyName, SshPublicKeyProperties properties)
+        internal HttpMessage CreateCreateRequest(string subscriptionId, string resourceGroupName, string sshPublicKeyName, SshPublicKeyInfoData parameters)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -143,12 +143,8 @@ namespace ResourceRename
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             request.Headers.Add("Content-Type", "application/json");
-            var model = new SshPublicKeyInfoData()
-            {
-                Properties = properties
-            };
             var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteObjectValue(model);
+            content.JsonWriter.WriteObjectValue(parameters);
             request.Content = content;
             message.SetProperty("SDKUserAgent", _userAgent);
             return message;
@@ -158,10 +154,10 @@ namespace ResourceRename
         /// <param name="subscriptionId"> Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call. </param>
         /// <param name="resourceGroupName"> The name of the resource group. </param>
         /// <param name="sshPublicKeyName"> The name of the SSH public key. </param>
-        /// <param name="properties"> Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed. </param>
+        /// <param name="parameters"> Parameters supplied to create the SSH public key. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/> or <paramref name="sshPublicKeyName"/> is null. </exception>
-        public async Task<Response<SshPublicKeyInfoData>> CreateAsync(string subscriptionId, string resourceGroupName, string sshPublicKeyName, SshPublicKeyProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="sshPublicKeyName"/> or <paramref name="parameters"/> is null. </exception>
+        public async Task<Response<SshPublicKeyInfoData>> CreateAsync(string subscriptionId, string resourceGroupName, string sshPublicKeyName, SshPublicKeyInfoData parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -175,8 +171,12 @@ namespace ResourceRename
             {
                 throw new ArgumentNullException(nameof(sshPublicKeyName));
             }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
 
-            using var message = CreateCreateRequest(subscriptionId, resourceGroupName, sshPublicKeyName, properties);
+            using var message = CreateCreateRequest(subscriptionId, resourceGroupName, sshPublicKeyName, parameters);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -197,10 +197,10 @@ namespace ResourceRename
         /// <param name="subscriptionId"> Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call. </param>
         /// <param name="resourceGroupName"> The name of the resource group. </param>
         /// <param name="sshPublicKeyName"> The name of the SSH public key. </param>
-        /// <param name="properties"> Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed. </param>
+        /// <param name="parameters"> Parameters supplied to create the SSH public key. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/> or <paramref name="sshPublicKeyName"/> is null. </exception>
-        public Response<SshPublicKeyInfoData> Create(string subscriptionId, string resourceGroupName, string sshPublicKeyName, SshPublicKeyProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/>, <paramref name="resourceGroupName"/>, <paramref name="sshPublicKeyName"/> or <paramref name="parameters"/> is null. </exception>
+        public Response<SshPublicKeyInfoData> Create(string subscriptionId, string resourceGroupName, string sshPublicKeyName, SshPublicKeyInfoData parameters, CancellationToken cancellationToken = default)
         {
             if (subscriptionId == null)
             {
@@ -214,8 +214,12 @@ namespace ResourceRename
             {
                 throw new ArgumentNullException(nameof(sshPublicKeyName));
             }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
 
-            using var message = CreateCreateRequest(subscriptionId, resourceGroupName, sshPublicKeyName, properties);
+            using var message = CreateCreateRequest(subscriptionId, resourceGroupName, sshPublicKeyName, parameters);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/test/TestProjects/ResourceRename/Generated/SshPublicKeyInfoCollection.cs
+++ b/test/TestProjects/ResourceRename/Generated/SshPublicKeyInfoCollection.cs
@@ -18,7 +18,6 @@ using Azure.Core.Pipeline;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Core;
 using Azure.ResourceManager.Resources;
-using ResourceRename.Models;
 
 namespace ResourceRename
 {
@@ -59,19 +58,20 @@ namespace ResourceRename
         /// </summary>
         /// <param name="waitForCompletion"> Waits for the completion of the long running operations. </param>
         /// <param name="sshPublicKeyName"> The name of the SSH public key. </param>
-        /// <param name="properties"> Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed. </param>
+        /// <param name="parameters"> Parameters supplied to create the SSH public key. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentException"> <paramref name="sshPublicKeyName"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="ArgumentNullException"> <paramref name="sshPublicKeyName"/> is null. </exception>
-        public async virtual Task<ArmOperation<SshPublicKeyInfo>> CreateOrUpdateAsync(bool waitForCompletion, string sshPublicKeyName, SshPublicKeyProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="sshPublicKeyName"/> or <paramref name="parameters"/> is null. </exception>
+        public async virtual Task<ArmOperation<SshPublicKeyInfo>> CreateOrUpdateAsync(bool waitForCompletion, string sshPublicKeyName, SshPublicKeyInfoData parameters, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(sshPublicKeyName, nameof(sshPublicKeyName));
+            Argument.AssertNotNull(parameters, nameof(parameters));
 
             using var scope = _sshPublicKeyInfoSshPublicKeysClientDiagnostics.CreateScope("SshPublicKeyInfoCollection.CreateOrUpdate");
             scope.Start();
             try
             {
-                var response = await _sshPublicKeyInfoSshPublicKeysRestClient.CreateAsync(Id.SubscriptionId, Id.ResourceGroupName, sshPublicKeyName, properties, cancellationToken).ConfigureAwait(false);
+                var response = await _sshPublicKeyInfoSshPublicKeysRestClient.CreateAsync(Id.SubscriptionId, Id.ResourceGroupName, sshPublicKeyName, parameters, cancellationToken).ConfigureAwait(false);
                 var operation = new ResourceRenameArmOperation<SshPublicKeyInfo>(Response.FromValue(new SshPublicKeyInfo(Client, response), response.GetRawResponse()));
                 if (waitForCompletion)
                     await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
@@ -91,19 +91,20 @@ namespace ResourceRename
         /// </summary>
         /// <param name="waitForCompletion"> Waits for the completion of the long running operations. </param>
         /// <param name="sshPublicKeyName"> The name of the SSH public key. </param>
-        /// <param name="properties"> Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed. </param>
+        /// <param name="parameters"> Parameters supplied to create the SSH public key. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentException"> <paramref name="sshPublicKeyName"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <exception cref="ArgumentNullException"> <paramref name="sshPublicKeyName"/> is null. </exception>
-        public virtual ArmOperation<SshPublicKeyInfo> CreateOrUpdate(bool waitForCompletion, string sshPublicKeyName, SshPublicKeyProperties properties = null, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="sshPublicKeyName"/> or <paramref name="parameters"/> is null. </exception>
+        public virtual ArmOperation<SshPublicKeyInfo> CreateOrUpdate(bool waitForCompletion, string sshPublicKeyName, SshPublicKeyInfoData parameters, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(sshPublicKeyName, nameof(sshPublicKeyName));
+            Argument.AssertNotNull(parameters, nameof(parameters));
 
             using var scope = _sshPublicKeyInfoSshPublicKeysClientDiagnostics.CreateScope("SshPublicKeyInfoCollection.CreateOrUpdate");
             scope.Start();
             try
             {
-                var response = _sshPublicKeyInfoSshPublicKeysRestClient.Create(Id.SubscriptionId, Id.ResourceGroupName, sshPublicKeyName, properties, cancellationToken);
+                var response = _sshPublicKeyInfoSshPublicKeysRestClient.Create(Id.SubscriptionId, Id.ResourceGroupName, sshPublicKeyName, parameters, cancellationToken);
                 var operation = new ResourceRenameArmOperation<SshPublicKeyInfo>(Response.FromValue(new SshPublicKeyInfo(Client, response), response.GetRawResponse()));
                 if (waitForCompletion)
                     operation.WaitForCompletion(cancellationToken);

--- a/test/TestProjects/ResourceRename/readme.md
+++ b/test/TestProjects/ResourceRename/readme.md
@@ -12,7 +12,6 @@ namespace: ResourceRename
 model-namespace: false
 public-clients: false
 head-as-boolean: false
-payload-flattening-threshold: 2
 modelerfour:
   lenient-model-deduplication: true
 

--- a/test/TestProjects/SingletonResource/Generated/Models/CarListResult.Serialization.cs
+++ b/test/TestProjects/SingletonResource/Generated/Models/CarListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SingletonResource;
 
 namespace SingletonResource.Models
 {
-    public partial class CarListResult
+    internal partial class CarListResult
     {
         internal static CarListResult DeserializeCarListResult(JsonElement element)
         {

--- a/test/TestProjects/SingletonResource/Generated/Models/CarListResult.cs
+++ b/test/TestProjects/SingletonResource/Generated/Models/CarListResult.cs
@@ -12,7 +12,7 @@ using SingletonResource;
 namespace SingletonResource.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class CarListResult
+    internal partial class CarListResult
     {
         /// <summary> Initializes a new instance of CarListResult. </summary>
         internal CarListResult()

--- a/test/TestProjects/SingletonResource/Generated/Models/ParentResourceListResult.Serialization.cs
+++ b/test/TestProjects/SingletonResource/Generated/Models/ParentResourceListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SingletonResource;
 
 namespace SingletonResource.Models
 {
-    public partial class ParentResourceListResult
+    internal partial class ParentResourceListResult
     {
         internal static ParentResourceListResult DeserializeParentResourceListResult(JsonElement element)
         {

--- a/test/TestProjects/SingletonResource/Generated/Models/ParentResourceListResult.cs
+++ b/test/TestProjects/SingletonResource/Generated/Models/ParentResourceListResult.cs
@@ -13,7 +13,7 @@ using SingletonResource;
 namespace SingletonResource.Models
 {
     /// <summary> The List Availability Set operation response. </summary>
-    public partial class ParentResourceListResult
+    internal partial class ParentResourceListResult
     {
         /// <summary> Initializes a new instance of ParentResourceListResult. </summary>
         /// <param name="value"> The list of parent resource. </param>

--- a/test/TestProjects/SubscriptionExtensions/Generated/Models/ToasterListResult.Serialization.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/Models/ToasterListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SubscriptionExtensions;
 
 namespace SubscriptionExtensions.Models
 {
-    public partial class ToasterListResult
+    internal partial class ToasterListResult
     {
         internal static ToasterListResult DeserializeToasterListResult(JsonElement element)
         {

--- a/test/TestProjects/SubscriptionExtensions/Generated/Models/ToasterListResult.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/Models/ToasterListResult.cs
@@ -12,7 +12,7 @@ using SubscriptionExtensions;
 namespace SubscriptionExtensions.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class ToasterListResult
+    internal partial class ToasterListResult
     {
         /// <summary> Initializes a new instance of ToasterListResult. </summary>
         internal ToasterListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel1ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel1ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class CustomModel1ListResult
+    internal partial class CustomModel1ListResult
     {
         internal static CustomModel1ListResult DeserializeCustomModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel1ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel1ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class CustomModel1ListResult
+    internal partial class CustomModel1ListResult
     {
         /// <summary> Initializes a new instance of CustomModel1ListResult. </summary>
         internal CustomModel1ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel2ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel2ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class CustomModel2ListResult
+    internal partial class CustomModel2ListResult
     {
         internal static CustomModel2ListResult DeserializeCustomModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel2ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/CustomModel2ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class CustomModel2ListResult
+    internal partial class CustomModel2ListResult
     {
         /// <summary> Initializes a new instance of CustomModel2ListResult. </summary>
         internal CustomModel2ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel1ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel1ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SupersetFlattenInheritance;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class ResourceModel1ListResult
+    internal partial class ResourceModel1ListResult
     {
         internal static ResourceModel1ListResult DeserializeResourceModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel1ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel1ListResult.cs
@@ -12,7 +12,7 @@ using SupersetFlattenInheritance;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class ResourceModel1ListResult
+    internal partial class ResourceModel1ListResult
     {
         /// <summary> Initializes a new instance of ResourceModel1ListResult. </summary>
         internal ResourceModel1ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel2ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel2ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class ResourceModel2ListResult
+    internal partial class ResourceModel2ListResult
     {
         internal static ResourceModel2ListResult DeserializeResourceModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel2ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/ResourceModel2ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class ResourceModel2ListResult
+    internal partial class ResourceModel2ListResult
     {
         /// <summary> Initializes a new instance of ResourceModel2ListResult. </summary>
         internal ResourceModel2ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel1ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel1ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class SubResourceModel1ListResult
+    internal partial class SubResourceModel1ListResult
     {
         internal static SubResourceModel1ListResult DeserializeSubResourceModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel1ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel1ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class SubResourceModel1ListResult
+    internal partial class SubResourceModel1ListResult
     {
         /// <summary> Initializes a new instance of SubResourceModel1ListResult. </summary>
         internal SubResourceModel1ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel2ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel2ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class SubResourceModel2ListResult
+    internal partial class SubResourceModel2ListResult
     {
         internal static SubResourceModel2ListResult DeserializeSubResourceModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel2ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/SubResourceModel2ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class SubResourceModel2ListResult
+    internal partial class SubResourceModel2ListResult
     {
         /// <summary> Initializes a new instance of SubResourceModel2ListResult. </summary>
         internal SubResourceModel2ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel1ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel1ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SupersetFlattenInheritance;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class TrackedResourceModel1ListResult
+    internal partial class TrackedResourceModel1ListResult
     {
         internal static TrackedResourceModel1ListResult DeserializeTrackedResourceModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel1ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel1ListResult.cs
@@ -12,7 +12,7 @@ using SupersetFlattenInheritance;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class TrackedResourceModel1ListResult
+    internal partial class TrackedResourceModel1ListResult
     {
         /// <summary> Initializes a new instance of TrackedResourceModel1ListResult. </summary>
         internal TrackedResourceModel1ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel2ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel2ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class TrackedResourceModel2ListResult
+    internal partial class TrackedResourceModel2ListResult
     {
         internal static TrackedResourceModel2ListResult DeserializeTrackedResourceModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel2ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/TrackedResourceModel2ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class TrackedResourceModel2ListResult
+    internal partial class TrackedResourceModel2ListResult
     {
         /// <summary> Initializes a new instance of TrackedResourceModel2ListResult. </summary>
         internal TrackedResourceModel2ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel1ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel1ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class WritableSubResourceModel1ListResult
+    internal partial class WritableSubResourceModel1ListResult
     {
         internal static WritableSubResourceModel1ListResult DeserializeWritableSubResourceModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel1ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel1ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class WritableSubResourceModel1ListResult
+    internal partial class WritableSubResourceModel1ListResult
     {
         /// <summary> Initializes a new instance of WritableSubResourceModel1ListResult. </summary>
         internal WritableSubResourceModel1ListResult()

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel2ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel2ListResult.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace SupersetFlattenInheritance.Models
 {
-    public partial class WritableSubResourceModel2ListResult
+    internal partial class WritableSubResourceModel2ListResult
     {
         internal static WritableSubResourceModel2ListResult DeserializeWritableSubResourceModel2ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel2ListResult.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/Models/WritableSubResourceModel2ListResult.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace SupersetFlattenInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class WritableSubResourceModel2ListResult
+    internal partial class WritableSubResourceModel2ListResult
     {
         /// <summary> Initializes a new instance of WritableSubResourceModel2ListResult. </summary>
         internal WritableSubResourceModel2ListResult()

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel1ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel1ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 
 namespace SupersetInheritance.Models
 {
-    public partial class SupersetModel1ListResult
+    internal partial class SupersetModel1ListResult
     {
         internal static SupersetModel1ListResult DeserializeSupersetModel1ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel1ListResult.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel1ListResult.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 namespace SupersetInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class SupersetModel1ListResult
+    internal partial class SupersetModel1ListResult
     {
         /// <summary> Initializes a new instance of SupersetModel1ListResult. </summary>
         internal SupersetModel1ListResult()

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel4ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel4ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 
 namespace SupersetInheritance.Models
 {
-    public partial class SupersetModel4ListResult
+    internal partial class SupersetModel4ListResult
     {
         internal static SupersetModel4ListResult DeserializeSupersetModel4ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel4ListResult.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel4ListResult.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 namespace SupersetInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class SupersetModel4ListResult
+    internal partial class SupersetModel4ListResult
     {
         /// <summary> Initializes a new instance of SupersetModel4ListResult. </summary>
         internal SupersetModel4ListResult()

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel5.Serialization.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel5.Serialization.cs
@@ -12,7 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace SupersetInheritance.Models
 {
-    public partial class SupersetModel5 : IUtf8JsonSerializable
+    internal partial class SupersetModel5 : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel5.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel5.cs
@@ -13,7 +13,7 @@ using SupersetInheritance;
 namespace SupersetInheritance.Models
 {
     /// <summary> This model should inherit from SupersetModel4. </summary>
-    public partial class SupersetModel5 : SupersetModel4Data
+    internal partial class SupersetModel5 : SupersetModel4Data
     {
         /// <summary> Initializes a new instance of SupersetModel5. </summary>
         /// <param name="location"> The location. </param>

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel6ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel6ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 
 namespace SupersetInheritance.Models
 {
-    public partial class SupersetModel6ListResult
+    internal partial class SupersetModel6ListResult
     {
         internal static SupersetModel6ListResult DeserializeSupersetModel6ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel6ListResult.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel6ListResult.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 namespace SupersetInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class SupersetModel6ListResult
+    internal partial class SupersetModel6ListResult
     {
         /// <summary> Initializes a new instance of SupersetModel6ListResult. </summary>
         internal SupersetModel6ListResult()

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel7ListResult.Serialization.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel7ListResult.Serialization.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 
 namespace SupersetInheritance.Models
 {
-    public partial class SupersetModel7ListResult
+    internal partial class SupersetModel7ListResult
     {
         internal static SupersetModel7ListResult DeserializeSupersetModel7ListResult(JsonElement element)
         {

--- a/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel7ListResult.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/Models/SupersetModel7ListResult.cs
@@ -12,7 +12,7 @@ using SupersetInheritance;
 namespace SupersetInheritance.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class SupersetModel7ListResult
+    internal partial class SupersetModel7ListResult
     {
         /// <summary> Initializes a new instance of SupersetModel7ListResult. </summary>
         internal SupersetModel7ListResult()

--- a/test/TestProjects/TenantOnly/Generated/Models/AgreementListResult.Serialization.cs
+++ b/test/TestProjects/TenantOnly/Generated/Models/AgreementListResult.Serialization.cs
@@ -12,7 +12,7 @@ using TenantOnly;
 
 namespace TenantOnly.Models
 {
-    public partial class AgreementListResult
+    internal partial class AgreementListResult
     {
         internal static AgreementListResult DeserializeAgreementListResult(JsonElement element)
         {

--- a/test/TestProjects/TenantOnly/Generated/Models/AgreementListResult.cs
+++ b/test/TestProjects/TenantOnly/Generated/Models/AgreementListResult.cs
@@ -12,7 +12,7 @@ using TenantOnly;
 namespace TenantOnly.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class AgreementListResult
+    internal partial class AgreementListResult
     {
         /// <summary> Initializes a new instance of AgreementListResult. </summary>
         internal AgreementListResult()

--- a/test/TestProjects/TenantOnly/Generated/Models/BillingAccountListResult.Serialization.cs
+++ b/test/TestProjects/TenantOnly/Generated/Models/BillingAccountListResult.Serialization.cs
@@ -12,7 +12,7 @@ using TenantOnly;
 
 namespace TenantOnly.Models
 {
-    public partial class BillingAccountListResult
+    internal partial class BillingAccountListResult
     {
         internal static BillingAccountListResult DeserializeBillingAccountListResult(JsonElement element)
         {

--- a/test/TestProjects/TenantOnly/Generated/Models/BillingAccountListResult.cs
+++ b/test/TestProjects/TenantOnly/Generated/Models/BillingAccountListResult.cs
@@ -12,7 +12,7 @@ using TenantOnly;
 namespace TenantOnly.Models
 {
     /// <summary> The response from the List Storage Accounts operation. </summary>
-    public partial class BillingAccountListResult
+    internal partial class BillingAccountListResult
     {
         /// <summary> Initializes a new instance of BillingAccountListResult. </summary>
         internal BillingAccountListResult()


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/1585

# Description

This PR shows a possible way to mark everything not used in the SDK's public methods `internal`.

First, this PR makes the `DefaultAccessibility` in `TypeProvider` no longer immutable - by overriding this property, you can change it and mark it dirty to let it take effect. As a side effect of this, since the `DefaultAccessibility` is no longer immutable, it has to be taken off from the `GetHashCode` of `TypeProvider`.

Everything is not changed if the target is not management plane, or it is `ArmCore`. 

If the target is management plane, in the output models, every model will be marked as `internal`, and before we writes anything, we will recursively add those are used in this SDK `public`. We first recursively go through all the models inside this generation, starting from those models that are referenced directly by the client operations (such as resources, resource collections, extensions), including the models used in parameters, responses, and the base class and their properties are added recursively.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first