### PR TITLE
Change the key of `operation-positions` configuration from request path to operation id

### DIFF
--- a/samples/Azure.Management.Storage/Generated/Configuration.json
+++ b/samples/Azure.Management.Storage/Generated/Configuration.json
@@ -15,10 +15,10 @@
     "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}"
   },
   "OperationPositions": {
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/deletedAccounts": [
+    "DeletedAccounts_List": [
       "collection"
     ],
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability": [
+    "StorageAccounts_CheckNameAvailability": [
       "collection"
     ]
   },

--- a/samples/Azure.Management.Storage/readme.md
+++ b/samples/Azure.Management.Storage/readme.md
@@ -25,8 +25,8 @@ request-path-to-parent:
   /subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}
 
 operation-positions:
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/deletedAccounts: collection
-  /subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability: collection
+  DeletedAccounts_List: collection
+  StorageAccounts_CheckNameAvailability: collection
 
 override-operation-name:
   DeletedAccounts_List: GetAll

--- a/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
@@ -53,14 +53,16 @@ namespace AutoRest.CSharp.Mgmt.Decorator
         /// <returns></returns>
         public static bool TryGetConfigOperationName(this Operation operation, [MaybeNullWhen(false)] out string name)
         {
-            var operationId = operation.OperationId(MgmtContext.Library.GetRestClient(operation).OperationGroup);
+            var operationId = operation.OperationId();
             return Configuration.MgmtConfiguration.OverrideOperationName.TryGetValue(operationId, out name);
         }
 
-        public static string OperationId(this Operation operation, OperationGroup operationGroup)
+        public static string OperationId(this Operation operation)
         {
             if (_operationIdCache.TryGetValue(operation, out var result))
                 return result;
+
+            var operationGroup = MgmtContext.Library.GetOperationGroup(operation);
             result = operationGroup.Key.IsNullOrEmpty() ? operation.Language.Default.Name : $"{operationGroup.Key}_{operation.Language.Default.Name}";
             _operationIdCache.TryAdd(operation, result);
             return result;

--- a/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
@@ -34,11 +34,8 @@ namespace AutoRest.CSharp.Mgmt.Models
         /// The underlying <see cref="Operation"/> object.
         /// </summary>
         public Operation Operation => Method.Operation;
-        /// <summary>
-        /// We use the <see cref="OperationGroup"/> to get a fully quanlified name for this operation
-        /// </summary>
-        public OperationGroup OperationGroup => RestClient.OperationGroup;
-        public string OperationId => Operation.OperationId(OperationGroup);
+
+        public string OperationId => Operation.OperationId();
         /// <summary>
         /// The name of this operation
         /// </summary>

--- a/src/AutoRest.CSharp/Mgmt/Models/OperationSet.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/OperationSet.cs
@@ -20,8 +20,6 @@ namespace AutoRest.CSharp.Mgmt.Models
     /// </summary>
     internal class OperationSet : IReadOnlyCollection<Operation>, IEquatable<OperationSet>
     {
-        private IDictionary<Operation, OperationGroup> _operationGroupCache = new Dictionary<Operation, OperationGroup>();
-
         /// <summary>
         /// The raw request path of string of the operations in this <see cref="OperationSet"/>
         /// </summary>
@@ -44,15 +42,13 @@ namespace AutoRest.CSharp.Mgmt.Models
         /// Add a new operation to this <see cref="OperationSet"/>
         /// </summary>
         /// <param name="operation">The operation to be added</param>
-        /// <param name="operationGroup">The operationGroup this operation belongs</param>
         /// <exception cref="InvalidOperationException">when trying to add an operation with a different path from <see cref="RequestPath"/></exception>
-        public void Add(Operation operation, OperationGroup operationGroup)
+        public void Add(Operation operation)
         {
             var path = operation.GetHttpPath();
             if (path != RequestPath)
                 throw new InvalidOperationException($"Cannot add operation with path {path} to OperationSet with path {RequestPath}");
             Operations.Add(operation);
-            _operationGroupCache.TryAdd(operation, operationGroup);
         }
 
         /// <summary>
@@ -62,16 +58,7 @@ namespace AutoRest.CSharp.Mgmt.Models
         public void Remove(Operation operation)
         {
             Operations.Remove(operation);
-            _operationGroupCache.Remove(operation);
         }
-
-        /// <summary>
-        /// Get the corresponding <see cref="OperationGroup"/> for the given <see cref="Operation"/>
-        /// </summary>
-        /// <param name="operation"></param>
-        /// <returns></returns>
-        /// <exception cref="KeyNotFoundException">the given operation was not found in this <see cref="OperationSet"/></exception>
-        internal OperationGroup this[Operation operation] => _operationGroupCache[operation];
 
         public IEnumerator<Operation> GetEnumerator() => Operations.GetEnumerator();
 
@@ -117,7 +104,7 @@ namespace AutoRest.CSharp.Mgmt.Models
         private RequestPath GetNonHintRequestPath()
         {
             var operation = FindBestOperation();
-            return Models.RequestPath.FromOperation(operation, this[operation]);
+            return Models.RequestPath.FromOperation(operation, MgmtContext.Library.GetOperationGroup(operation));
         }
 
         private Operation FindBestOperation()

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -187,8 +187,8 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         protected virtual bool ShouldIncludeOperation(Operation operation)
         {
-            var requestPath = operation.GetHttpPath();
-            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(requestPath, out var positions))
+            var operationId = operation.OperationId();
+            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(operationId, out var positions))
             {
                 return positions.Contains(Position);
             }

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
@@ -172,8 +172,8 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         protected override bool ShouldIncludeOperation(Operation operation)
         {
-            var requestPath = operation.GetHttpPath();
-            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(requestPath, out var positions))
+            var operationId = operation.OperationId();
+            if (Configuration.MgmtConfiguration.OperationPositions.TryGetValue(operationId, out var positions))
             {
                 return positions.Contains(Position);
             }

--- a/test/TestProjects/MgmtCollectionParent/Generated/Configuration.json
+++ b/test/TestProjects/MgmtCollectionParent/Generated/Configuration.json
@@ -13,7 +13,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orders": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/locations/{location}/orders/{orderName}"
   },
   "OperationPositions": {
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orders": [
+    "ListOrderAtResourceGroupLevel": [
       "collection"
     ]
   },

--- a/test/TestProjects/MgmtCollectionParent/readme.md
+++ b/test/TestProjects/MgmtCollectionParent/readme.md
@@ -16,7 +16,7 @@ modelerfour:
   lenient-model-deduplication: true
 
 operation-positions:
-  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orders: collection
+  ListOrderAtResourceGroupLevel: collection
 
 request-path-to-parent:
   /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orders: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/locations/{location}/orders/{orderName}

--- a/test/TestProjects/MgmtScopeResource/Generated/Configuration.json
+++ b/test/TestProjects/MgmtScopeResource/Generated/Configuration.json
@@ -21,7 +21,7 @@
     "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf": "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}"
   },
   "OperationPositions": {
-    "/{scope}/providers/Microsoft.Resources/links": [
+    "ResourceLinks_ListAtSourceScope": [
       "collection"
     ]
   },

--- a/test/TestProjects/MgmtScopeResource/readme.md
+++ b/test/TestProjects/MgmtScopeResource/readme.md
@@ -42,7 +42,7 @@ request-path-to-scope-resource-types:
 override-operation-name:
   ResourceLinks_ListAtSourceScope: GetAll
 operation-positions:
-  /{scope}/providers/Microsoft.Resources/links: collection
+  ResourceLinks_ListAtSourceScope: collection
 directive:
   # PolicyDefinition resource has the corresponding method written using `scope`, therefore the "ById" methods are no longer required. Remove those
   - remove-operation: FakePolicyAssignments_DeleteById


### PR DESCRIPTION
# Description

Previously the key of configuration `operation-positions` is the request path of the operation. But multiple operations could have the same request path, this PR changes the key to operation id to uniquely identify one specific operation to change.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first