### PR TITLE
move the internalizer and remover to mgmt namespace

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
@@ -39,7 +39,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 }
                 else
                 {
-                    MgmtTarget.Execute(project, codeModel, sourceInputModel);
+                    await MgmtTarget.Execute(project, codeModel, sourceInputModel);
                 }
             }
             else

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
@@ -172,14 +172,14 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         public static bool IsSharedDocument(Document document) => document.Folders.Contains(SharedFolder);
         public static bool IsGeneratedDocument(Document document) => document.Folders.Contains(GeneratedFolder);
 
-        public async Task InternalizeOrphanedModels(ImmutableHashSet<string> modelsToKeep)
+        /// <summary>
+        /// This method delegates the caller to do something on the generated code project
+        /// </summary>
+        /// <param name="processor"></param>
+        /// <returns></returns>
+        public async Task PostProcess(Func<Project, Task<Project>> processor)
         {
-            _project = await Internalizer.InternalizeAsync(_project, modelsToKeep);
-        }
-
-        public async Task RemoveUnusedModels(ImmutableHashSet<string> modelsToKeep)
-        {
-            _project = await Remover.RemoveUnusedAsync(_project, modelsToKeep);
+            _project = await processor(_project);
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/DefinitionVisitor.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/DefinitionVisitor.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace AutoRest.CSharp.AutoRest.Plugins
+namespace AutoRest.CSharp.Mgmt.AutoRest.PostProcess
 {
     internal class DefinitionVisitor : CSharpSyntaxRewriter
     {

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/Internalizer.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/Internalizer.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Simplification;
 
-namespace AutoRest.CSharp.AutoRest.Plugins
+namespace AutoRest.CSharp.Mgmt.AutoRest.PostProcess
 {
     internal static class Internalizer
     {

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/MemberVisitor.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/MemberVisitor.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace AutoRest.CSharp.AutoRest.Plugins
+namespace AutoRest.CSharp.Mgmt.AutoRest.PostProcess
 {
     internal class MemberVisitor : CSharpSyntaxRewriter
     {

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/Remover.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/Remover.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Simplification;
 
-namespace AutoRest.CSharp.AutoRest.Plugins
+namespace AutoRest.CSharp.Mgmt.AutoRest.PostProcess
 {
     internal static class Remover
     {


### PR DESCRIPTION
# Description

Since the `Internalizer` and `Remover` are only used in mgmt plane, DPG does not use them, and does not need them because these two mechanisms work for models, which DPG does not have. Therefore it makes no sense that the Internalizer and Remover stay at the Common layer of our generator. This PR moves them to `Mgmt` directory, and decouples the invocation of these post-processes using a delegate inside `GeneratedCodeWorkspace` class.

I have regenerated the azure-sdk-for-net repo using this change, and there is no change

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first