### PR TITLE
Remove dependency on OperationOrResponseInternals

### DIFF
--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperation.cs
@@ -19,7 +19,7 @@ namespace Azure.Management.Storage
     internal class StorageArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of StorageArmOperation for mocking. </summary>
         protected StorageArmOperation()
@@ -28,22 +28,25 @@ namespace Azure.Management.Storage
 
         internal StorageArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal StorageArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "StorageArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "StorageArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperationOfT.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace Azure.Management.Storage
     internal class StorageArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of StorageArmOperation for mocking. </summary>
         protected StorageArmOperation()
@@ -28,16 +28,19 @@ namespace Azure.Management.Storage
 
         internal StorageArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal StorageArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "StorageArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "StorageArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace Azure.Management.Storage
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperation.cs
@@ -19,7 +19,7 @@ namespace Azure.ResourceManager.Sample
     internal class SampleArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of SampleArmOperation for mocking. </summary>
         protected SampleArmOperation()
@@ -28,22 +28,25 @@ namespace Azure.ResourceManager.Sample
 
         internal SampleArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal SampleArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "SampleArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "SampleArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperationOfT.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace Azure.ResourceManager.Sample
     internal class SampleArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of SampleArmOperation for mocking. </summary>
         protected SampleArmOperation()
@@ -28,16 +28,19 @@ namespace Azure.ResourceManager.Sample
 
         internal SampleArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal SampleArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "SampleArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "SampleArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace Azure.ResourceManager.Sample
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/LongRunningOperation/ExactMatchFlattenInheritanceArmOperation.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/LongRunningOperation/ExactMatchFlattenInheritanceArmOperation.cs
@@ -19,7 +19,7 @@ namespace ExactMatchFlattenInheritance
     internal class ExactMatchFlattenInheritanceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of ExactMatchFlattenInheritanceArmOperation for mocking. </summary>
         protected ExactMatchFlattenInheritanceArmOperation()
@@ -28,22 +28,25 @@ namespace ExactMatchFlattenInheritance
 
         internal ExactMatchFlattenInheritanceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal ExactMatchFlattenInheritanceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "ExactMatchFlattenInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "ExactMatchFlattenInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/LongRunningOperation/ExactMatchFlattenInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/LongRunningOperation/ExactMatchFlattenInheritanceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace ExactMatchFlattenInheritance
     internal class ExactMatchFlattenInheritanceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of ExactMatchFlattenInheritanceArmOperation for mocking. </summary>
         protected ExactMatchFlattenInheritanceArmOperation()
@@ -28,16 +28,19 @@ namespace ExactMatchFlattenInheritance
 
         internal ExactMatchFlattenInheritanceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal ExactMatchFlattenInheritanceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "ExactMatchFlattenInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "ExactMatchFlattenInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace ExactMatchFlattenInheritance
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ExactMatchInheritance/Generated/LongRunningOperation/ExactMatchInheritanceArmOperation.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/LongRunningOperation/ExactMatchInheritanceArmOperation.cs
@@ -19,7 +19,7 @@ namespace ExactMatchInheritance
     internal class ExactMatchInheritanceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of ExactMatchInheritanceArmOperation for mocking. </summary>
         protected ExactMatchInheritanceArmOperation()
@@ -28,22 +28,25 @@ namespace ExactMatchInheritance
 
         internal ExactMatchInheritanceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal ExactMatchInheritanceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "ExactMatchInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "ExactMatchInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ExactMatchInheritance/Generated/LongRunningOperation/ExactMatchInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/LongRunningOperation/ExactMatchInheritanceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace ExactMatchInheritance
     internal class ExactMatchInheritanceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of ExactMatchInheritanceArmOperation for mocking. </summary>
         protected ExactMatchInheritanceArmOperation()
@@ -28,16 +28,19 @@ namespace ExactMatchInheritance
 
         internal ExactMatchInheritanceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal ExactMatchInheritanceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "ExactMatchInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "ExactMatchInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace ExactMatchInheritance
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtCollectionParent/Generated/LongRunningOperation/MgmtCollectionParentArmOperation.cs
+++ b/test/TestProjects/MgmtCollectionParent/Generated/LongRunningOperation/MgmtCollectionParentArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtCollectionParent
     internal class MgmtCollectionParentArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtCollectionParentArmOperation for mocking. </summary>
         protected MgmtCollectionParentArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtCollectionParent
 
         internal MgmtCollectionParentArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtCollectionParentArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtCollectionParentArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtCollectionParentArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtCollectionParent/Generated/LongRunningOperation/MgmtCollectionParentArmOperationOfT.cs
+++ b/test/TestProjects/MgmtCollectionParent/Generated/LongRunningOperation/MgmtCollectionParentArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtCollectionParent
     internal class MgmtCollectionParentArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtCollectionParentArmOperation for mocking. </summary>
         protected MgmtCollectionParentArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtCollectionParent
 
         internal MgmtCollectionParentArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtCollectionParentArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtCollectionParentArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtCollectionParentArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtCollectionParent
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperation.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtDiscriminator
     internal class MgmtDiscriminatorArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtDiscriminatorArmOperation for mocking. </summary>
         protected MgmtDiscriminatorArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtDiscriminator
 
         internal MgmtDiscriminatorArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtDiscriminatorArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtDiscriminatorArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtDiscriminatorArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperationOfT.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtDiscriminator
     internal class MgmtDiscriminatorArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtDiscriminatorArmOperation for mocking. </summary>
         protected MgmtDiscriminatorArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtDiscriminator
 
         internal MgmtDiscriminatorArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtDiscriminatorArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtDiscriminatorArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtDiscriminatorArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtDiscriminator
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperation.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtExpandResourceTypes
     internal class MgmtExpandResourceTypesArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtExpandResourceTypesArmOperation for mocking. </summary>
         protected MgmtExpandResourceTypesArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtExpandResourceTypes
 
         internal MgmtExpandResourceTypesArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtExpandResourceTypesArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtExpandResourceTypesArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtExpandResourceTypesArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperationOfT.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtExpandResourceTypes
     internal class MgmtExpandResourceTypesArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtExpandResourceTypesArmOperation for mocking. </summary>
         protected MgmtExpandResourceTypesArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtExpandResourceTypes
 
         internal MgmtExpandResourceTypesArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtExpandResourceTypesArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtExpandResourceTypesArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtExpandResourceTypesArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtExpandResourceTypes
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/LongRunningOperation/MgmtExtensionCommonRestOperationArmOperation.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/LongRunningOperation/MgmtExtensionCommonRestOperationArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtExtensionCommonRestOperation
     internal class MgmtExtensionCommonRestOperationArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtExtensionCommonRestOperationArmOperation for mocking. </summary>
         protected MgmtExtensionCommonRestOperationArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtExtensionCommonRestOperation
 
         internal MgmtExtensionCommonRestOperationArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtExtensionCommonRestOperationArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtExtensionCommonRestOperationArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtExtensionCommonRestOperationArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/LongRunningOperation/MgmtExtensionCommonRestOperationArmOperationOfT.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/LongRunningOperation/MgmtExtensionCommonRestOperationArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtExtensionCommonRestOperation
     internal class MgmtExtensionCommonRestOperationArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtExtensionCommonRestOperationArmOperation for mocking. </summary>
         protected MgmtExtensionCommonRestOperationArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtExtensionCommonRestOperation
 
         internal MgmtExtensionCommonRestOperationArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtExtensionCommonRestOperationArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtExtensionCommonRestOperationArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtExtensionCommonRestOperationArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtExtensionCommonRestOperation
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperation.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtExtensionResource
     internal class MgmtExtensionResourceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtExtensionResourceArmOperation for mocking. </summary>
         protected MgmtExtensionResourceArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtExtensionResource
 
         internal MgmtExtensionResourceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtExtensionResourceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtExtensionResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtExtensionResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtExtensionResource
     internal class MgmtExtensionResourceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtExtensionResourceArmOperation for mocking. </summary>
         protected MgmtExtensionResourceArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtExtensionResource
 
         internal MgmtExtensionResourceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtExtensionResourceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtExtensionResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtExtensionResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtExtensionResource
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/LongRunningOperation/MgmtHierarchicalNonResourceArmOperation.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/LongRunningOperation/MgmtHierarchicalNonResourceArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtHierarchicalNonResource
     internal class MgmtHierarchicalNonResourceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtHierarchicalNonResourceArmOperation for mocking. </summary>
         protected MgmtHierarchicalNonResourceArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtHierarchicalNonResource
 
         internal MgmtHierarchicalNonResourceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtHierarchicalNonResourceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtHierarchicalNonResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtHierarchicalNonResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/LongRunningOperation/MgmtHierarchicalNonResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/LongRunningOperation/MgmtHierarchicalNonResourceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtHierarchicalNonResource
     internal class MgmtHierarchicalNonResourceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtHierarchicalNonResourceArmOperation for mocking. </summary>
         protected MgmtHierarchicalNonResourceArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtHierarchicalNonResource
 
         internal MgmtHierarchicalNonResourceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtHierarchicalNonResourceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtHierarchicalNonResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtHierarchicalNonResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtHierarchicalNonResource
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/MgmtKeyvaultArmOperation.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/MgmtKeyvaultArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtKeyvault
     internal class MgmtKeyvaultArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtKeyvaultArmOperation for mocking. </summary>
         protected MgmtKeyvaultArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtKeyvault
 
         internal MgmtKeyvaultArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtKeyvaultArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtKeyvaultArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtKeyvaultArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/MgmtKeyvaultArmOperationOfT.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/LongRunningOperation/MgmtKeyvaultArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtKeyvault
     internal class MgmtKeyvaultArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtKeyvaultArmOperation for mocking. </summary>
         protected MgmtKeyvaultArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtKeyvault
 
         internal MgmtKeyvaultArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtKeyvaultArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtKeyvaultArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtKeyvaultArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtKeyvault
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperation.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtLRO
     internal class MgmtLROArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtLROArmOperation for mocking. </summary>
         protected MgmtLROArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtLRO
 
         internal MgmtLROArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtLROArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtLROArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtLROArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperationOfT.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtLRO
     internal class MgmtLROArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtLROArmOperation for mocking. </summary>
         protected MgmtLROArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtLRO
 
         internal MgmtLROArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtLROArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtLROArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtLROArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtLRO
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/MgmtListMethodsArmOperation.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/MgmtListMethodsArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtListMethods
     internal class MgmtListMethodsArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtListMethodsArmOperation for mocking. </summary>
         protected MgmtListMethodsArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtListMethods
 
         internal MgmtListMethodsArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtListMethodsArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtListMethodsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtListMethodsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/MgmtListMethodsArmOperationOfT.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/MgmtListMethodsArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtListMethods
     internal class MgmtListMethodsArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtListMethodsArmOperation for mocking. </summary>
         protected MgmtListMethodsArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtListMethods
 
         internal MgmtListMethodsArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtListMethodsArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtListMethodsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtListMethodsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtListMethods
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperation.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtMultipleParentResource
     internal class MgmtMultipleParentResourceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtMultipleParentResourceArmOperation for mocking. </summary>
         protected MgmtMultipleParentResourceArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtMultipleParentResource
 
         internal MgmtMultipleParentResourceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtMultipleParentResourceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtMultipleParentResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtMultipleParentResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtMultipleParentResource
     internal class MgmtMultipleParentResourceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtMultipleParentResourceArmOperation for mocking. </summary>
         protected MgmtMultipleParentResourceArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtMultipleParentResource
 
         internal MgmtMultipleParentResourceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtMultipleParentResourceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtMultipleParentResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtMultipleParentResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtMultipleParentResource
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperation.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtNonStringPathVariable
     internal class MgmtNonStringPathVariableArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtNonStringPathVariableArmOperation for mocking. </summary>
         protected MgmtNonStringPathVariableArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtNonStringPathVariable
 
         internal MgmtNonStringPathVariableArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtNonStringPathVariableArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtNonStringPathVariableArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtNonStringPathVariableArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperationOfT.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtNonStringPathVariable
     internal class MgmtNonStringPathVariableArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtNonStringPathVariableArmOperation for mocking. </summary>
         protected MgmtNonStringPathVariableArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtNonStringPathVariable
 
         internal MgmtNonStringPathVariableArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtNonStringPathVariableArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtNonStringPathVariableArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtNonStringPathVariableArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtNonStringPathVariable
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperation.cs
+++ b/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtOperations
     internal class MgmtOperationsArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtOperationsArmOperation for mocking. </summary>
         protected MgmtOperationsArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtOperations
 
         internal MgmtOperationsArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtOperationsArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtOperationsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtOperationsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperationOfT.cs
+++ b/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtOperations
     internal class MgmtOperationsArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtOperationsArmOperation for mocking. </summary>
         protected MgmtOperationsArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtOperations
 
         internal MgmtOperationsArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtOperationsArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtOperationsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtOperationsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtOperations
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperation.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtParamOrdering
     internal class MgmtParamOrderingArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtParamOrderingArmOperation for mocking. </summary>
         protected MgmtParamOrderingArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtParamOrdering
 
         internal MgmtParamOrderingArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtParamOrderingArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtParamOrderingArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtParamOrderingArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperationOfT.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtParamOrdering
     internal class MgmtParamOrderingArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtParamOrderingArmOperation for mocking. </summary>
         protected MgmtParamOrderingArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtParamOrdering
 
         internal MgmtParamOrderingArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtParamOrderingArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtParamOrderingArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtParamOrderingArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtParamOrdering
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperation.cs
+++ b/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtParent
     internal class MgmtParentArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtParentArmOperation for mocking. </summary>
         protected MgmtParentArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtParent
 
         internal MgmtParentArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtParentArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtParentArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtParentArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperationOfT.cs
+++ b/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtParent
     internal class MgmtParentArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtParentArmOperation for mocking. </summary>
         protected MgmtParentArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtParent
 
         internal MgmtParentArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtParentArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtParentArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtParentArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtParent
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperation.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtPropertyChooser
     internal class MgmtPropertyChooserArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtPropertyChooserArmOperation for mocking. </summary>
         protected MgmtPropertyChooserArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtPropertyChooser
 
         internal MgmtPropertyChooserArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtPropertyChooserArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtPropertyChooserArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtPropertyChooserArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperationOfT.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtPropertyChooser
     internal class MgmtPropertyChooserArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtPropertyChooserArmOperation for mocking. </summary>
         protected MgmtPropertyChooserArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtPropertyChooser
 
         internal MgmtPropertyChooserArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtPropertyChooserArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtPropertyChooserArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtPropertyChooserArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtPropertyChooser
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperation.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtRenameRules
     internal class MgmtRenameRulesArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtRenameRulesArmOperation for mocking. </summary>
         protected MgmtRenameRulesArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtRenameRules
 
         internal MgmtRenameRulesArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtRenameRulesArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtRenameRulesArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtRenameRulesArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperationOfT.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtRenameRules
     internal class MgmtRenameRulesArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtRenameRulesArmOperation for mocking. </summary>
         protected MgmtRenameRulesArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtRenameRules
 
         internal MgmtRenameRulesArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtRenameRulesArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtRenameRulesArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtRenameRulesArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtRenameRules
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtResourceName/Generated/LongRunningOperation/MgmtResourceNameArmOperation.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/LongRunningOperation/MgmtResourceNameArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtResourceName
     internal class MgmtResourceNameArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtResourceNameArmOperation for mocking. </summary>
         protected MgmtResourceNameArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtResourceName
 
         internal MgmtResourceNameArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtResourceNameArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtResourceNameArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtResourceNameArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtResourceName/Generated/LongRunningOperation/MgmtResourceNameArmOperationOfT.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/LongRunningOperation/MgmtResourceNameArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtResourceName
     internal class MgmtResourceNameArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtResourceNameArmOperation for mocking. </summary>
         protected MgmtResourceNameArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtResourceName
 
         internal MgmtResourceNameArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtResourceNameArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtResourceNameArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtResourceNameArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtResourceName
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtSafeFlatten/Generated/LongRunningOperation/MgmtSafeFlattenArmOperation.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/LongRunningOperation/MgmtSafeFlattenArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtSafeFlatten
     internal class MgmtSafeFlattenArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtSafeFlattenArmOperation for mocking. </summary>
         protected MgmtSafeFlattenArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtSafeFlatten
 
         internal MgmtSafeFlattenArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtSafeFlattenArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtSafeFlattenArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtSafeFlattenArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtSafeFlatten/Generated/LongRunningOperation/MgmtSafeFlattenArmOperationOfT.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/LongRunningOperation/MgmtSafeFlattenArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtSafeFlatten
     internal class MgmtSafeFlattenArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtSafeFlattenArmOperation for mocking. </summary>
         protected MgmtSafeFlattenArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtSafeFlatten
 
         internal MgmtSafeFlattenArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtSafeFlattenArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtSafeFlattenArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtSafeFlattenArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtSafeFlatten
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperation.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtScopeResource
     internal class MgmtScopeResourceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtScopeResourceArmOperation for mocking. </summary>
         protected MgmtScopeResourceArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtScopeResource
 
         internal MgmtScopeResourceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtScopeResourceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtScopeResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtScopeResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtScopeResource
     internal class MgmtScopeResourceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtScopeResourceArmOperation for mocking. </summary>
         protected MgmtScopeResourceArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtScopeResource
 
         internal MgmtScopeResourceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtScopeResourceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtScopeResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtScopeResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtScopeResource
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperation.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperation.cs
@@ -19,7 +19,7 @@ namespace MgmtSubscriptionNameParameter
     internal class MgmtSubscriptionNameParameterArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of MgmtSubscriptionNameParameterArmOperation for mocking. </summary>
         protected MgmtSubscriptionNameParameterArmOperation()
@@ -28,22 +28,25 @@ namespace MgmtSubscriptionNameParameter
 
         internal MgmtSubscriptionNameParameterArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal MgmtSubscriptionNameParameterArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtSubscriptionNameParameterArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "MgmtSubscriptionNameParameterArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperationOfT.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace MgmtSubscriptionNameParameter
     internal class MgmtSubscriptionNameParameterArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of MgmtSubscriptionNameParameterArmOperation for mocking. </summary>
         protected MgmtSubscriptionNameParameterArmOperation()
@@ -28,16 +28,19 @@ namespace MgmtSubscriptionNameParameter
 
         internal MgmtSubscriptionNameParameterArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal MgmtSubscriptionNameParameterArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "MgmtSubscriptionNameParameterArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "MgmtSubscriptionNameParameterArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace MgmtSubscriptionNameParameter
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/NoTypeReplacement/Generated/LongRunningOperation/NoTypeReplacementArmOperation.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/LongRunningOperation/NoTypeReplacementArmOperation.cs
@@ -19,7 +19,7 @@ namespace NoTypeReplacement
     internal class NoTypeReplacementArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of NoTypeReplacementArmOperation for mocking. </summary>
         protected NoTypeReplacementArmOperation()
@@ -28,22 +28,25 @@ namespace NoTypeReplacement
 
         internal NoTypeReplacementArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal NoTypeReplacementArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "NoTypeReplacementArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "NoTypeReplacementArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/NoTypeReplacement/Generated/LongRunningOperation/NoTypeReplacementArmOperationOfT.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/LongRunningOperation/NoTypeReplacementArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace NoTypeReplacement
     internal class NoTypeReplacementArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of NoTypeReplacementArmOperation for mocking. </summary>
         protected NoTypeReplacementArmOperation()
@@ -28,16 +28,19 @@ namespace NoTypeReplacement
 
         internal NoTypeReplacementArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal NoTypeReplacementArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "NoTypeReplacementArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "NoTypeReplacementArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace NoTypeReplacement
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/OmitOperationGroups/Generated/LongRunningOperation/OmitOperationGroupsArmOperation.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/LongRunningOperation/OmitOperationGroupsArmOperation.cs
@@ -19,7 +19,7 @@ namespace OmitOperationGroups
     internal class OmitOperationGroupsArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of OmitOperationGroupsArmOperation for mocking. </summary>
         protected OmitOperationGroupsArmOperation()
@@ -28,22 +28,25 @@ namespace OmitOperationGroups
 
         internal OmitOperationGroupsArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal OmitOperationGroupsArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "OmitOperationGroupsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "OmitOperationGroupsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/OmitOperationGroups/Generated/LongRunningOperation/OmitOperationGroupsArmOperationOfT.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/LongRunningOperation/OmitOperationGroupsArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace OmitOperationGroups
     internal class OmitOperationGroupsArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of OmitOperationGroupsArmOperation for mocking. </summary>
         protected OmitOperationGroupsArmOperation()
@@ -28,16 +28,19 @@ namespace OmitOperationGroups
 
         internal OmitOperationGroupsArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal OmitOperationGroupsArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "OmitOperationGroupsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "OmitOperationGroupsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace OmitOperationGroups
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/Pagination/Generated/LongRunningOperation/PaginationArmOperation.cs
+++ b/test/TestProjects/Pagination/Generated/LongRunningOperation/PaginationArmOperation.cs
@@ -19,7 +19,7 @@ namespace Pagination
     internal class PaginationArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of PaginationArmOperation for mocking. </summary>
         protected PaginationArmOperation()
@@ -28,22 +28,25 @@ namespace Pagination
 
         internal PaginationArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal PaginationArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "PaginationArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "PaginationArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/Pagination/Generated/LongRunningOperation/PaginationArmOperationOfT.cs
+++ b/test/TestProjects/Pagination/Generated/LongRunningOperation/PaginationArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace Pagination
     internal class PaginationArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of PaginationArmOperation for mocking. </summary>
         protected PaginationArmOperation()
@@ -28,16 +28,19 @@ namespace Pagination
 
         internal PaginationArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal PaginationArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "PaginationArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "PaginationArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace Pagination
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ReferenceTypes/Generated/LongRunningOperation/ReferenceTypesArmOperation.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/LongRunningOperation/ReferenceTypesArmOperation.cs
@@ -19,7 +19,7 @@ namespace ReferenceTypes
     internal class ReferenceTypesArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of ReferenceTypesArmOperation for mocking. </summary>
         protected ReferenceTypesArmOperation()
@@ -28,22 +28,25 @@ namespace ReferenceTypes
 
         internal ReferenceTypesArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal ReferenceTypesArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "ReferenceTypesArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "ReferenceTypesArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ReferenceTypes/Generated/LongRunningOperation/ReferenceTypesArmOperationOfT.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/LongRunningOperation/ReferenceTypesArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace ReferenceTypes
     internal class ReferenceTypesArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of ReferenceTypesArmOperation for mocking. </summary>
         protected ReferenceTypesArmOperation()
@@ -28,16 +28,19 @@ namespace ReferenceTypes
 
         internal ReferenceTypesArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal ReferenceTypesArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "ReferenceTypesArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "ReferenceTypesArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace ReferenceTypes
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperation.cs
+++ b/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperation.cs
@@ -19,7 +19,7 @@ namespace ResourceRename
     internal class ResourceRenameArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of ResourceRenameArmOperation for mocking. </summary>
         protected ResourceRenameArmOperation()
@@ -28,22 +28,25 @@ namespace ResourceRename
 
         internal ResourceRenameArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal ResourceRenameArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "ResourceRenameArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "ResourceRenameArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperationOfT.cs
+++ b/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace ResourceRename
     internal class ResourceRenameArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of ResourceRenameArmOperation for mocking. </summary>
         protected ResourceRenameArmOperation()
@@ -28,16 +28,19 @@ namespace ResourceRename
 
         internal ResourceRenameArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal ResourceRenameArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "ResourceRenameArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "ResourceRenameArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace ResourceRename
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SingletonResource/Generated/LongRunningOperation/SingletonResourceArmOperation.cs
+++ b/test/TestProjects/SingletonResource/Generated/LongRunningOperation/SingletonResourceArmOperation.cs
@@ -19,7 +19,7 @@ namespace SingletonResource
     internal class SingletonResourceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of SingletonResourceArmOperation for mocking. </summary>
         protected SingletonResourceArmOperation()
@@ -28,22 +28,25 @@ namespace SingletonResource
 
         internal SingletonResourceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal SingletonResourceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "SingletonResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "SingletonResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SingletonResource/Generated/LongRunningOperation/SingletonResourceArmOperationOfT.cs
+++ b/test/TestProjects/SingletonResource/Generated/LongRunningOperation/SingletonResourceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace SingletonResource
     internal class SingletonResourceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of SingletonResourceArmOperation for mocking. </summary>
         protected SingletonResourceArmOperation()
@@ -28,16 +28,19 @@ namespace SingletonResource
 
         internal SingletonResourceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal SingletonResourceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "SingletonResourceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "SingletonResourceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace SingletonResource
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/SubscriptionExtensionsArmOperation.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/SubscriptionExtensionsArmOperation.cs
@@ -19,7 +19,7 @@ namespace SubscriptionExtensions
     internal class SubscriptionExtensionsArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of SubscriptionExtensionsArmOperation for mocking. </summary>
         protected SubscriptionExtensionsArmOperation()
@@ -28,22 +28,25 @@ namespace SubscriptionExtensions
 
         internal SubscriptionExtensionsArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal SubscriptionExtensionsArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "SubscriptionExtensionsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "SubscriptionExtensionsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/SubscriptionExtensionsArmOperationOfT.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/SubscriptionExtensionsArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace SubscriptionExtensions
     internal class SubscriptionExtensionsArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of SubscriptionExtensionsArmOperation for mocking. </summary>
         protected SubscriptionExtensionsArmOperation()
@@ -28,16 +28,19 @@ namespace SubscriptionExtensions
 
         internal SubscriptionExtensionsArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal SubscriptionExtensionsArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "SubscriptionExtensionsArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "SubscriptionExtensionsArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace SubscriptionExtensions
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/LongRunningOperation/SupersetFlattenInheritanceArmOperation.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/LongRunningOperation/SupersetFlattenInheritanceArmOperation.cs
@@ -19,7 +19,7 @@ namespace SupersetFlattenInheritance
     internal class SupersetFlattenInheritanceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of SupersetFlattenInheritanceArmOperation for mocking. </summary>
         protected SupersetFlattenInheritanceArmOperation()
@@ -28,22 +28,25 @@ namespace SupersetFlattenInheritance
 
         internal SupersetFlattenInheritanceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal SupersetFlattenInheritanceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "SupersetFlattenInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "SupersetFlattenInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/LongRunningOperation/SupersetFlattenInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/LongRunningOperation/SupersetFlattenInheritanceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace SupersetFlattenInheritance
     internal class SupersetFlattenInheritanceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of SupersetFlattenInheritanceArmOperation for mocking. </summary>
         protected SupersetFlattenInheritanceArmOperation()
@@ -28,16 +28,19 @@ namespace SupersetFlattenInheritance
 
         internal SupersetFlattenInheritanceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal SupersetFlattenInheritanceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "SupersetFlattenInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "SupersetFlattenInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace SupersetFlattenInheritance
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SupersetInheritance/Generated/LongRunningOperation/SupersetInheritanceArmOperation.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/LongRunningOperation/SupersetInheritanceArmOperation.cs
@@ -19,7 +19,7 @@ namespace SupersetInheritance
     internal class SupersetInheritanceArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of SupersetInheritanceArmOperation for mocking. </summary>
         protected SupersetInheritanceArmOperation()
@@ -28,22 +28,25 @@ namespace SupersetInheritance
 
         internal SupersetInheritanceArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal SupersetInheritanceArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "SupersetInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "SupersetInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/SupersetInheritance/Generated/LongRunningOperation/SupersetInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/LongRunningOperation/SupersetInheritanceArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace SupersetInheritance
     internal class SupersetInheritanceArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of SupersetInheritanceArmOperation for mocking. </summary>
         protected SupersetInheritanceArmOperation()
@@ -28,16 +28,19 @@ namespace SupersetInheritance
 
         internal SupersetInheritanceArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal SupersetInheritanceArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "SupersetInheritanceArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "SupersetInheritanceArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace SupersetInheritance
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/TenantOnly/Generated/LongRunningOperation/TenantOnlyArmOperation.cs
+++ b/test/TestProjects/TenantOnly/Generated/LongRunningOperation/TenantOnlyArmOperation.cs
@@ -19,7 +19,7 @@ namespace TenantOnly
     internal class TenantOnlyArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of TenantOnlyArmOperation for mocking. </summary>
         protected TenantOnlyArmOperation()
@@ -28,22 +28,25 @@ namespace TenantOnly
 
         internal TenantOnlyArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal TenantOnlyArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "TenantOnlyArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "TenantOnlyArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/TenantOnly/Generated/LongRunningOperation/TenantOnlyArmOperationOfT.cs
+++ b/test/TestProjects/TenantOnly/Generated/LongRunningOperation/TenantOnlyArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace TenantOnly
     internal class TenantOnlyArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of TenantOnlyArmOperation for mocking. </summary>
         protected TenantOnlyArmOperation()
@@ -28,16 +28,19 @@ namespace TenantOnly
 
         internal TenantOnlyArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal TenantOnlyArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "TenantOnlyArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "TenantOnlyArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace TenantOnly
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperation.cs
+++ b/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperation.cs
@@ -19,7 +19,7 @@ namespace XmlDeserialization
     internal class XmlDeserializationArmOperation : ArmOperation
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of XmlDeserializationArmOperation for mocking. </summary>
         protected XmlDeserializationArmOperation()
@@ -28,22 +28,25 @@ namespace XmlDeserialization
 
         internal XmlDeserializationArmOperation(Response response)
         {
-            _operation = new OperationOrResponseInternals(response);
+            _operation = OperationInternal.Succeeded(response);
         }
 
         internal XmlDeserializationArmOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, finalStateVia, "XmlDeserializationArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "XmlDeserializationArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperationOfT.cs
+++ b/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperationOfT.cs
@@ -19,7 +19,7 @@ namespace XmlDeserialization
     internal class XmlDeserializationArmOperation<T> : ArmOperation<T>
 #pragma warning restore SA1649 // File name should match first type name
     {
-        private readonly OperationOrResponseInternals<T> _operation;
+        private readonly OperationInternal<T> _operation;
 
         /// <summary> Initializes a new instance of XmlDeserializationArmOperation for mocking. </summary>
         protected XmlDeserializationArmOperation()
@@ -28,16 +28,19 @@ namespace XmlDeserialization
 
         internal XmlDeserializationArmOperation(Response<T> response)
         {
-            _operation = new OperationOrResponseInternals<T>(response);
+            _operation = OperationInternal<T>.Succeeded(response.GetRawResponse(), response.Value);
         }
 
         internal XmlDeserializationArmOperation(IOperationSource<T> source, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, OperationFinalStateVia finalStateVia)
         {
-            _operation = new OperationOrResponseInternals<T>(source, clientDiagnostics, pipeline, request, response, finalStateVia, "XmlDeserializationArmOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(source, pipeline, request.Method, request.Uri.ToUri(), response, finalStateVia);
+            _operation = new OperationInternal<T>(clientDiagnostics, nextLinkOperation, response, "XmlDeserializationArmOperation", fallbackStrategy: new ExponentialDelayStrategy());
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override T Value => _operation.Value;
@@ -49,7 +52,7 @@ namespace XmlDeserialization
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);


### PR DESCRIPTION
With the updated `OperationInternal` and `OperationInternalOfT`, we can get rid of `OperationOrResponseInternals` and `OperationOrResponseInternals<T>`. That minimizes amount of duplicated code and helps minimize amount of service calls when `WaitForCompletionAsync` is called concurrently by multiple callers