### PR TITLE
[poll]: change the synchronous call to synchronous version in upstream

### DIFF
--- a/src/assets/Generator.Shared/OperationInternals.cs
+++ b/src/assets/Generator.Shared/OperationInternals.cs
@@ -33,9 +33,11 @@ namespace Azure.Core
 
         public Response GetRawResponse() => _operationInternal.RawResponse;
 
+#pragma warning disable AZC0106 // Non-public asynchronous method needs 'async' parameter.
         public Response WaitForCompletionResponse(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionResponseAsync(DefaultPollingInterval, cancellationToken).EnsureCompleted();
 
         public Response WaitForCompletionResponse(TimeSpan pollingInterval, CancellationToken cancellationToken) => _operationInternal.WaitForCompletionResponseAsync(pollingInterval, cancellationToken).EnsureCompleted();
+#pragma warning restore AZC0106 // Non-public asynchronous method needs 'async' parameter.
 
         public ValueTask<Response> WaitForCompletionResponseAsync(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionResponseAsync(DefaultPollingInterval, cancellationToken);
 

--- a/src/assets/Generator.Shared/OperationInternals.cs
+++ b/src/assets/Generator.Shared/OperationInternals.cs
@@ -33,11 +33,9 @@ namespace Azure.Core
 
         public Response GetRawResponse() => _operationInternal.RawResponse;
 
-#pragma warning disable AZC0106 // Non-public asynchronous method needs 'async' parameter.
-        public Response WaitForCompletionResponse(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionResponseAsync(DefaultPollingInterval, cancellationToken).EnsureCompleted();
+        public Response WaitForCompletionResponse(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionResponse(DefaultPollingInterval, cancellationToken);
 
-        public Response WaitForCompletionResponse(TimeSpan pollingInterval, CancellationToken cancellationToken) => _operationInternal.WaitForCompletionResponseAsync(pollingInterval, cancellationToken).EnsureCompleted();
-#pragma warning restore AZC0106 // Non-public asynchronous method needs 'async' parameter.
+        public Response WaitForCompletionResponse(TimeSpan pollingInterval, CancellationToken cancellationToken) => _operationInternal.WaitForCompletionResponse(pollingInterval, cancellationToken);
 
         public ValueTask<Response> WaitForCompletionResponseAsync(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionResponseAsync(DefaultPollingInterval, cancellationToken);
 

--- a/src/assets/Generator.Shared/OperationInternalsOfT.cs
+++ b/src/assets/Generator.Shared/OperationInternalsOfT.cs
@@ -43,9 +43,11 @@ namespace Azure.Core
             _operationInternal = new OperationInternal<T>(clientDiagnostics, this, originalResponse, scopeName, null, fallbackDelayStrategy);
         }
 
+#pragma warning disable AZC0106 // Non-public asynchronous method needs 'async' parameter.
         public Response<T> WaitForCompletion(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionAsync(cancellationToken).EnsureCompleted();
 
         public Response<T> WaitForCompletion(TimeSpan pollingInterval, CancellationToken cancellationToken) => _operationInternal.WaitForCompletionAsync(pollingInterval, cancellationToken).EnsureCompleted();
+#pragma warning restore AZC0106 // Non-public asynchronous method needs 'async' parameter.
 
         public ValueTask<Response<T>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionAsync(cancellationToken);
 

--- a/src/assets/Generator.Shared/OperationInternalsOfT.cs
+++ b/src/assets/Generator.Shared/OperationInternalsOfT.cs
@@ -43,11 +43,9 @@ namespace Azure.Core
             _operationInternal = new OperationInternal<T>(clientDiagnostics, this, originalResponse, scopeName, null, fallbackDelayStrategy);
         }
 
-#pragma warning disable AZC0106 // Non-public asynchronous method needs 'async' parameter.
-        public Response<T> WaitForCompletion(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionAsync(cancellationToken).EnsureCompleted();
+        public Response<T> WaitForCompletion(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletion(cancellationToken);
 
-        public Response<T> WaitForCompletion(TimeSpan pollingInterval, CancellationToken cancellationToken) => _operationInternal.WaitForCompletionAsync(pollingInterval, cancellationToken).EnsureCompleted();
-#pragma warning restore AZC0106 // Non-public asynchronous method needs 'async' parameter.
+        public Response<T> WaitForCompletion(TimeSpan pollingInterval, CancellationToken cancellationToken) => _operationInternal.WaitForCompletion(pollingInterval, cancellationToken);
 
         public ValueTask<Response<T>> WaitForCompletionAsync(CancellationToken cancellationToken = default) => _operationInternal.WaitForCompletionAsync(cancellationToken);
 


### PR DESCRIPTION
The error `AZC0106` won't appear in `autorest.csharp`, but it will pop up in `azure-skd-for-net`

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first