### PR TITLE
No multiple API versions in one operation group (RestOperations client)

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -109,6 +109,7 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
             _mergedOperations = Configuration.MgmtConfiguration.MergeOperations
                 .SelectMany(kv => kv.Value.Select(v => (FullOperationName: v, MethodName: kv.Key)))
                 .ToDictionary(kv => kv.FullOperationName, kv => kv.MethodName);
+            MgmtContext.CodeModel.VerifyApiVersions();
             MgmtContext.CodeModel.UpdateAcronyms();
             _allSchemas = MgmtContext.CodeModel.AllSchemas;
             UrlToUri.UpdateSuffix(_allSchemas);


### PR DESCRIPTION
RestOperations classes are generated based on operation groups, currently RestOperations only supports sharing one API version for all its operations. This PR adds a check to avoid multiple API versions in one operation group.

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first