### PR TITLE
enlarging the timeout for publish job

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -129,6 +129,7 @@ stages:
         - Release
       jobs:
         - job: Update
+          timeoutInMinutes: 120
           pool:
             vmImage: ubuntu-20.04
           variables:
@@ -146,7 +147,6 @@ stages:
               failOnStderr: false
               workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
               displayName: 'Update generator version in Azure SDK repo'
-              timeoutInMinutes: 120
             - template: /eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
               parameters:
                 BaseBranchName: main

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -146,6 +146,7 @@ stages:
               failOnStderr: false
               workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
               displayName: 'Update generator version in Azure SDK repo'
+              timeoutInMinutes: 120
             - template: /eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
               parameters:
                 BaseBranchName: main


### PR DESCRIPTION
# Description

The time consumed by the publish job is proportional to the amount of RPs we have in azure-sdk-for-net, since we are having more and more RPs in azure-sdk-for-net, we will need more time for the UpdateAzureSDKForNet.ps1 script to run

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first