### PR TITLE
Add trailing slashes to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,21 @@
 *       @ShivangiReja @AlexanderSher
 
 # Data Plane Reviewers
-/samples/AppConfiguration                     @annelo-msft
-/samples/Azure.AI.*                           @annelo-msft
-/samples/Azure.Analytics.*                    @annelo-msft
-/samples/Azure.Storage.*                      @annelo-msft
-/samples/Cognitive*                           @annelo-msft
-/src/assets/Generator.Shared                  @annelo-msft
-/src/AutoRest.CSharp/DataPlane                @annelo-msft
-/src/AutoRest.CSharp/LowLevel                 @annelo-msft
-/test/AutoRest.TestServer.Tests               @annelo-msft
-/test/AutoRest.TestServerLowLevel.Tests       @annelo-msft
+/samples/AppConfiguration/                     @annelo-msft
+/samples/Azure.AI.*/                           @annelo-msft
+/samples/Azure.Analytics.*/                    @annelo-msft
+/samples/Azure.Storage.*/                      @annelo-msft
+/samples/Cognitive*/                           @annelo-msft
+/src/assets/Generator.Shared/                  @annelo-msft
+/src/AutoRest.CSharp/DataPlane/                @annelo-msft
+/src/AutoRest.CSharp/LowLevel/                 @annelo-msft
+/test/AutoRest.TestServer.Tests/               @annelo-msft
+/test/AutoRest.TestServerLowLevel.Tests/       @annelo-msft
 
 # Management CSharp CodeReviewers
-/samples/Azure.Management.Storage             @allenjzhang @m-nash
-/samples/Azure.Network.Management.Interface   @allenjzhang @m-nash
-/samples/Azure.ResourceManager.*              @allenjzhang @m-nash
-/src/AutoRest.CSharp/Mgmt                     @allenjzhang @m-nash
-/src/AutoRest.CSharp/Common                   @allenjzhang @m-nash
-/test/AutoRest.TestServer.Tests/Mgmt          @allenjzhang @m-nash
+/samples/Azure.Management.Storage/             @allenjzhang @m-nash
+/samples/Azure.Network.Management.Interface/   @allenjzhang @m-nash
+/samples/Azure.ResourceManager.*/              @allenjzhang @m-nash
+/src/AutoRest.CSharp/Mgmt/                     @allenjzhang @m-nash
+/src/AutoRest.CSharp/Common/                   @allenjzhang @m-nash
+/test/AutoRest.TestServer.Tests/Mgmt/          @allenjzhang @m-nash


### PR DESCRIPTION
There have been instances when CODEOWNERs haven't been added to PR reviews for relevant files.  @jsquire suggested perhaps helping CODEOWNERS succeed by formatting paths with a trailing slash.