### PR TITLE
Add ProcessMessage<T> and ProcessMessageAsync<T> methods to LowLevelOperationHelpers

### DIFF
--- a/test/TestProjects/TypeSchemaMapping/TypeSchemaMapping.csproj
+++ b/test/TestProjects/TypeSchemaMapping/TypeSchemaMapping.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.22.0-alpha.20211207.1" />
+    <PackageReference Include="Azure.Core" Version="1.23.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Also remove `EXPERIMENTAL` flag cause `WaitUntil` is released.