### PR TITLE
Add AppendPath override that takes type long.

### DIFF
--- a/src/assets/Generator.Shared/RequestUriBuilderExtensions.cs
+++ b/src/assets/Generator.Shared/RequestUriBuilderExtensions.cs
@@ -57,6 +57,11 @@ namespace Azure.Core
             builder.AppendPath(value.ToString(), escape);
         }
 
+        public static void AppendPath(this RequestUriBuilder builder, long value, bool escape = true)
+        {
+            builder.AppendPath(value.ToString(TypeFormatters.DefaultNumberFormat, CultureInfo.InvariantCulture), escape);
+        }
+
         public static void AppendQuery(this RequestUriBuilder builder, string name, bool value, bool escape = false)
         {
             builder.AppendQuery(name, TypeFormatters.ToString(value), escape);

--- a/test/AutoRest.Shared.Tests/RawRequestUriBuilderTest.cs
+++ b/test/AutoRest.Shared.Tests/RawRequestUriBuilderTest.cs
@@ -122,5 +122,20 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual(expected, builder.ToUri().ToString());
         }
+
+        [Theory]
+        [TestCase(long.MinValue)]
+        [TestCase(0L)]
+        [TestCase(long.MaxValue)]
+        public void AppendPathTypeLong(long longPathPart)
+        {
+            const string Endpoint = "http://localhost:12345/getByLong/";
+
+            var builder = new RawRequestUriBuilder();
+            builder.AppendRaw(Endpoint, false);
+            builder.AppendPath(longPathPart, true);
+
+            Assert.AreEqual($"{Endpoint}{longPathPart:G}", builder.ToUri().ToString());
+        }
     }
 }


### PR DESCRIPTION
# Description
Added AppendPath override for long type. Fixes #2250
Without this override the compiler would infer the AppendPath extension method that takes type float, resulting in the bug outlined in #2250

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [x] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first