### PR TITLE
Pin to specific version of azure-sdk-tools repo

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -19,6 +19,7 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
+      ref: refs/tags/azure-sdk-tools_20220404.2
     - repository: azure-sdk-for-net
       type: github
       name: Azure/azure-sdk-for-net


### PR DESCRIPTION
Pin this pipeline to a tagged version of the azure-sdk-tools repo. I discovered this while working on another issue and realized we are always pulling the latest azure-sdk-tools which is something we need to avoid. 