### PR TITLE
Fixing csproj generation so that C# 9.0 and the new feed are used

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpProj.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpProj.cs
@@ -44,9 +44,9 @@ namespace AutoRest.CSharp.AutoRest.Plugins
 
         private string _csProjPackageReference = @"
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
-    <RestoreAdditionalProjectSources>https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

This fixes issue #1573 

When using the latest version of AutoRest and attempting to generate a client, the `.csproj` file that is generated has an old package feed that does not contain the correct version of `Microsoft.Azure.AutoRest.CSharp` that is intended. A `dotnet build` will fail unless the package feed is updated to the "new" one.

This finds the correct package, but then the build breaks again due to the latest version of that package relying on C# 9.0.

This PR fixes both these values which results in a successful build.

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first