### PR TITLE
feat(mgmt): add global autorest directive to shorten name `privateLinkServiceConnectionState`

### DIFF
--- a/samples/Azure.Analytics.Purview.Account/Generated/CodeModel.yaml
+++ b/samples/Azure.Analytics.Purview.Account/Generated/CodeModel.yaml
@@ -1919,7 +1919,7 @@ schemas: !Schemas
                               serializedName: privateLinkServiceConnectionState
                               language: !Languages 
                                 default:
-                                  name: privateLinkServiceConnectionState
+                                  name: connectionState
                                   description: The private link service connection state.
                               protocol: !Protocols {}
                             - !Property 

--- a/samples/Azure.Management.Storage/Generated/CodeModel.yaml
+++ b/samples/Azure.Management.Storage/Generated/CodeModel.yaml
@@ -6877,7 +6877,7 @@ schemas: !Schemas
                               serializedName: privateLinkServiceConnectionState
                               language: !Languages 
                                 default:
-                                  name: privateLinkServiceConnectionState
+                                  name: connectionState
                                   description: A collection of information about the state of the connection between service consumer and provider.
                               protocol: !Protocols {}
                             - !Property 

--- a/samples/Azure.Management.Storage/Generated/Models/StoragePrivateEndpointConnectionData.Serialization.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/StoragePrivateEndpointConnectionData.Serialization.cs
@@ -25,10 +25,10 @@ namespace Azure.Management.Storage
                 writer.WritePropertyName("privateEndpoint");
                 JsonSerializer.Serialize(writer, PrivateEndpoint);
             }
-            if (Optional.IsDefined(PrivateLinkServiceConnectionState))
+            if (Optional.IsDefined(ConnectionState))
             {
                 writer.WritePropertyName("privateLinkServiceConnectionState");
-                writer.WriteObjectValue(PrivateLinkServiceConnectionState);
+                writer.WriteObjectValue(ConnectionState);
             }
             writer.WriteEndObject();
             writer.WriteEndObject();

--- a/samples/Azure.Management.Storage/Generated/StoragePrivateEndpointConnectionData.cs
+++ b/samples/Azure.Management.Storage/Generated/StoragePrivateEndpointConnectionData.cs
@@ -26,12 +26,12 @@ namespace Azure.Management.Storage
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
         /// <param name="privateEndpoint"> The resource of private end point. </param>
-        /// <param name="privateLinkServiceConnectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
+        /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
         /// <param name="provisioningState"> The provisioning state of the private endpoint connection resource. </param>
-        internal StoragePrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, SubResource privateEndpoint, StoragePrivateLinkServiceConnectionState privateLinkServiceConnectionState, StoragePrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
+        internal StoragePrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, SubResource privateEndpoint, StoragePrivateLinkServiceConnectionState connectionState, StoragePrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             PrivateEndpoint = privateEndpoint;
-            PrivateLinkServiceConnectionState = privateLinkServiceConnectionState;
+            ConnectionState = connectionState;
             ProvisioningState = provisioningState;
         }
 
@@ -44,7 +44,7 @@ namespace Azure.Management.Storage
         }
 
         /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
-        public StoragePrivateLinkServiceConnectionState PrivateLinkServiceConnectionState { get; set; }
+        public StoragePrivateLinkServiceConnectionState ConnectionState { get; set; }
         /// <summary> The provisioning state of the private endpoint connection resource. </summary>
         public StoragePrivateEndpointConnectionProvisioningState? ProvisioningState { get; }
     }

--- a/src/AutoRest.CSharp/readme.md
+++ b/src/AutoRest.CSharp/readme.md
@@ -58,6 +58,16 @@ testmodeler:
   add-armtemplate-payload-string: true
 ```
 
+## Customization
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.PrivateEndpointConnectionProperties
+    transform: >
+      $.properties.privateLinkServiceConnectionState["x-ms-client-name"] = "connectionState";   
+```
+
 ## Help
 ```yaml
 help-content:

--- a/test/TestProjects/MgmtKeyvault/src/Generated/CodeModel.yaml
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/CodeModel.yaml
@@ -2848,7 +2848,7 @@ schemas: !Schemas
                         serializedName: privateLinkServiceConnectionState
                         language: !Languages 
                           default:
-                            name: privateLinkServiceConnectionState
+                            name: connectionState
                             description: Approval state of the private link connection.
                         protocol: !Protocols {}
                       - !Property 
@@ -3867,7 +3867,7 @@ schemas: !Schemas
           serializedName: privateLinkServiceConnectionState
           language: !Languages 
             default:
-              name: privateLinkServiceConnectionState
+              name: connectionState
               description: Approval state of the private link connection.
           protocol: !Protocols {}
         - !Property 

--- a/test/TestProjects/MgmtKeyvault/src/Generated/MgmtKeyvaultPrivateEndpointConnectionData.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/MgmtKeyvaultPrivateEndpointConnectionData.cs
@@ -30,13 +30,13 @@ namespace MgmtKeyvault
         /// <param name="tags"> Tags assigned to the key vault resource. </param>
         /// <param name="etag"> Modified whenever there is a change in the state of private endpoint connection. </param>
         /// <param name="privateEndpoint"> Properties of the private endpoint object. </param>
-        /// <param name="privateLinkServiceConnectionState"> Approval state of the private link connection. </param>
+        /// <param name="connectionState"> Approval state of the private link connection. </param>
         /// <param name="provisioningState"> Provisioning state of the private endpoint connection. </param>
-        internal MgmtKeyvaultPrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string location, IReadOnlyDictionary<string, string> tags, string etag, SubResource privateEndpoint, MgmtKeyvaultPrivateLinkServiceConnectionState privateLinkServiceConnectionState, MgmtKeyvaultPrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData, location, tags)
+        internal MgmtKeyvaultPrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string location, IReadOnlyDictionary<string, string> tags, string etag, SubResource privateEndpoint, MgmtKeyvaultPrivateLinkServiceConnectionState connectionState, MgmtKeyvaultPrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData, location, tags)
         {
             Etag = etag;
             PrivateEndpoint = privateEndpoint;
-            PrivateLinkServiceConnectionState = privateLinkServiceConnectionState;
+            ConnectionState = connectionState;
             ProvisioningState = provisioningState;
         }
 
@@ -51,7 +51,7 @@ namespace MgmtKeyvault
         }
 
         /// <summary> Approval state of the private link connection. </summary>
-        public MgmtKeyvaultPrivateLinkServiceConnectionState PrivateLinkServiceConnectionState { get; set; }
+        public MgmtKeyvaultPrivateLinkServiceConnectionState ConnectionState { get; set; }
         /// <summary> Provisioning state of the private endpoint connection. </summary>
         public MgmtKeyvaultPrivateEndpointConnectionProvisioningState? ProvisioningState { get; set; }
     }

--- a/test/TestProjects/MgmtKeyvault/src/Generated/Models/MgmtKeyvaultPrivateEndpointConnectionData.Serialization.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/Models/MgmtKeyvaultPrivateEndpointConnectionData.Serialization.cs
@@ -31,10 +31,10 @@ namespace MgmtKeyvault
                 writer.WritePropertyName("privateEndpoint");
                 JsonSerializer.Serialize(writer, PrivateEndpoint);
             }
-            if (Optional.IsDefined(PrivateLinkServiceConnectionState))
+            if (Optional.IsDefined(ConnectionState))
             {
                 writer.WritePropertyName("privateLinkServiceConnectionState");
-                writer.WriteObjectValue(PrivateLinkServiceConnectionState);
+                writer.WriteObjectValue(ConnectionState);
             }
             if (Optional.IsDefined(ProvisioningState))
             {

--- a/test/TestProjects/MgmtKeyvault/src/Generated/Models/PrivateEndpointConnectionItem.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/Models/PrivateEndpointConnectionItem.cs
@@ -22,14 +22,14 @@ namespace MgmtKeyvault.Models
         /// <param name="id"> Id of private endpoint connection. </param>
         /// <param name="etag"> Modified whenever there is a change in the state of private endpoint connection. </param>
         /// <param name="privateEndpoint"> Properties of the private endpoint object. </param>
-        /// <param name="privateLinkServiceConnectionState"> Approval state of the private link connection. </param>
+        /// <param name="connectionState"> Approval state of the private link connection. </param>
         /// <param name="provisioningState"> Provisioning state of the private endpoint connection. </param>
-        internal PrivateEndpointConnectionItem(string id, string etag, SubResource privateEndpoint, MgmtKeyvaultPrivateLinkServiceConnectionState privateLinkServiceConnectionState, MgmtKeyvaultPrivateEndpointConnectionProvisioningState? provisioningState)
+        internal PrivateEndpointConnectionItem(string id, string etag, SubResource privateEndpoint, MgmtKeyvaultPrivateLinkServiceConnectionState connectionState, MgmtKeyvaultPrivateEndpointConnectionProvisioningState? provisioningState)
         {
             Id = id;
             Etag = etag;
             PrivateEndpoint = privateEndpoint;
-            PrivateLinkServiceConnectionState = privateLinkServiceConnectionState;
+            ConnectionState = connectionState;
             ProvisioningState = provisioningState;
         }
 
@@ -46,7 +46,7 @@ namespace MgmtKeyvault.Models
         }
 
         /// <summary> Approval state of the private link connection. </summary>
-        public MgmtKeyvaultPrivateLinkServiceConnectionState PrivateLinkServiceConnectionState { get; }
+        public MgmtKeyvaultPrivateLinkServiceConnectionState ConnectionState { get; }
         /// <summary> Provisioning state of the private endpoint connection. </summary>
         public MgmtKeyvaultPrivateEndpointConnectionProvisioningState? ProvisioningState { get; }
     }

--- a/test/TestProjects/MgmtKeyvault/tests/Generated/CodeModel.yaml
+++ b/test/TestProjects/MgmtKeyvault/tests/Generated/CodeModel.yaml
@@ -2848,7 +2848,7 @@ schemas: !Schemas
                         serializedName: privateLinkServiceConnectionState
                         language: !Languages &ref_373
                           default:
-                            name: privateLinkServiceConnectionState
+                            name: connectionState
                             description: Approval state of the private link connection.
                         protocol: !Protocols {}
                       - !Property 
@@ -3867,7 +3867,7 @@ schemas: !Schemas
           serializedName: privateLinkServiceConnectionState
           language: !Languages &ref_462
             default:
-              name: privateLinkServiceConnectionState
+              name: connectionState
               description: Approval state of the private link connection.
           protocol: !Protocols {}
         - !Property 

--- a/test/TestProjects/MgmtKeyvault/tests/Generated/Mock/MgmtKeyvaultPrivateEndpointConnectionCollectionTest.cs
+++ b/test/TestProjects/MgmtKeyvault/tests/Generated/Mock/MgmtKeyvaultPrivateEndpointConnectionCollectionTest.cs
@@ -33,7 +33,7 @@ namespace MgmtKeyvault.Tests.Mock
             MgmtKeyvault.MgmtKeyvaultPrivateEndpointConnectionData data = new MgmtKeyvault.MgmtKeyvaultPrivateEndpointConnectionData()
             {
                 Etag = "",
-                PrivateLinkServiceConnectionState = new MgmtKeyvault.Models.MgmtKeyvaultPrivateLinkServiceConnectionState()
+                ConnectionState = new MgmtKeyvault.Models.MgmtKeyvaultPrivateLinkServiceConnectionState()
                 {
                     Status = new MgmtKeyvault.Models.MgmtKeyvaultPrivateEndpointServiceConnectionStatus("Approved"),
                     Description = "My name is Joe and I'm approving this.",

--- a/test/TestProjects/ReferenceTypes/Generated/CodeModel.yaml
+++ b/test/TestProjects/ReferenceTypes/Generated/CodeModel.yaml
@@ -889,7 +889,7 @@ schemas: !Schemas
                 serializedName: privateLinkServiceConnectionState
                 language: !Languages 
                   default:
-                    name: privateLinkServiceConnectionState
+                    name: connectionState
                     description: A collection of information about the state of the connection between service consumer and provider.
                 protocol: !Protocols {}
               - !Property 

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionData.Serialization.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionData.Serialization.cs
@@ -26,10 +26,10 @@ namespace Azure.ResourceManager.Fake.Models
                 writer.WritePropertyName("privateEndpoint");
                 writer.WriteObjectValue(PrivateEndpoint);
             }
-            if (Optional.IsDefined(PrivateLinkServiceConnectionState))
+            if (Optional.IsDefined(ConnectionState))
             {
                 writer.WritePropertyName("privateLinkServiceConnectionState");
-                writer.WriteObjectValue(PrivateLinkServiceConnectionState);
+                writer.WriteObjectValue(ConnectionState);
             }
             writer.WriteEndObject();
             writer.WriteEndObject();

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionData.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionData.cs
@@ -26,13 +26,13 @@ namespace Azure.ResourceManager.Fake.Models
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
         /// <param name="privateEndpoint"> The resource of private end point. </param>
-        /// <param name="privateLinkServiceConnectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
+        /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
         /// <param name="provisioningState"> The provisioning state of the private endpoint connection resource. </param>
         [SerializationConstructor]
-        internal PrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, ResourceManager.Models.SystemData systemData, PrivateEndpoint privateEndpoint, ReferenceTypesPrivateLinkServiceConnectionState privateLinkServiceConnectionState, ReferenceTypesPrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
+        internal PrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, ResourceManager.Models.SystemData systemData, PrivateEndpoint privateEndpoint, ReferenceTypesPrivateLinkServiceConnectionState connectionState, ReferenceTypesPrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             PrivateEndpoint = privateEndpoint;
-            PrivateLinkServiceConnectionState = privateLinkServiceConnectionState;
+            ConnectionState = connectionState;
             ProvisioningState = provisioningState;
         }
 
@@ -45,7 +45,7 @@ namespace Azure.ResourceManager.Fake.Models
         }
 
         /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
-        public ReferenceTypesPrivateLinkServiceConnectionState PrivateLinkServiceConnectionState { get; set; }
+        public ReferenceTypesPrivateLinkServiceConnectionState ConnectionState { get; set; }
         /// <summary> The provisioning state of the private endpoint connection resource. </summary>
         public ReferenceTypesPrivateEndpointConnectionProvisioningState? ProvisioningState { get; }
     }


### PR DESCRIPTION
add a directive to shorten `privateLinkServiceConnectionState` of `PrivateEndpointConnectionProperties` to `connectionState`

part of #2194

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first