### PR TITLE
Update some configurations - change the key from request path to operationId

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtConfiguration.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtConfiguration.cs
@@ -107,6 +107,7 @@ namespace AutoRest.CSharp.Input
             IReadOnlyList<string> keepOrphanedModels,
             IReadOnlyList<string> noResourceSuffix,
             MgmtDebugConfiguration mgmtDebug,
+            JsonElement? operationToParent = default,
             JsonElement? requestPathToParent = default,
             JsonElement? requestPathToResourceName = default,
             JsonElement? requestPathToResourceData = default,
@@ -124,6 +125,7 @@ namespace AutoRest.CSharp.Input
             TestModelerConfiguration? testmodeler = default,
             JsonElement? operationIdMappings = default)
         {
+            OperationToParent = !IsValidJsonElement(operationToParent) ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(operationToParent.ToString());
             RequestPathToParent = !IsValidJsonElement(requestPathToParent) ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(requestPathToParent.ToString());
             RequestPathToResourceName = !IsValidJsonElement(requestPathToResourceName) ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(requestPathToResourceName.ToString());
             RequestPathToResourceData = !IsValidJsonElement(requestPathToResourceData) ? new Dictionary<string, string>() : JsonSerializer.Deserialize<Dictionary<string, string>>(requestPathToResourceData.ToString());
@@ -182,6 +184,7 @@ namespace AutoRest.CSharp.Input
         /// Will we only see the resource name to be in the dictionary to make a resource singleton? Defaults to false
         /// </summary>
         public bool DoesSingletonRequiresKeyword { get; }
+        public IReadOnlyDictionary<string, string> OperationToParent { get; }
         public IReadOnlyDictionary<string, string> RequestPathToParent { get; }
         public IReadOnlyDictionary<string, string> RequestPathToResourceName { get; }
         public IReadOnlyDictionary<string, string> RequestPathToResourceData { get; }
@@ -216,6 +219,7 @@ namespace AutoRest.CSharp.Input
                 keepOrphanedModels: autoRest.GetValue<string[]?>("keep-orphaned-models").GetAwaiter().GetResult() ?? Array.Empty<string>(),
                 noResourceSuffix: autoRest.GetValue<string[]?>("no-resource-suffix").GetAwaiter().GetResult() ?? Array.Empty<string>(),
                 mgmtDebug: MgmtDebugConfiguration.GetConfiguration(autoRest),
+                operationToParent: autoRest.GetValue<JsonElement?>("operation-to-parent").GetAwaiter().GetResult(),
                 requestPathToParent: autoRest.GetValue<JsonElement?>("request-path-to-parent").GetAwaiter().GetResult(),
                 requestPathToResourceName: autoRest.GetValue<JsonElement?>("request-path-to-resource-name").GetAwaiter().GetResult(),
                 requestPathToResourceData: autoRest.GetValue<JsonElement?>("request-path-to-resource-data").GetAwaiter().GetResult(),
@@ -243,6 +247,7 @@ namespace AutoRest.CSharp.Input
             WriteNonEmptySettings(writer, nameof(KeepOrphanedModels), KeepOrphanedModels);
             WriteNonEmptySettings(writer, nameof(NoResourceSuffix), NoResourceSuffix);
             WriteNonEmptySettings(writer, nameof(OperationGroupsToOmit), OperationGroupsToOmit);
+            WriteNonEmptySettings(writer, nameof(OperationToParent), OperationToParent);
             WriteNonEmptySettings(writer, nameof(RequestPathToParent), RequestPathToParent);
             WriteNonEmptySettings(writer, nameof(OperationPositions), OperationPositions);
             WriteNonEmptySettings(writer, nameof(RequestPathToResourceName), RequestPathToResourceName);
@@ -277,6 +282,7 @@ namespace AutoRest.CSharp.Input
             root.TryGetProperty(nameof(ListException), out var listException);
             root.TryGetProperty(nameof(KeepOrphanedModels), out var keepOrphanedModels);
             root.TryGetProperty(nameof(NoResourceSuffix), out var noResourceSuffix);
+            root.TryGetProperty(nameof(OperationToParent), out var operationToParent);
             root.TryGetProperty(nameof(RequestPathToParent), out var requestPathToParent);
             root.TryGetProperty(nameof(RequestPathToResourceName), out var requestPathToResourceName);
             root.TryGetProperty(nameof(RequestPathToResourceData), out var requestPathToResourceData);
@@ -332,6 +338,7 @@ namespace AutoRest.CSharp.Input
                 keepOrphanedModels: keepOrphanedModelsList,
                 noResourceSuffix: noResourceSuffixList,
                 mgmtDebug: MgmtDebugConfiguration.LoadConfiguration(mgmtDebugRoot),
+                operationToParent: operationToParent,
                 requestPathToParent: requestPathToParent,
                 requestPathToResourceName: requestPathToResourceName,
                 requestPathToResourceData: requestPathToResourceData,

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -39,6 +39,11 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
         private CachedDictionary<string, OperationSet> RawRequestPathToOperationSets { get; }
 
         /// <summary>
+        /// This is a map from operation to its corresponding operation group
+        /// </summary>
+        private CachedDictionary<Operation, OperationGroup> OperationsToOperationGroups { get; }
+
+        /// <summary>
         /// This is a map from operation to its request path
         /// </summary>
         private CachedDictionary<Operation, RequestPath> OperationsToRequestPaths { get; }
@@ -88,6 +93,7 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
             MgmtContext.CodeModel.UpdateSubscriptionIdForAllResource();
             _operationGroupToRequestPaths = new Dictionary<OperationGroup, IEnumerable<string>>();
             RawRequestPathToOperationSets = new CachedDictionary<string, OperationSet>(CategorizeOperationGroups);
+            OperationsToOperationGroups = new CachedDictionary<Operation, OperationGroup>(PopulateOperationsToOperationGroups);
             OperationsToRequestPaths = new CachedDictionary<Operation, RequestPath>(PopulateOperationsToRequestPaths);
             ResourceDataSchemaNameToOperationSets = new CachedDictionary<string, HashSet<OperationSet>>(DecorateOperationSets);
             RawRequestPathToRestClient = new CachedDictionary<string, HashSet<MgmtRestClient>>(EnsureRestClients);
@@ -276,6 +282,8 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
 
         private IEnumerable<OperationSet>? _resourceOperationSets;
         public IEnumerable<OperationSet> ResourceOperationSets => _resourceOperationSets ??= ResourceDataSchemaNameToOperationSets.SelectMany(pair => pair.Value);
+
+        public OperationGroup GetOperationGroup(Operation operation) => OperationsToOperationGroups[operation];
 
         public OperationSet GetOperationSet(string requestPath) => RawRequestPathToOperationSets[requestPath];
 
@@ -856,6 +864,19 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
                 }
             }
             return operationsToRequestPath;
+        }
+
+        private Dictionary<Operation, OperationGroup> PopulateOperationsToOperationGroups()
+        {
+            var operationsToOperationGroups = new Dictionary<Operation, OperationGroup>();
+            foreach (var operationGroup in MgmtContext.CodeModel.OperationGroups)
+            {
+                foreach (var operation in operationGroup.Operations)
+                {
+                    operationsToOperationGroups[operation] = operationGroup;
+                }
+            }
+            return operationsToOperationGroups;
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
@@ -53,14 +53,16 @@ namespace AutoRest.CSharp.Mgmt.Decorator
         /// <returns></returns>
         public static bool TryGetConfigOperationName(this Operation operation, [MaybeNullWhen(false)] out string name)
         {
-            var operationId = operation.OperationId(MgmtContext.Library.GetRestClient(operation).OperationGroup);
+            var operationId = operation.OperationId();
             return Configuration.MgmtConfiguration.OverrideOperationName.TryGetValue(operationId, out name);
         }
 
-        public static string OperationId(this Operation operation, OperationGroup operationGroup)
+        public static string OperationId(this Operation operation)
         {
             if (_operationIdCache.TryGetValue(operation, out var result))
                 return result;
+
+            var operationGroup = MgmtContext.Library.GetOperationGroup(operation);
             result = operationGroup.Key.IsNullOrEmpty() ? operation.Language.Default.Name : $"{operationGroup.Key}_{operation.Language.Default.Name}";
             _operationIdCache.TryAdd(operation, result);
             return result;

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
@@ -122,8 +122,11 @@ namespace AutoRest.CSharp.Mgmt.Decorator
 
         private static RequestPath GetParentRequestPath(this Operation operation)
         {
+            // returns early if this operation has been set its own parent
+            if (Configuration.MgmtConfiguration.OperationToParent.TryGetValue(operation.OperationId(), out var rawPath))
+                return GetRequestPathFromRawPath(rawPath);
             // escape the calculation if this is configured in the configuration
-            if (Configuration.MgmtConfiguration.RequestPathToParent.TryGetValue(operation.GetHttpPath(), out var rawPath))
+            if (Configuration.MgmtConfiguration.RequestPathToParent.TryGetValue(operation.GetHttpPath(), out rawPath))
                 return GetRequestPathFromRawPath(rawPath);
 
             var currentRequestPath = operation.GetRequestPath();

--- a/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
@@ -34,11 +34,7 @@ namespace AutoRest.CSharp.Mgmt.Models
         /// The underlying <see cref="Operation"/> object.
         /// </summary>
         public Operation Operation => Method.Operation;
-        /// <summary>
-        /// We use the <see cref="OperationGroup"/> to get a fully quanlified name for this operation
-        /// </summary>
-        public OperationGroup OperationGroup => RestClient.OperationGroup;
-        public string OperationId => Operation.OperationId(OperationGroup);
+        public string OperationId => Operation.OperationId();
         /// <summary>
         /// The name of this operation
         /// </summary>

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -187,8 +187,8 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         protected virtual bool ShouldIncludeOperation(Operation operation)
         {
-            var requestPath = operation.GetHttpPath();
-            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(requestPath, out var positions))
+            var operationId = operation.OperationId();
+            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(operationId, out var positions))
             {
                 return positions.Contains(Position);
             }

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
@@ -172,8 +172,8 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         protected override bool ShouldIncludeOperation(Operation operation)
         {
-            var requestPath = operation.GetHttpPath();
-            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(requestPath, out var positions))
+            var operationId = operation.OperationId();
+            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(operationId, out var positions))
             {
                 return positions.Contains(Position);
             }

--- a/test/TestProjects/MgmtScopeResource/Generated/Configuration.json
+++ b/test/TestProjects/MgmtScopeResource/Generated/Configuration.json
@@ -10,18 +10,15 @@
   "public-clients": true,
   "head-as-boolean": true,
   "skip-csproj-packagereference": true,
-  "ListException": [
-    "/{linkId}"
-  ],
-  "RequestPathToParent": {
-    "/{scope}/providers/Microsoft.Resources/links": "/{linkId}",
-    "/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
-    "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
-    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}"
+  "OperationToParent": {
+    "ResourceLinks_ListAtSourceScope": "/{linkId}",
+    "Deployments_WhatIfAtTenantScope": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
+    "Deployments_WhatIfAtSubscriptionScope": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
+    "Deployments_WhatIfAtManagementGroupScope": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
+    "Deployments_WhatIf": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}"
   },
   "OperationPositions": {
-    "/{scope}/providers/Microsoft.Resources/links": [
+    "ResourceLinks_ListAtSourceScope": [
       "collection"
     ]
   },

--- a/test/TestProjects/MgmtScopeResource/Generated/Extensions/MgmtScopeResourceExtensions.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Extensions/MgmtScopeResourceExtensions.cs
@@ -71,14 +71,10 @@ namespace MgmtScopeResource
 
         /// <summary> Gets a collection of ResourceLinkResources in the TenantResource. </summary>
         /// <param name="tenantResource"> The <see cref="TenantResource" /> instance the method will execute against. </param>
-        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
         /// <returns> An object representing collection of ResourceLinkResources and their operations over a ResourceLinkResource. </returns>
-        public static ResourceLinkCollection GetResourceLinks(this TenantResource tenantResource, string scope)
+        public static ResourceLinkCollection GetResourceLinks(this TenantResource tenantResource)
         {
-            Argument.AssertNotNull(scope, nameof(scope));
-
-            return GetExtensionClient(tenantResource).GetResourceLinks(scope);
+            return GetExtensionClient(tenantResource).GetResourceLinks();
         }
 
         /// <summary>
@@ -87,13 +83,13 @@ namespace MgmtScopeResource
         /// Operation Id: ResourceLinks_Get
         /// </summary>
         /// <param name="tenantResource"> The <see cref="TenantResource" /> instance the method will execute against. </param>
-        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
+        /// <param name="linkId"> The fully qualified Id of the resource link. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
         [ForwardsClientCalls]
-        public static async Task<Response<ResourceLinkResource>> GetResourceLinkAsync(this TenantResource tenantResource, string scope, CancellationToken cancellationToken = default)
+        public static async Task<Response<ResourceLinkResource>> GetResourceLinkAsync(this TenantResource tenantResource, ResourceIdentifier linkId, CancellationToken cancellationToken = default)
         {
-            return await GetResourceLinks(tenantResource, scope).GetAsync(cancellationToken).ConfigureAwait(false);
+            return await tenantResource.GetResourceLinks().GetAsync(linkId, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -102,13 +98,13 @@ namespace MgmtScopeResource
         /// Operation Id: ResourceLinks_Get
         /// </summary>
         /// <param name="tenantResource"> The <see cref="TenantResource" /> instance the method will execute against. </param>
-        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
+        /// <param name="linkId"> The fully qualified Id of the resource link. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
         [ForwardsClientCalls]
-        public static Response<ResourceLinkResource> GetResourceLink(this TenantResource tenantResource, string scope, CancellationToken cancellationToken = default)
+        public static Response<ResourceLinkResource> GetResourceLink(this TenantResource tenantResource, ResourceIdentifier linkId, CancellationToken cancellationToken = default)
         {
-            return GetResourceLinks(tenantResource, scope).Get(cancellationToken);
+            return tenantResource.GetResourceLinks().Get(linkId, cancellationToken);
         }
 
         /// <summary>

--- a/test/TestProjects/MgmtScopeResource/Generated/Extensions/TenantResourceExtensionClient.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Extensions/TenantResourceExtensionClient.cs
@@ -51,11 +51,10 @@ namespace MgmtScopeResource
         }
 
         /// <summary> Gets a collection of ResourceLinkResources in the TenantResource. </summary>
-        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
         /// <returns> An object representing collection of ResourceLinkResources and their operations over a ResourceLinkResource. </returns>
-        public virtual ResourceLinkCollection GetResourceLinks(string scope)
+        public virtual ResourceLinkCollection GetResourceLinks()
         {
-            return new ResourceLinkCollection(Client, Id, scope);
+            return GetCachedClient(Client => new ResourceLinkCollection(Client, Id));
         }
 
         /// <summary>
@@ -67,8 +66,8 @@ namespace MgmtScopeResource
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response<TemplateHashResult>> CalculateTemplateHashDeploymentAsync(BinaryData template, CancellationToken cancellationToken = default)
         {
-            using var scope0 = DeploymentExtendedDeploymentsClientDiagnostics.CreateScope("TenantResourceExtensionClient.CalculateTemplateHashDeployment");
-            scope0.Start();
+            using var scope = DeploymentExtendedDeploymentsClientDiagnostics.CreateScope("TenantResourceExtensionClient.CalculateTemplateHashDeployment");
+            scope.Start();
             try
             {
                 var response = await DeploymentExtendedDeploymentsRestClient.CalculateTemplateHashAsync(template, cancellationToken).ConfigureAwait(false);
@@ -76,7 +75,7 @@ namespace MgmtScopeResource
             }
             catch (Exception e)
             {
-                scope0.Failed(e);
+                scope.Failed(e);
                 throw;
             }
         }
@@ -90,8 +89,8 @@ namespace MgmtScopeResource
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response<TemplateHashResult> CalculateTemplateHashDeployment(BinaryData template, CancellationToken cancellationToken = default)
         {
-            using var scope0 = DeploymentExtendedDeploymentsClientDiagnostics.CreateScope("TenantResourceExtensionClient.CalculateTemplateHashDeployment");
-            scope0.Start();
+            using var scope = DeploymentExtendedDeploymentsClientDiagnostics.CreateScope("TenantResourceExtensionClient.CalculateTemplateHashDeployment");
+            scope.Start();
             try
             {
                 var response = DeploymentExtendedDeploymentsRestClient.CalculateTemplateHash(template, cancellationToken);
@@ -99,7 +98,7 @@ namespace MgmtScopeResource
             }
             catch (Exception e)
             {
-                scope0.Failed(e);
+                scope.Failed(e);
                 throw;
             }
         }

--- a/test/TestProjects/MgmtScopeResource/Generated/ResourceLinkCollection.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/ResourceLinkCollection.cs
@@ -27,7 +27,6 @@ namespace MgmtScopeResource
     {
         private readonly ClientDiagnostics _resourceLinkClientDiagnostics;
         private readonly ResourceLinksRestOperations _resourceLinkRestClient;
-        private readonly string _scope;
 
         /// <summary> Initializes a new instance of the <see cref="ResourceLinkCollection"/> class for mocking. </summary>
         protected ResourceLinkCollection()
@@ -37,11 +36,8 @@ namespace MgmtScopeResource
         /// <summary> Initializes a new instance of the <see cref="ResourceLinkCollection"/> class. </summary>
         /// <param name="client"> The client parameters to use in these operations. </param>
         /// <param name="id"> The identifier of the parent resource that is the target of operations. </param>
-        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
-        internal ResourceLinkCollection(ArmClient client, ResourceIdentifier id, string scope) : base(client, id)
+        internal ResourceLinkCollection(ArmClient client, ResourceIdentifier id) : base(client, id)
         {
-            _scope = scope;
             _resourceLinkClientDiagnostics = new ClientDiagnostics("MgmtScopeResource", ResourceLinkResource.ResourceType.Namespace, Diagnostics);
             TryGetApiVersion(ResourceLinkResource.ResourceType, out string resourceLinkApiVersion);
             _resourceLinkRestClient = new ResourceLinksRestOperations(Pipeline, Diagnostics.ApplicationId, Endpoint, resourceLinkApiVersion);
@@ -62,18 +58,20 @@ namespace MgmtScopeResource
         /// Operation Id: ResourceLinks_CreateOrUpdate
         /// </summary>
         /// <param name="waitUntil"> "F:Azure.WaitUntil.Completed" if the method should wait to return until the long-running operation has completed on the service; "F:Azure.WaitUntil.Started" if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
+        /// <param name="linkId"> The fully qualified ID of the resource link. Use the format, /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="data"> Parameters for creating or updating a resource link. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="data"/> is null. </exception>
-        public virtual async Task<ArmOperation<ResourceLinkResource>> CreateOrUpdateAsync(WaitUntil waitUntil, ResourceLinkData data, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> or <paramref name="data"/> is null. </exception>
+        public virtual async Task<ArmOperation<ResourceLinkResource>> CreateOrUpdateAsync(WaitUntil waitUntil, ResourceIdentifier linkId, ResourceLinkData data, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(linkId, nameof(linkId));
             Argument.AssertNotNull(data, nameof(data));
 
-            using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.CreateOrUpdate");
-            scope0.Start();
+            using var scope = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.CreateOrUpdate");
+            scope.Start();
             try
             {
-                var response = await _resourceLinkRestClient.CreateOrUpdateAsync(_scope, data, cancellationToken).ConfigureAwait(false);
+                var response = await _resourceLinkRestClient.CreateOrUpdateAsync(linkId, data, cancellationToken).ConfigureAwait(false);
                 var operation = new MgmtScopeResourceArmOperation<ResourceLinkResource>(Response.FromValue(new ResourceLinkResource(Client, response), response.GetRawResponse()));
                 if (waitUntil == WaitUntil.Completed)
                     await operation.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
@@ -81,7 +79,7 @@ namespace MgmtScopeResource
             }
             catch (Exception e)
             {
-                scope0.Failed(e);
+                scope.Failed(e);
                 throw;
             }
         }
@@ -92,18 +90,20 @@ namespace MgmtScopeResource
         /// Operation Id: ResourceLinks_CreateOrUpdate
         /// </summary>
         /// <param name="waitUntil"> "F:Azure.WaitUntil.Completed" if the method should wait to return until the long-running operation has completed on the service; "F:Azure.WaitUntil.Started" if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
+        /// <param name="linkId"> The fully qualified ID of the resource link. Use the format, /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="data"> Parameters for creating or updating a resource link. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="data"/> is null. </exception>
-        public virtual ArmOperation<ResourceLinkResource> CreateOrUpdate(WaitUntil waitUntil, ResourceLinkData data, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> or <paramref name="data"/> is null. </exception>
+        public virtual ArmOperation<ResourceLinkResource> CreateOrUpdate(WaitUntil waitUntil, ResourceIdentifier linkId, ResourceLinkData data, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(linkId, nameof(linkId));
             Argument.AssertNotNull(data, nameof(data));
 
-            using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.CreateOrUpdate");
-            scope0.Start();
+            using var scope = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.CreateOrUpdate");
+            scope.Start();
             try
             {
-                var response = _resourceLinkRestClient.CreateOrUpdate(_scope, data, cancellationToken);
+                var response = _resourceLinkRestClient.CreateOrUpdate(linkId, data, cancellationToken);
                 var operation = new MgmtScopeResourceArmOperation<ResourceLinkResource>(Response.FromValue(new ResourceLinkResource(Client, response), response.GetRawResponse()));
                 if (waitUntil == WaitUntil.Completed)
                     operation.WaitForCompletion(cancellationToken);
@@ -111,7 +111,7 @@ namespace MgmtScopeResource
             }
             catch (Exception e)
             {
-                scope0.Failed(e);
+                scope.Failed(e);
                 throw;
             }
         }
@@ -121,21 +121,25 @@ namespace MgmtScopeResource
         /// Request Path: /{linkId}
         /// Operation Id: ResourceLinks_Get
         /// </summary>
+        /// <param name="linkId"> The fully qualified Id of the resource link. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response<ResourceLinkResource>> GetAsync(CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
+        public virtual async Task<Response<ResourceLinkResource>> GetAsync(ResourceIdentifier linkId, CancellationToken cancellationToken = default)
         {
-            using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.Get");
-            scope0.Start();
+            Argument.AssertNotNull(linkId, nameof(linkId));
+
+            using var scope = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.Get");
+            scope.Start();
             try
             {
-                var response = await _resourceLinkRestClient.GetAsync(_scope, cancellationToken).ConfigureAwait(false);
+                var response = await _resourceLinkRestClient.GetAsync(linkId, cancellationToken).ConfigureAwait(false);
                 if (response.Value == null)
                     throw new RequestFailedException(response.GetRawResponse());
                 return Response.FromValue(new ResourceLinkResource(Client, response.Value), response.GetRawResponse());
             }
             catch (Exception e)
             {
-                scope0.Failed(e);
+                scope.Failed(e);
                 throw;
             }
         }
@@ -145,21 +149,25 @@ namespace MgmtScopeResource
         /// Request Path: /{linkId}
         /// Operation Id: ResourceLinks_Get
         /// </summary>
+        /// <param name="linkId"> The fully qualified Id of the resource link. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<ResourceLinkResource> Get(CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
+        public virtual Response<ResourceLinkResource> Get(ResourceIdentifier linkId, CancellationToken cancellationToken = default)
         {
-            using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.Get");
-            scope0.Start();
+            Argument.AssertNotNull(linkId, nameof(linkId));
+
+            using var scope = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.Get");
+            scope.Start();
             try
             {
-                var response = _resourceLinkRestClient.Get(_scope, cancellationToken);
+                var response = _resourceLinkRestClient.Get(linkId, cancellationToken);
                 if (response.Value == null)
                     throw new RequestFailedException(response.GetRawResponse());
                 return Response.FromValue(new ResourceLinkResource(Client, response.Value), response.GetRawResponse());
             }
             catch (Exception e)
             {
-                scope0.Failed(e);
+                scope.Failed(e);
                 throw;
             }
         }
@@ -169,17 +177,21 @@ namespace MgmtScopeResource
         /// Request Path: /{scope}/providers/Microsoft.Resources/links
         /// Operation Id: ResourceLinks_ListAtSourceScope
         /// </summary>
+        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
         /// <returns> An async collection of <see cref="ResourceLinkResource" /> that may take multiple service requests to iterate over. </returns>
-        public virtual AsyncPageable<ResourceLinkResource> GetAllAsync(CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<ResourceLinkResource> GetAllAsync(string scope, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(scope, nameof(scope));
+
             async Task<Page<ResourceLinkResource>> FirstPageFunc(int? pageSizeHint)
             {
                 using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.GetAll");
                 scope0.Start();
                 try
                 {
-                    var response = await _resourceLinkRestClient.ListAtSourceScopeAsync(_scope, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var response = await _resourceLinkRestClient.ListAtSourceScopeAsync(scope, cancellationToken: cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value.Select(value => new ResourceLinkResource(Client, value)), response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)
@@ -194,7 +206,7 @@ namespace MgmtScopeResource
                 scope0.Start();
                 try
                 {
-                    var response = await _resourceLinkRestClient.ListAtSourceScopeNextPageAsync(nextLink, _scope, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var response = await _resourceLinkRestClient.ListAtSourceScopeNextPageAsync(nextLink, scope, cancellationToken: cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value.Select(value => new ResourceLinkResource(Client, value)), response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)
@@ -211,17 +223,21 @@ namespace MgmtScopeResource
         /// Request Path: /{scope}/providers/Microsoft.Resources/links
         /// Operation Id: ResourceLinks_ListAtSourceScope
         /// </summary>
+        /// <param name="scope"> The fully qualified ID of the scope for getting the resource links. For example, to list resource links at and under a resource group, set the scope to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="scope"/> is null. </exception>
         /// <returns> A collection of <see cref="ResourceLinkResource" /> that may take multiple service requests to iterate over. </returns>
-        public virtual Pageable<ResourceLinkResource> GetAll(CancellationToken cancellationToken = default)
+        public virtual Pageable<ResourceLinkResource> GetAll(string scope, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(scope, nameof(scope));
+
             Page<ResourceLinkResource> FirstPageFunc(int? pageSizeHint)
             {
                 using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.GetAll");
                 scope0.Start();
                 try
                 {
-                    var response = _resourceLinkRestClient.ListAtSourceScope(_scope, cancellationToken: cancellationToken);
+                    var response = _resourceLinkRestClient.ListAtSourceScope(scope, cancellationToken: cancellationToken);
                     return Page.FromValues(response.Value.Value.Select(value => new ResourceLinkResource(Client, value)), response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)
@@ -236,7 +252,7 @@ namespace MgmtScopeResource
                 scope0.Start();
                 try
                 {
-                    var response = _resourceLinkRestClient.ListAtSourceScopeNextPage(nextLink, _scope, cancellationToken: cancellationToken);
+                    var response = _resourceLinkRestClient.ListAtSourceScopeNextPage(nextLink, scope, cancellationToken: cancellationToken);
                     return Page.FromValues(response.Value.Value.Select(value => new ResourceLinkResource(Client, value)), response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)
@@ -253,14 +269,18 @@ namespace MgmtScopeResource
         /// Request Path: /{linkId}
         /// Operation Id: ResourceLinks_Get
         /// </summary>
+        /// <param name="linkId"> The fully qualified Id of the resource link. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response<bool>> ExistsAsync(CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
+        public virtual async Task<Response<bool>> ExistsAsync(ResourceIdentifier linkId, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(linkId, nameof(linkId));
+
             using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.Exists");
             scope0.Start();
             try
             {
-                var response = await _resourceLinkRestClient.GetAsync(_scope, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var response = await _resourceLinkRestClient.GetAsync(linkId, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(response.Value != null, response.GetRawResponse());
             }
             catch (Exception e)
@@ -275,14 +295,18 @@ namespace MgmtScopeResource
         /// Request Path: /{linkId}
         /// Operation Id: ResourceLinks_Get
         /// </summary>
+        /// <param name="linkId"> The fully qualified Id of the resource link. For example, /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<bool> Exists(CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"> <paramref name="linkId"/> is null. </exception>
+        public virtual Response<bool> Exists(ResourceIdentifier linkId, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(linkId, nameof(linkId));
+
             using var scope0 = _resourceLinkClientDiagnostics.CreateScope("ResourceLinkCollection.Exists");
             scope0.Start();
             try
             {
-                var response = _resourceLinkRestClient.Get(_scope, cancellationToken: cancellationToken);
+                var response = _resourceLinkRestClient.Get(linkId, cancellationToken: cancellationToken);
                 return Response.FromValue(response.Value != null, response.GetRawResponse());
             }
             catch (Exception e)

--- a/test/TestProjects/MgmtScopeResource/readme.md
+++ b/test/TestProjects/MgmtScopeResource/readme.md
@@ -14,18 +14,16 @@ input-file:
   - $(this-folder)/Links.json
 namespace: MgmtScopeResource
 
-list-exception:
-  - /{linkId}
 request-path-to-resource-data:
   # model of this has id, type and name, but its type has the type of `object` instead of `string`
   /{linkId}: ResourceLink
-request-path-to-parent:
-  /{scope}/providers/Microsoft.Resources/links: /{linkId}
+operation-to-parent:
+  ResourceLinks_ListAtSourceScope: /{linkId}
   # setting these to the same parent will automatically merge these operations
-  /providers/Microsoft.Resources/deployments/{deploymentName}/whatIf: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
-  /subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
-  /providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
-  /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
+  Deployments_WhatIfAtTenantScope: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
+  Deployments_WhatIfAtSubscriptionScope: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
+  Deployments_WhatIfAtManagementGroupScope: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
+  Deployments_WhatIf: /{scope}/providers/Microsoft.Resources/deployments/{deploymentName}
 request-path-to-resource-type:
   /{linkId}: Microsoft.Resources/links
 request-path-to-scope-resource-types:
@@ -42,7 +40,7 @@ request-path-to-scope-resource-types:
 override-operation-name:
   ResourceLinks_ListAtSourceScope: GetAll
 operation-positions:
-  /{scope}/providers/Microsoft.Resources/links: collection
+  ResourceLinks_ListAtSourceScope: collection
 directive:
   # PolicyDefinition resource has the corresponding method written using `scope`, therefore the "ById" methods are no longer required. Remove those
   - remove-operation: FakePolicyAssignments_DeleteById


### PR DESCRIPTION
# Description

Some of our configurations only applies to operations, but is using request paths as their keys. This PR changes the request path to operationId

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first