### PR TITLE
Change exception thrown for LowLevelFuncOperation.Id

### DIFF
--- a/src/assets/Generator.Shared/LowLevelFuncOperation.cs
+++ b/src/assets/Generator.Shared/LowLevelFuncOperation.cs
@@ -24,9 +24,10 @@ namespace Azure.Core
         }
 
 #pragma warning disable CA1822
-        //TODO: This is currently unused.
+        // This scenario is currently unsupported.
+        // See: https://github.com/Azure/autorest.csharp/issues/2158.
         /// <inheritdoc />
-        public override string Id => throw new NotImplementedException();
+        public override string Id => throw new NotSupportedException();
 #pragma warning restore CA1822
 
         /// <inheritdoc />


### PR DESCRIPTION
DPG libraries return `LowLevelFuncOperation` for `Operation<T>`.  Operation rehydration is not currently supported (see https://github.com/Azure/azure-sdk-for-net/issues/28562, https://github.com/Azure/autorest.csharp/issues/2158) and will not be for the first GA release of DPG.  Changing the type of the exception thrown to make it clear that this scenario is not supported and not just that someone forgot to implement the Id property.