### PR TITLE
Remove dependencies on OperationInternals and OperationInternals<T>

### DIFF
--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsCreateOrUpdateOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsCreateOrUpdateOperation.cs
@@ -28,7 +28,7 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfaceTapConfigurationsCreateOrUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            IOperation<NetworkInterfaceTapConfiguration> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
             _operation = new OperationInternal<NetworkInterfaceTapConfiguration>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfaceTapConfigurationsCreateOrUpdateOperation");
         }
 

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsCreateOrUpdateOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsCreateOrUpdateOperation.cs
@@ -19,7 +19,7 @@ namespace Azure.Network.Management.Interface
     /// <summary> Creates or updates a Tap configuration in the specified NetworkInterface. </summary>
     public partial class NetworkInterfaceTapConfigurationsCreateOrUpdateOperation : Operation<NetworkInterfaceTapConfiguration>, IOperationSource<NetworkInterfaceTapConfiguration>
     {
-        private readonly OperationInternals<NetworkInterfaceTapConfiguration> _operation;
+        private readonly OperationInternal<NetworkInterfaceTapConfiguration> _operation;
 
         /// <summary> Initializes a new instance of NetworkInterfaceTapConfigurationsCreateOrUpdateOperation for mocking. </summary>
         protected NetworkInterfaceTapConfigurationsCreateOrUpdateOperation()
@@ -28,11 +28,14 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfaceTapConfigurationsCreateOrUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<NetworkInterfaceTapConfiguration>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "NetworkInterfaceTapConfigurationsCreateOrUpdateOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            _operation = new OperationInternal<NetworkInterfaceTapConfiguration>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfaceTapConfigurationsCreateOrUpdateOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override NetworkInterfaceTapConfiguration Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace Azure.Network.Management.Interface
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsDeleteOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsDeleteOperation.cs
@@ -17,7 +17,7 @@ namespace Azure.Network.Management.Interface
     /// <summary> Deletes the specified tap configuration from the NetworkInterface. </summary>
     public partial class NetworkInterfaceTapConfigurationsDeleteOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of NetworkInterfaceTapConfigurationsDeleteOperation for mocking. </summary>
         protected NetworkInterfaceTapConfigurationsDeleteOperation()
@@ -26,17 +26,20 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfaceTapConfigurationsDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "NetworkInterfaceTapConfigurationsDeleteOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "NetworkInterfaceTapConfigurationsDeleteOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsDeleteOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsDeleteOperation.cs
@@ -26,7 +26,7 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfaceTapConfigurationsDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "NetworkInterfaceTapConfigurationsDeleteOperation");
         }
 

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesCreateOrUpdateOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesCreateOrUpdateOperation.cs
@@ -28,7 +28,7 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesCreateOrUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            IOperation<NetworkInterface> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
             _operation = new OperationInternal<NetworkInterface>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesCreateOrUpdateOperation");
         }
 

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesCreateOrUpdateOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesCreateOrUpdateOperation.cs
@@ -19,7 +19,7 @@ namespace Azure.Network.Management.Interface
     /// <summary> Creates or updates a network interface. </summary>
     public partial class NetworkInterfacesCreateOrUpdateOperation : Operation<NetworkInterface>, IOperationSource<NetworkInterface>
     {
-        private readonly OperationInternals<NetworkInterface> _operation;
+        private readonly OperationInternal<NetworkInterface> _operation;
 
         /// <summary> Initializes a new instance of NetworkInterfacesCreateOrUpdateOperation for mocking. </summary>
         protected NetworkInterfacesCreateOrUpdateOperation()
@@ -28,11 +28,14 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesCreateOrUpdateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<NetworkInterface>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "NetworkInterfacesCreateOrUpdateOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            _operation = new OperationInternal<NetworkInterface>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesCreateOrUpdateOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override NetworkInterface Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace Azure.Network.Management.Interface
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesDeleteOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesDeleteOperation.cs
@@ -26,7 +26,7 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesDeleteOperation");
         }
 

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesDeleteOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesDeleteOperation.cs
@@ -17,7 +17,7 @@ namespace Azure.Network.Management.Interface
     /// <summary> Deletes the specified network interface. </summary>
     public partial class NetworkInterfacesDeleteOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of NetworkInterfacesDeleteOperation for mocking. </summary>
         protected NetworkInterfacesDeleteOperation()
@@ -26,17 +26,20 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "NetworkInterfacesDeleteOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesDeleteOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesGetEffectiveRouteTableOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesGetEffectiveRouteTableOperation.cs
@@ -28,7 +28,7 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesGetEffectiveRouteTableOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<EffectiveRouteListResult> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<EffectiveRouteListResult>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesGetEffectiveRouteTableOperation");
         }
 

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesGetEffectiveRouteTableOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesGetEffectiveRouteTableOperation.cs
@@ -19,7 +19,7 @@ namespace Azure.Network.Management.Interface
     /// <summary> Gets all route tables applied to a network interface. </summary>
     public partial class NetworkInterfacesGetEffectiveRouteTableOperation : Operation<EffectiveRouteListResult>, IOperationSource<EffectiveRouteListResult>
     {
-        private readonly OperationInternals<EffectiveRouteListResult> _operation;
+        private readonly OperationInternal<EffectiveRouteListResult> _operation;
 
         /// <summary> Initializes a new instance of NetworkInterfacesGetEffectiveRouteTableOperation for mocking. </summary>
         protected NetworkInterfacesGetEffectiveRouteTableOperation()
@@ -28,11 +28,14 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesGetEffectiveRouteTableOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<EffectiveRouteListResult>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "NetworkInterfacesGetEffectiveRouteTableOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<EffectiveRouteListResult>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesGetEffectiveRouteTableOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override EffectiveRouteListResult Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace Azure.Network.Management.Interface
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation.cs
@@ -19,7 +19,7 @@ namespace Azure.Network.Management.Interface
     /// <summary> Gets all network security groups applied to a network interface. </summary>
     public partial class NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation : Operation<EffectiveNetworkSecurityGroupListResult>, IOperationSource<EffectiveNetworkSecurityGroupListResult>
     {
-        private readonly OperationInternals<EffectiveNetworkSecurityGroupListResult> _operation;
+        private readonly OperationInternal<EffectiveNetworkSecurityGroupListResult> _operation;
 
         /// <summary> Initializes a new instance of NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation for mocking. </summary>
         protected NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation()
@@ -28,11 +28,14 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<EffectiveNetworkSecurityGroupListResult>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<EffectiveNetworkSecurityGroupListResult>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override EffectiveNetworkSecurityGroupListResult Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace Azure.Network.Management.Interface
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation.cs
@@ -28,7 +28,7 @@ namespace Azure.Network.Management.Interface
 
         internal NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<EffectiveNetworkSecurityGroupListResult> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<EffectiveNetworkSecurityGroupListResult>(clientDiagnostics, nextLinkOperation, response, "NetworkInterfacesListEffectiveNetworkSecurityGroupsOperation");
         }
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/LongRunningOperationWriter.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/LongRunningOperationWriter.cs
@@ -121,6 +121,11 @@ namespace AutoRest.CSharp.Generation.Writers
             return operation.ResultType != null ? new CSharpType(typeof(IOperationSource<>), operation.ResultType) : null;
         }
 
+        protected virtual CSharpType GetNextLinkOperationType(LongRunningOperation operation)
+        {
+            return operation.ResultType != null ? new CSharpType(typeof(IOperation<>), operation.ResultType) : typeof(IOperation);
+        }
+
         protected virtual CSharpType GetBaseType(LongRunningOperation operation)
         {
             return operation.ResultType != null ? new CSharpType(typeof(Operation<>), operation.ResultType) : new CSharpType(typeof(Operation));
@@ -160,7 +165,7 @@ namespace AutoRest.CSharp.Generation.Writers
             {
                 var nextLinkOperationVariable = new CodeWriterDeclaration("nextLinkOperation");
                 writer
-                    .Append($"var {nextLinkOperationVariable:D} = {typeof(NextLinkOperationImplementation)}.{nameof(NextLinkOperationImplementation.Create)}(")
+                    .Append($"{GetNextLinkOperationType(operation)} {nextLinkOperationVariable:D} = {typeof(NextLinkOperationImplementation)}.{nameof(NextLinkOperationImplementation.Create)}(")
                     .AppendIf($"this, ", operation.ResultType != null)
                     .Line($"pipeline, request.Method, request.Uri.ToUri(), response, {typeof(OperationFinalStateVia)}.{operation.FinalStateVia});")
                     .Line($"_operation = new {helperType}(clientDiagnostics, nextLinkOperation, response, { operation.Diagnostics.ScopeName:L});");

--- a/test/TestProjects/NameConflicts/Generated/AutoRestParameterFlatteningAnalyzeBodyOperation.cs
+++ b/test/TestProjects/NameConflicts/Generated/AutoRestParameterFlatteningAnalyzeBodyOperation.cs
@@ -26,7 +26,7 @@ namespace NameConflicts
 
         internal AutoRestParameterFlatteningAnalyzeBodyOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "AutoRestParameterFlatteningAnalyzeBodyOperation");
         }
 

--- a/test/TestProjects/NameConflicts/Generated/AutoRestParameterFlatteningAnalyzeBodyOperation.cs
+++ b/test/TestProjects/NameConflicts/Generated/AutoRestParameterFlatteningAnalyzeBodyOperation.cs
@@ -17,7 +17,7 @@ namespace NameConflicts
     /// <summary> Analyze body, that could be different media types. </summary>
     public partial class AutoRestParameterFlatteningAnalyzeBodyOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of AutoRestParameterFlatteningAnalyzeBodyOperation for mocking. </summary>
         protected AutoRestParameterFlatteningAnalyzeBodyOperation()
@@ -26,17 +26,20 @@ namespace NameConflicts
 
         internal AutoRestParameterFlatteningAnalyzeBodyOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "AutoRestParameterFlatteningAnalyzeBodyOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "AutoRestParameterFlatteningAnalyzeBodyOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/TypeSchemaMapping/SomeFolder/Generated/MainOperation.cs
+++ b/test/TestProjects/TypeSchemaMapping/SomeFolder/Generated/MainOperation.cs
@@ -17,7 +17,7 @@ namespace CustomNamespace
 {
     internal partial class MainOperation : Operation<CustomizedModel>, IOperationSource<CustomizedModel>
     {
-        private readonly OperationInternals<CustomizedModel> _operation;
+        private readonly OperationInternal<CustomizedModel> _operation;
 
         /// <summary> Initializes a new instance of MainOperation for mocking. </summary>
         protected MainOperation()
@@ -26,11 +26,14 @@ namespace CustomNamespace
 
         internal MainOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<CustomizedModel>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "MainOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<CustomizedModel>(clientDiagnostics, nextLinkOperation, response, "MainOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override CustomizedModel Value => _operation.Value;
@@ -42,7 +45,7 @@ namespace CustomNamespace
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestProjects/TypeSchemaMapping/SomeFolder/Generated/MainOperation.cs
+++ b/test/TestProjects/TypeSchemaMapping/SomeFolder/Generated/MainOperation.cs
@@ -26,7 +26,7 @@ namespace CustomNamespace
 
         internal MainOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<CustomizedModel> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<CustomizedModel>(clientDiagnostics, nextLinkOperation, response, "MainOperation");
         }
 

--- a/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation.cs
+++ b/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation.cs
@@ -27,7 +27,7 @@ namespace lro_parameterized_endpoints
 
         internal LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<string> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<string>(clientDiagnostics, nextLinkOperation, response, "LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation");
         }
 

--- a/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation.cs
+++ b/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation.cs
@@ -18,7 +18,7 @@ namespace lro_parameterized_endpoints
     /// <summary> Poll with method and client level parameters in endpoint, with a constant value. </summary>
     public partial class LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation : Operation<string>, IOperationSource<string>
     {
-        private readonly OperationInternals<string> _operation;
+        private readonly OperationInternal<string> _operation;
 
         /// <summary> Initializes a new instance of LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation for mocking. </summary>
         protected LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation()
@@ -27,11 +27,14 @@ namespace lro_parameterized_endpoints
 
         internal LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<string>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<string>(clientDiagnostics, nextLinkOperation, response, "LROWithParamaterizedEndpointsPollWithConstantParameterizedEndpointsOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override string Value => _operation.Value;
@@ -43,7 +46,7 @@ namespace lro_parameterized_endpoints
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation.cs
+++ b/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation.cs
@@ -27,7 +27,7 @@ namespace lro_parameterized_endpoints
 
         internal LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<string> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<string>(clientDiagnostics, nextLinkOperation, response, "LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation");
         }
 

--- a/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation.cs
+++ b/test/TestServerProjects/lro-parameterized-endpoints/Generated/LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation.cs
@@ -18,7 +18,7 @@ namespace lro_parameterized_endpoints
     /// <summary> Poll with method and client level parameters in endpoint. </summary>
     public partial class LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation : Operation<string>, IOperationSource<string>
     {
-        private readonly OperationInternals<string> _operation;
+        private readonly OperationInternal<string> _operation;
 
         /// <summary> Initializes a new instance of LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation for mocking. </summary>
         protected LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation()
@@ -27,11 +27,14 @@ namespace lro_parameterized_endpoints
 
         internal LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<string>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<string>(clientDiagnostics, nextLinkOperation, response, "LROWithParamaterizedEndpointsPollWithParameterizedEndpointsOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override string Value => _operation.Value;
@@ -43,7 +46,7 @@ namespace lro_parameterized_endpoints
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysDelete202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysDelete202Retry200Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LRORetrysDelete202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysDelete202Retry200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysDelete202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysDelete202Retry200Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LRORetrysDelete202Retry200Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LRORetrysDelete202Retry200Operation for mocking. </summary>
         protected LRORetrysDelete202Retry200Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LRORetrysDelete202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysDelete202Retry200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysDelete202Retry200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysDeleteAsyncRelativeRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysDeleteAsyncRelativeRetrySucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LRORetrysDeleteAsyncRelativeRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysDeleteAsyncRelativeRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysDeleteAsyncRelativeRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysDeleteAsyncRelativeRetrySucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LRORetrysDeleteAsyncRelativeRetrySucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LRORetrysDeleteAsyncRelativeRetrySucceededOperation for mocking. </summary>
         protected LRORetrysDeleteAsyncRelativeRetrySucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LRORetrysDeleteAsyncRelativeRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysDeleteAsyncRelativeRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysDeleteAsyncRelativeRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysDeleteProvisioning202Accepted200SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysDeleteProvisioning202Accepted200SucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LRORetrysDeleteProvisioning202Accepted200SucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LRORetrysDeleteProvisioning202Accepted200SucceededOperation for mocking. </summary>
         protected LRORetrysDeleteProvisioning202Accepted200SucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LRORetrysDeleteProvisioning202Accepted200SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysDeleteProvisioning202Accepted200SucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LRORetrysDeleteProvisioning202Accepted200SucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysDeleteProvisioning202Accepted200SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysDeleteProvisioning202Accepted200SucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LRORetrysDeleteProvisioning202Accepted200SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LRORetrysDeleteProvisioning202Accepted200SucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysPost202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPost202Retry200Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 500, then a 202 to the initial request, with &apos;Location&apos; and &apos;Retry-After&apos; headers, Polls return a 200 with a response body after success. </summary>
     public partial class LRORetrysPost202Retry200Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LRORetrysPost202Retry200Operation for mocking. </summary>
         protected LRORetrysPost202Retry200Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LRORetrysPost202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysPost202Retry200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysPost202Retry200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysPost202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPost202Retry200Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LRORetrysPost202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysPost202Retry200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysPostAsyncRelativeRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPostAsyncRelativeRetrySucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LRORetrysPostAsyncRelativeRetrySucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LRORetrysPostAsyncRelativeRetrySucceededOperation for mocking. </summary>
         protected LRORetrysPostAsyncRelativeRetrySucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LRORetrysPostAsyncRelativeRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysPostAsyncRelativeRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysPostAsyncRelativeRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysPostAsyncRelativeRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPostAsyncRelativeRetrySucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LRORetrysPostAsyncRelativeRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LRORetrysPostAsyncRelativeRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysPut201CreatingSucceeded200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPut201CreatingSucceeded200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LRORetrysPut201CreatingSucceeded200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LRORetrysPut201CreatingSucceeded200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysPut201CreatingSucceeded200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPut201CreatingSucceeded200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LRORetrysPut201CreatingSucceeded200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LRORetrysPut201CreatingSucceeded200Operation for mocking. </summary>
         protected LRORetrysPut201CreatingSucceeded200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LRORetrysPut201CreatingSucceeded200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysPut201CreatingSucceeded200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LRORetrysPut201CreatingSucceeded200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LRORetrysPutAsyncRelativeRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPutAsyncRelativeRetrySucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LRORetrysPutAsyncRelativeRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LRORetrysPutAsyncRelativeRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LRORetrysPutAsyncRelativeRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LRORetrysPutAsyncRelativeRetrySucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LRORetrysPutAsyncRelativeRetrySucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LRORetrysPutAsyncRelativeRetrySucceededOperation for mocking. </summary>
         protected LRORetrysPutAsyncRelativeRetrySucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LRORetrysPutAsyncRelativeRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LRORetrysPutAsyncRelativeRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LRORetrysPutAsyncRelativeRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPost202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPost202Retry200Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with &apos;Location&apos; and &apos;Retry-After&apos; headers, Polls return a 200 with a response body after success. </summary>
     public partial class LROsCustomHeaderPost202Retry200Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsCustomHeaderPost202Retry200Operation for mocking. </summary>
         protected LROsCustomHeaderPost202Retry200Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsCustomHeaderPost202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsCustomHeaderPost202Retry200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPost202Retry200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPost202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPost202Retry200Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsCustomHeaderPost202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPost202Retry200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPostAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPostAsyncRetrySucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsCustomHeaderPostAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPostAsyncRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPostAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPostAsyncRetrySucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsCustomHeaderPostAsyncRetrySucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsCustomHeaderPostAsyncRetrySucceededOperation for mocking. </summary>
         protected LROsCustomHeaderPostAsyncRetrySucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsCustomHeaderPostAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsCustomHeaderPostAsyncRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPostAsyncRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPut201CreatingSucceeded200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPut201CreatingSucceeded200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsCustomHeaderPut201CreatingSucceeded200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPut201CreatingSucceeded200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPut201CreatingSucceeded200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPut201CreatingSucceeded200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LROsCustomHeaderPut201CreatingSucceeded200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsCustomHeaderPut201CreatingSucceeded200Operation for mocking. </summary>
         protected LROsCustomHeaderPut201CreatingSucceeded200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsCustomHeaderPut201CreatingSucceeded200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsCustomHeaderPut201CreatingSucceeded200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPut201CreatingSucceeded200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPutAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPutAsyncRetrySucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsCustomHeaderPutAsyncRetrySucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsCustomHeaderPutAsyncRetrySucceededOperation for mocking. </summary>
         protected LROsCustomHeaderPutAsyncRetrySucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsCustomHeaderPutAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsCustomHeaderPutAsyncRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPutAsyncRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsCustomHeaderPutAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsCustomHeaderPutAsyncRetrySucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsCustomHeaderPutAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsCustomHeaderPutAsyncRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDelete202NoRetry204Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDelete202NoRetry204Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LROsDelete202NoRetry204Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsDelete202NoRetry204Operation for mocking. </summary>
         protected LROsDelete202NoRetry204Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsDelete202NoRetry204Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDelete202NoRetry204Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDelete202NoRetry204Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDelete202NoRetry204Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDelete202NoRetry204Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsDelete202NoRetry204Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDelete202NoRetry204Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDelete202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDelete202Retry200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsDelete202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDelete202Retry200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDelete202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDelete202Retry200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LROsDelete202Retry200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsDelete202Retry200Operation for mocking. </summary>
         protected LROsDelete202Retry200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsDelete202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDelete202Retry200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDelete202Retry200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDelete204SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDelete204SucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDelete204SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDelete204SucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDelete204SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDelete204SucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete succeeds and returns right away. </summary>
     public partial class LROsDelete204SucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDelete204SucceededOperation for mocking. </summary>
         protected LROsDelete204SucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDelete204SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDelete204SucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDelete204SucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoHeaderInRetryOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header. </summary>
     public partial class LROsDeleteAsyncNoHeaderInRetryOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteAsyncNoHeaderInRetryOperation for mocking. </summary>
         protected LROsDeleteAsyncNoHeaderInRetryOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDeleteAsyncNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteAsyncNoHeaderInRetryOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncNoHeaderInRetryOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoHeaderInRetryOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDeleteAsyncNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncNoHeaderInRetryOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoRetrySucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDeleteAsyncNoRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncNoRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncNoRetrySucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsDeleteAsyncNoRetrySucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteAsyncNoRetrySucceededOperation for mocking. </summary>
         protected LROsDeleteAsyncNoRetrySucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDeleteAsyncNoRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteAsyncNoRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncNoRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetryFailedOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetryFailedOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDeleteAsyncRetryFailedOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncRetryFailedOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetryFailedOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetryFailedOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsDeleteAsyncRetryFailedOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteAsyncRetryFailedOperation for mocking. </summary>
         protected LROsDeleteAsyncRetryFailedOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDeleteAsyncRetryFailedOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteAsyncRetryFailedOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncRetryFailedOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrySucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDeleteAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrySucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsDeleteAsyncRetrySucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteAsyncRetrySucceededOperation for mocking. </summary>
         protected LROsDeleteAsyncRetrySucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDeleteAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteAsyncRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrycanceledOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrycanceledOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDeleteAsyncRetrycanceledOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncRetrycanceledOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrycanceledOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteAsyncRetrycanceledOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsDeleteAsyncRetrycanceledOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteAsyncRetrycanceledOperation for mocking. </summary>
         protected LROsDeleteAsyncRetrycanceledOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDeleteAsyncRetrycanceledOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteAsyncRetrycanceledOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteAsyncRetrycanceledOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteNoHeaderInRetryOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsDeleteNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteNoHeaderInRetryOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteNoHeaderInRetryOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header. </summary>
     public partial class LROsDeleteNoHeaderInRetryOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteNoHeaderInRetryOperation for mocking. </summary>
         protected LROsDeleteNoHeaderInRetryOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsDeleteNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteNoHeaderInRetryOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsDeleteNoHeaderInRetryOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Accepted200SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Accepted200SucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsDeleteProvisioning202Accepted200SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDeleteProvisioning202Accepted200SucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Accepted200SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Accepted200SucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LROsDeleteProvisioning202Accepted200SucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteProvisioning202Accepted200SucceededOperation for mocking. </summary>
         protected LROsDeleteProvisioning202Accepted200SucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsDeleteProvisioning202Accepted200SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteProvisioning202Accepted200SucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDeleteProvisioning202Accepted200SucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202DeletingFailed200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202DeletingFailed200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’. </summary>
     public partial class LROsDeleteProvisioning202DeletingFailed200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteProvisioning202DeletingFailed200Operation for mocking. </summary>
         protected LROsDeleteProvisioning202DeletingFailed200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsDeleteProvisioning202DeletingFailed200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteProvisioning202DeletingFailed200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDeleteProvisioning202DeletingFailed200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202DeletingFailed200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202DeletingFailed200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsDeleteProvisioning202DeletingFailed200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDeleteProvisioning202DeletingFailed200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Deletingcanceled200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Deletingcanceled200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsDeleteProvisioning202Deletingcanceled200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDeleteProvisioning202Deletingcanceled200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Deletingcanceled200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsDeleteProvisioning202Deletingcanceled200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’. </summary>
     public partial class LROsDeleteProvisioning202Deletingcanceled200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsDeleteProvisioning202Deletingcanceled200Operation for mocking. </summary>
         protected LROsDeleteProvisioning202Deletingcanceled200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsDeleteProvisioning202Deletingcanceled200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsDeleteProvisioning202Deletingcanceled200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsDeleteProvisioning202Deletingcanceled200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPatch200SucceededIgnoreHeadersOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPatch200SucceededIgnoreHeadersOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPatch200SucceededIgnoreHeadersOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPatch200SucceededIgnoreHeadersOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPatch200SucceededIgnoreHeadersOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPatch200SucceededIgnoreHeadersOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request with location header. We should not have any subsequent calls after receiving this first response. </summary>
     public partial class LROsPatch200SucceededIgnoreHeadersOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPatch200SucceededIgnoreHeadersOperation for mocking. </summary>
         protected LROsPatch200SucceededIgnoreHeadersOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPatch200SucceededIgnoreHeadersOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPatch200SucceededIgnoreHeadersOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPatch200SucceededIgnoreHeadersOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPatch201RetryWithAsyncHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPatch201RetryWithAsyncHeaderOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPatch201RetryWithAsyncHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPatch201RetryWithAsyncHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPatch201RetryWithAsyncHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPatch201RetryWithAsyncHeaderOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running patch request, service returns a 201 to the initial request with async header. </summary>
     public partial class LROsPatch201RetryWithAsyncHeaderOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPatch201RetryWithAsyncHeaderOperation for mocking. </summary>
         protected LROsPatch201RetryWithAsyncHeaderOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPatch201RetryWithAsyncHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "LROsPatch201RetryWithAsyncHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPatch201RetryWithAsyncHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPatch202RetryWithAsyncAndLocationHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPatch202RetryWithAsyncAndLocationHeaderOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running patch request, service returns a 202 to the initial request with async and location header. </summary>
     public partial class LROsPatch202RetryWithAsyncAndLocationHeaderOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPatch202RetryWithAsyncAndLocationHeaderOperation for mocking. </summary>
         protected LROsPatch202RetryWithAsyncAndLocationHeaderOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPatch202RetryWithAsyncAndLocationHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPatch202RetryWithAsyncAndLocationHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPatch202RetryWithAsyncAndLocationHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPatch202RetryWithAsyncAndLocationHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPatch202RetryWithAsyncAndLocationHeaderOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPatch202RetryWithAsyncAndLocationHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPatch202RetryWithAsyncAndLocationHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPost200WithPayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost200WithPayloadOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPost200WithPayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Sku> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Sku>(clientDiagnostics, nextLinkOperation, response, "LROsPost200WithPayloadOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPost200WithPayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost200WithPayloadOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with &apos;Location&apos; header. Poll returns a 200 with a response body after success. </summary>
     public partial class LROsPost200WithPayloadOperation : Operation<Sku>, IOperationSource<Sku>
     {
-        private readonly OperationInternals<Sku> _operation;
+        private readonly OperationInternal<Sku> _operation;
 
         /// <summary> Initializes a new instance of LROsPost200WithPayloadOperation for mocking. </summary>
         protected LROsPost200WithPayloadOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPost200WithPayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Sku>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPost200WithPayloadOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Sku>(clientDiagnostics, nextLinkOperation, response, "LROsPost200WithPayloadOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Sku Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPost202ListOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost202ListOperation.cs
@@ -29,7 +29,7 @@ namespace lro
 
         internal LROsPost202ListOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<IReadOnlyList<Product>> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<IReadOnlyList<Product>>(clientDiagnostics, nextLinkOperation, response, "LROsPost202ListOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPost202ListOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost202ListOperation.cs
@@ -20,7 +20,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 202 with empty body to first request, returns a 200 with body [{ &apos;id&apos;: &apos;100&apos;, &apos;name&apos;: &apos;foo&apos; }]. </summary>
     public partial class LROsPost202ListOperation : Operation<IReadOnlyList<Product>>, IOperationSource<IReadOnlyList<Product>>
     {
-        private readonly OperationInternals<IReadOnlyList<Product>> _operation;
+        private readonly OperationInternal<IReadOnlyList<Product>> _operation;
 
         /// <summary> Initializes a new instance of LROsPost202ListOperation for mocking. </summary>
         protected LROsPost202ListOperation()
@@ -29,11 +29,14 @@ namespace lro
 
         internal LROsPost202ListOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<IReadOnlyList<Product>>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPost202ListOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<IReadOnlyList<Product>>(clientDiagnostics, nextLinkOperation, response, "LROsPost202ListOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override IReadOnlyList<Product> Value => _operation.Value;
@@ -45,7 +48,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPost202NoRetry204Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost202NoRetry204Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPost202NoRetry204Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPost202NoRetry204Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPost202NoRetry204Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost202NoRetry204Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with &apos;Location&apos; header, 204 with noresponse body after success. </summary>
     public partial class LROsPost202NoRetry204Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPost202NoRetry204Operation for mocking. </summary>
         protected LROsPost202NoRetry204Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPost202NoRetry204Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPost202NoRetry204Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPost202NoRetry204Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPost202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost202Retry200Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsPost202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsPost202Retry200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPost202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPost202Retry200Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with &apos;Location&apos; and &apos;Retry-After&apos; headers, Polls return a 200 with a response body after success. </summary>
     public partial class LROsPost202Retry200Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsPost202Retry200Operation for mocking. </summary>
         protected LROsPost202Retry200Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsPost202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPost202Retry200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsPost202Retry200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncNoRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncNoRetrySucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPostAsyncNoRetrySucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPostAsyncNoRetrySucceededOperation for mocking. </summary>
         protected LROsPostAsyncNoRetrySucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPostAsyncNoRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPostAsyncNoRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncNoRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncNoRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncNoRetrySucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPostAsyncNoRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncNoRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncRetryFailedOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncRetryFailedOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPostAsyncRetryFailedOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsPostAsyncRetryFailedOperation for mocking. </summary>
         protected LROsPostAsyncRetryFailedOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsPostAsyncRetryFailedOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPostAsyncRetryFailedOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncRetryFailedOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncRetryFailedOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncRetryFailedOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsPostAsyncRetryFailedOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncRetryFailedOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrySucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPostAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrySucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPostAsyncRetrySucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPostAsyncRetrySucceededOperation for mocking. </summary>
         protected LROsPostAsyncRetrySucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPostAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPostAsyncRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrycanceledOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrycanceledOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPostAsyncRetrycanceledOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LROsPostAsyncRetrycanceledOperation for mocking. </summary>
         protected LROsPostAsyncRetrycanceledOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LROsPostAsyncRetrycanceledOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPostAsyncRetrycanceledOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncRetrycanceledOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrycanceledOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostAsyncRetrycanceledOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LROsPostAsyncRetrycanceledOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LROsPostAsyncRetrycanceledOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it&apos;s success. Should NOT poll Location to get the final object if you support initial Autorest behavior. </summary>
     public partial class LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation for mocking. </summary>
         protected LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostDoubleHeadersFinalAzureHeaderGetDefaultOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPostDoubleHeadersFinalAzureHeaderGetOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostDoubleHeadersFinalAzureHeaderGetOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalAzureHeaderGetOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it&apos;s success. Should NOT poll Location to get the final object. </summary>
     public partial class LROsPostDoubleHeadersFinalAzureHeaderGetOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPostDoubleHeadersFinalAzureHeaderGetOperation for mocking. </summary>
         protected LROsPostDoubleHeadersFinalAzureHeaderGetOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPostDoubleHeadersFinalAzureHeaderGetOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "LROsPostDoubleHeadersFinalAzureHeaderGetOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.AzureAsyncOperation);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostDoubleHeadersFinalAzureHeaderGetOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalLocationGetOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalLocationGetOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it&apos;s success. Should poll Location to get the final object. </summary>
     public partial class LROsPostDoubleHeadersFinalLocationGetOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPostDoubleHeadersFinalLocationGetOperation for mocking. </summary>
         protected LROsPostDoubleHeadersFinalLocationGetOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPostDoubleHeadersFinalLocationGetOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPostDoubleHeadersFinalLocationGetOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostDoubleHeadersFinalLocationGetOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalLocationGetOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPostDoubleHeadersFinalLocationGetOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPostDoubleHeadersFinalLocationGetOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPostDoubleHeadersFinalLocationGetOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut200Acceptedcanceled200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200Acceptedcanceled200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut200Acceptedcanceled200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200Acceptedcanceled200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut200Acceptedcanceled200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200Acceptedcanceled200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’. </summary>
     public partial class LROsPut200Acceptedcanceled200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut200Acceptedcanceled200Operation for mocking. </summary>
         protected LROsPut200Acceptedcanceled200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut200Acceptedcanceled200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut200Acceptedcanceled200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200Acceptedcanceled200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut200SucceededNoStateOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200SucceededNoStateOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’. </summary>
     public partial class LROsPut200SucceededNoStateOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut200SucceededNoStateOperation for mocking. </summary>
         protected LROsPut200SucceededNoStateOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut200SucceededNoStateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut200SucceededNoStateOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200SucceededNoStateOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut200SucceededNoStateOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200SucceededNoStateOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut200SucceededNoStateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200SucceededNoStateOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut200SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200SucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’. </summary>
     public partial class LROsPut200SucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut200SucceededOperation for mocking. </summary>
         protected LROsPut200SucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut200SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut200SucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200SucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut200SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200SucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut200SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200SucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut200UpdatingSucceeded204Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200UpdatingSucceeded204Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut200UpdatingSucceeded204Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200UpdatingSucceeded204Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut200UpdatingSucceeded204Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut200UpdatingSucceeded204Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LROsPut200UpdatingSucceeded204Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut200UpdatingSucceeded204Operation for mocking. </summary>
         protected LROsPut200UpdatingSucceeded204Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut200UpdatingSucceeded204Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut200UpdatingSucceeded204Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut200UpdatingSucceeded204Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut201CreatingFailed200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut201CreatingFailed200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut201CreatingFailed200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut201CreatingFailed200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut201CreatingFailed200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut201CreatingFailed200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’. </summary>
     public partial class LROsPut201CreatingFailed200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut201CreatingFailed200Operation for mocking. </summary>
         protected LROsPut201CreatingFailed200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut201CreatingFailed200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut201CreatingFailed200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut201CreatingFailed200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut201CreatingSucceeded200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut201CreatingSucceeded200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut201CreatingSucceeded200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut201CreatingSucceeded200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut201CreatingSucceeded200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut201CreatingSucceeded200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’. </summary>
     public partial class LROsPut201CreatingSucceeded200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut201CreatingSucceeded200Operation for mocking. </summary>
         protected LROsPut201CreatingSucceeded200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut201CreatingSucceeded200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut201CreatingSucceeded200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut201CreatingSucceeded200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut201SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut201SucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut201SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut201SucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPut201SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut201SucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Succeeded’. </summary>
     public partial class LROsPut201SucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut201SucceededOperation for mocking. </summary>
         protected LROsPut201SucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut201SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut201SucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut201SucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut202Retry200Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn&apos;t contains ProvisioningState. </summary>
     public partial class LROsPut202Retry200Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPut202Retry200Operation for mocking. </summary>
         protected LROsPut202Retry200Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPut202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPut202Retry200Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut202Retry200Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPut202Retry200Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPut202Retry200Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPut202Retry200Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPut202Retry200Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNoHeaderInRetryOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNoHeaderInRetryOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNoHeaderInRetryOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header. </summary>
     public partial class LROsPutAsyncNoHeaderInRetryOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncNoHeaderInRetryOperation for mocking. </summary>
         protected LROsPutAsyncNoHeaderInRetryOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncNoHeaderInRetryOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNoHeaderInRetryOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrySucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPutAsyncNoRetrySucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncNoRetrySucceededOperation for mocking. </summary>
         protected LROsPutAsyncNoRetrySucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncNoRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncNoRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNoRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrySucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncNoRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNoRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrycanceledOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrycanceledOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPutAsyncNoRetrycanceledOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncNoRetrycanceledOperation for mocking. </summary>
         protected LROsPutAsyncNoRetrycanceledOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncNoRetrycanceledOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncNoRetrycanceledOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNoRetrycanceledOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrycanceledOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNoRetrycanceledOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncNoRetrycanceledOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNoRetrycanceledOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNonResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNonResourceOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request with non resource. </summary>
     public partial class LROsPutAsyncNonResourceOperation : Operation<Sku>, IOperationSource<Sku>
     {
-        private readonly OperationInternals<Sku> _operation;
+        private readonly OperationInternal<Sku> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncNonResourceOperation for mocking. </summary>
         protected LROsPutAsyncNonResourceOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncNonResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Sku>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncNonResourceOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Sku>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNonResourceOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Sku Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncNonResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncNonResourceOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncNonResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Sku> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Sku>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncNonResourceOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncRetryFailedOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncRetryFailedOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPutAsyncRetryFailedOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncRetryFailedOperation for mocking. </summary>
         protected LROsPutAsyncRetryFailedOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncRetryFailedOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncRetryFailedOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncRetryFailedOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncRetryFailedOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncRetryFailedOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncRetryFailedOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncRetryFailedOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncRetrySucceededOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncRetrySucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncRetrySucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncRetrySucceededOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LROsPutAsyncRetrySucceededOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncRetrySucceededOperation for mocking. </summary>
         protected LROsPutAsyncRetrySucceededOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncRetrySucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncRetrySucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncRetrySucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncSubResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncSubResourceOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutAsyncSubResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<SubProduct> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<SubProduct>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncSubResourceOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutAsyncSubResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutAsyncSubResourceOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request with sub resource. </summary>
     public partial class LROsPutAsyncSubResourceOperation : Operation<SubProduct>, IOperationSource<SubProduct>
     {
-        private readonly OperationInternals<SubProduct> _operation;
+        private readonly OperationInternal<SubProduct> _operation;
 
         /// <summary> Initializes a new instance of LROsPutAsyncSubResourceOperation for mocking. </summary>
         protected LROsPutAsyncSubResourceOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutAsyncSubResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<SubProduct>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutAsyncSubResourceOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<SubProduct>(clientDiagnostics, nextLinkOperation, response, "LROsPutAsyncSubResourceOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override SubProduct Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutNoHeaderInRetryOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header. </summary>
     public partial class LROsPutNoHeaderInRetryOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LROsPutNoHeaderInRetryOperation for mocking. </summary>
         protected LROsPutNoHeaderInRetryOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutNoHeaderInRetryOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutNoHeaderInRetryOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutNoHeaderInRetryOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutNoHeaderInRetryOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutNoHeaderInRetryOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LROsPutNoHeaderInRetryOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutNonResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutNonResourceOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request with non resource. </summary>
     public partial class LROsPutNonResourceOperation : Operation<Sku>, IOperationSource<Sku>
     {
-        private readonly OperationInternals<Sku> _operation;
+        private readonly OperationInternal<Sku> _operation;
 
         /// <summary> Initializes a new instance of LROsPutNonResourceOperation for mocking. </summary>
         protected LROsPutNonResourceOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutNonResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Sku>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutNonResourceOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Sku>(clientDiagnostics, nextLinkOperation, response, "LROsPutNonResourceOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Sku Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LROsPutNonResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutNonResourceOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutNonResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Sku> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Sku>(clientDiagnostics, nextLinkOperation, response, "LROsPutNonResourceOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutSubResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutSubResourceOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LROsPutSubResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<SubProduct> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<SubProduct>(clientDiagnostics, nextLinkOperation, response, "LROsPutSubResourceOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LROsPutSubResourceOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LROsPutSubResourceOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request with sub resource. </summary>
     public partial class LROsPutSubResourceOperation : Operation<SubProduct>, IOperationSource<SubProduct>
     {
-        private readonly OperationInternals<SubProduct> _operation;
+        private readonly OperationInternal<SubProduct> _operation;
 
         /// <summary> Initializes a new instance of LROsPutSubResourceOperation for mocking. </summary>
         protected LROsPutSubResourceOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LROsPutSubResourceOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<SubProduct>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LROsPutSubResourceOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<SubProduct>(clientDiagnostics, nextLinkOperation, response, "LROsPutSubResourceOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override SubProduct Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDelete202NonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDelete202NonRetry400Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDelete202NonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDelete202NonRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDelete202NonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDelete202NonRetry400Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 with a location header. </summary>
     public partial class LrosaDsDelete202NonRetry400Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDelete202NonRetry400Operation for mocking. </summary>
         protected LrosaDsDelete202NonRetry400Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDelete202NonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDelete202NonRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDelete202NonRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDelete202RetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDelete202RetryInvalidHeaderOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDelete202RetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDelete202RetryInvalidHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDelete202RetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDelete202RetryInvalidHeaderOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid &apos;Location&apos; and &apos;Retry-After&apos; headers. </summary>
     public partial class LrosaDsDelete202RetryInvalidHeaderOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDelete202RetryInvalidHeaderOperation for mocking. </summary>
         protected LrosaDsDelete202RetryInvalidHeaderOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDelete202RetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDelete202RetryInvalidHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDelete202RetryInvalidHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDelete204SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDelete204SucceededOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 204 to the initial request, indicating success. </summary>
     public partial class LrosaDsDelete204SucceededOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDelete204SucceededOperation for mocking. </summary>
         protected LrosaDsDelete204SucceededOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDelete204SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDelete204SucceededOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDelete204SucceededOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDelete204SucceededOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDelete204SucceededOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDelete204SucceededOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDelete204SucceededOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetry400Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsDeleteAsyncRelativeRetry400Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDeleteAsyncRelativeRetry400Operation for mocking. </summary>
         protected LrosaDsDeleteAsyncRelativeRetry400Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDeleteAsyncRelativeRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetry400Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid. </summary>
     public partial class LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation for mocking. </summary>
         protected LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation for mocking. </summary>
         protected LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryNoStatusOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryNoStatusOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetryNoStatusOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetryNoStatusOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryNoStatusOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteAsyncRelativeRetryNoStatusOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsDeleteAsyncRelativeRetryNoStatusOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDeleteAsyncRelativeRetryNoStatusOperation for mocking. </summary>
         protected LrosaDsDeleteAsyncRelativeRetryNoStatusOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDeleteAsyncRelativeRetryNoStatusOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDeleteAsyncRelativeRetryNoStatusOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteAsyncRelativeRetryNoStatusOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteNonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteNonRetry400Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsDeleteNonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteNonRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsDeleteNonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsDeleteNonRetry400Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running delete request, service returns a 400 with an error body. </summary>
     public partial class LrosaDsDeleteNonRetry400Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsDeleteNonRetry400Operation for mocking. </summary>
         protected LrosaDsDeleteNonRetry400Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsDeleteNonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsDeleteNonRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsDeleteNonRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPost202NoLocationOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPost202NoLocationOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPost202NoLocationOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPost202NoLocationOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPost202NoLocationOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPost202NoLocationOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, without a location header. </summary>
     public partial class LrosaDsPost202NoLocationOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPost202NoLocationOperation for mocking. </summary>
         protected LrosaDsPost202NoLocationOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPost202NoLocationOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPost202NoLocationOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPost202NoLocationOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPost202NonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPost202NonRetry400Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPost202NonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPost202NonRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPost202NonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPost202NonRetry400Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 with a location header. </summary>
     public partial class LrosaDsPost202NonRetry400Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPost202NonRetry400Operation for mocking. </summary>
         protected LrosaDsPost202NonRetry400Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPost202NonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPost202NonRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPost202NonRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPost202RetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPost202RetryInvalidHeaderOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with invalid &apos;Location&apos; and &apos;Retry-After&apos; headers. </summary>
     public partial class LrosaDsPost202RetryInvalidHeaderOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPost202RetryInvalidHeaderOperation for mocking. </summary>
         protected LrosaDsPost202RetryInvalidHeaderOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPost202RetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPost202RetryInvalidHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPost202RetryInvalidHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPost202RetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPost202RetryInvalidHeaderOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPost202RetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPost202RetryInvalidHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetry400Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPostAsyncRelativeRetry400Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPostAsyncRelativeRetry400Operation for mocking. </summary>
         protected LrosaDsPostAsyncRelativeRetry400Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPostAsyncRelativeRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetry400Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid. </summary>
     public partial class LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation for mocking. </summary>
         protected LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetryInvalidHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation for mocking. </summary>
         protected LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetryInvalidJsonPollingOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryNoPayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryNoPayloadOperation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPostAsyncRelativeRetryNoPayloadOperation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPostAsyncRelativeRetryNoPayloadOperation for mocking. </summary>
         protected LrosaDsPostAsyncRelativeRetryNoPayloadOperation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetryNoPayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPostAsyncRelativeRetryNoPayloadOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetryNoPayloadOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryNoPayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostAsyncRelativeRetryNoPayloadOperation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPostAsyncRelativeRetryNoPayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostAsyncRelativeRetryNoPayloadOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostNonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostNonRetry400Operation.cs
@@ -17,7 +17,7 @@ namespace lro
     /// <summary> Long running post request, service returns a 400 with no error body. </summary>
     public partial class LrosaDsPostNonRetry400Operation : Operation
     {
-        private readonly OperationInternals _operation;
+        private readonly OperationInternal _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPostNonRetry400Operation for mocking. </summary>
         protected LrosaDsPostNonRetry400Operation()
@@ -26,17 +26,20 @@ namespace lro
 
         internal LrosaDsPostNonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPostNonRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostNonRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override bool HasCompleted => _operation.HasCompleted;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPostNonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPostNonRetry400Operation.cs
@@ -26,7 +26,7 @@ namespace lro
 
         internal LrosaDsPostNonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation nextLinkOperation = NextLinkOperationImplementation.Create(pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal(clientDiagnostics, nextLinkOperation, response, "LrosaDsPostNonRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPut200InvalidJsonOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPut200InvalidJsonOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json. </summary>
     public partial class LrosaDsPut200InvalidJsonOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPut200InvalidJsonOperation for mocking. </summary>
         protected LrosaDsPut200InvalidJsonOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPut200InvalidJsonOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPut200InvalidJsonOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPut200InvalidJsonOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPut200InvalidJsonOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPut200InvalidJsonOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPut200InvalidJsonOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPut200InvalidJsonOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetry400Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPutAsyncRelativeRetry400Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutAsyncRelativeRetry400Operation for mocking. </summary>
         protected LrosaDsPutAsyncRelativeRetry400Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutAsyncRelativeRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetry400Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid. </summary>
     public partial class LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation for mocking. </summary>
         protected LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryInvalidHeaderOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation for mocking. </summary>
         protected LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryInvalidJsonPollingOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryNoStatusOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryNoStatusOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPutAsyncRelativeRetryNoStatusOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutAsyncRelativeRetryNoStatusOperation for mocking. </summary>
         protected LrosaDsPutAsyncRelativeRetryNoStatusOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryNoStatusOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutAsyncRelativeRetryNoStatusOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryNoStatusOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status. </summary>
     public partial class LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation for mocking. </summary>
         protected LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutAsyncRelativeRetryNoStatusPayloadOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutError201NoProvisioningStatePayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutError201NoProvisioningStatePayloadOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutError201NoProvisioningStatePayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutError201NoProvisioningStatePayloadOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutError201NoProvisioningStatePayloadOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutError201NoProvisioningStatePayloadOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 201 to the initial request with no payload. </summary>
     public partial class LrosaDsPutError201NoProvisioningStatePayloadOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutError201NoProvisioningStatePayloadOperation for mocking. </summary>
         protected LrosaDsPutError201NoProvisioningStatePayloadOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutError201NoProvisioningStatePayloadOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutError201NoProvisioningStatePayloadOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutError201NoProvisioningStatePayloadOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400InvalidJsonOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400InvalidJsonOperation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutNonRetry201Creating400InvalidJsonOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutNonRetry201Creating400InvalidJsonOperation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400InvalidJsonOperation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400InvalidJsonOperation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a Product with &apos;ProvisioningState&apos; = &apos;Creating&apos; and 201 response code. </summary>
     public partial class LrosaDsPutNonRetry201Creating400InvalidJsonOperation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutNonRetry201Creating400InvalidJsonOperation for mocking. </summary>
         protected LrosaDsPutNonRetry201Creating400InvalidJsonOperation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutNonRetry201Creating400InvalidJsonOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutNonRetry201Creating400InvalidJsonOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutNonRetry201Creating400InvalidJsonOperation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutNonRetry201Creating400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutNonRetry201Creating400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry201Creating400Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a Product with &apos;ProvisioningState&apos; = &apos;Creating&apos; and 201 response code. </summary>
     public partial class LrosaDsPutNonRetry201Creating400Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutNonRetry201Creating400Operation for mocking. </summary>
         protected LrosaDsPutNonRetry201Creating400Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutNonRetry201Creating400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutNonRetry201Creating400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutNonRetry201Creating400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry400Operation.cs
@@ -28,7 +28,7 @@ namespace lro
 
         internal LrosaDsPutNonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<Product> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutNonRetry400Operation");
         }
 

--- a/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry400Operation.cs
+++ b/test/TestServerProjects/lro/Generated/LrosaDsPutNonRetry400Operation.cs
@@ -19,7 +19,7 @@ namespace lro
     /// <summary> Long running put request, service returns a 400 to the initial request. </summary>
     public partial class LrosaDsPutNonRetry400Operation : Operation<Product>, IOperationSource<Product>
     {
-        private readonly OperationInternals<Product> _operation;
+        private readonly OperationInternal<Product> _operation;
 
         /// <summary> Initializes a new instance of LrosaDsPutNonRetry400Operation for mocking. </summary>
         protected LrosaDsPutNonRetry400Operation()
@@ -28,11 +28,14 @@ namespace lro
 
         internal LrosaDsPutNonRetry400Operation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationInternals<Product>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "LrosaDsPutNonRetry400Operation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<Product>(clientDiagnostics, nextLinkOperation, response, "LrosaDsPutNonRetry400Operation");
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override Product Value => _operation.Value;
@@ -44,7 +47,7 @@ namespace lro
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);

--- a/test/TestServerProjects/paging/Generated/PagingGetMultiplePagesLROOperation.cs
+++ b/test/TestServerProjects/paging/Generated/PagingGetMultiplePagesLROOperation.cs
@@ -29,7 +29,7 @@ namespace paging
 
         internal PagingGetMultiplePagesLROOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, Func<string, Task<Response>> nextPageFunc)
         {
-            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            IOperation<AsyncPageable<Product>> nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
             _operation = new OperationInternal<AsyncPageable<Product>>(clientDiagnostics, nextLinkOperation, response, "PagingGetMultiplePagesLROOperation");
             _nextPageFunc = nextPageFunc;
         }

--- a/test/TestServerProjects/paging/Generated/PagingGetMultiplePagesLROOperation.cs
+++ b/test/TestServerProjects/paging/Generated/PagingGetMultiplePagesLROOperation.cs
@@ -19,7 +19,7 @@ namespace paging
     /// <summary> A long-running paging operation that includes a nextLink that has 10 pages. </summary>
     public partial class PagingGetMultiplePagesLROOperation : Operation<AsyncPageable<Product>>, IOperationSource<AsyncPageable<Product>>
     {
-        private readonly OperationInternals<AsyncPageable<Product>> _operation;
+        private readonly OperationInternal<AsyncPageable<Product>> _operation;
         private readonly Func<string, Task<Response>> _nextPageFunc;
 
         /// <summary> Initializes a new instance of PagingGetMultiplePagesLROOperation for mocking. </summary>
@@ -29,12 +29,15 @@ namespace paging
 
         internal PagingGetMultiplePagesLROOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response, Func<string, Task<Response>> nextPageFunc)
         {
-            _operation = new OperationInternals<AsyncPageable<Product>>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "PagingGetMultiplePagesLROOperation");
+            var nextLinkOperation = NextLinkOperationImplementation.Create(this, pipeline, request.Method, request.Uri.ToUri(), response, OperationFinalStateVia.Location);
+            _operation = new OperationInternal<AsyncPageable<Product>>(clientDiagnostics, nextLinkOperation, response, "PagingGetMultiplePagesLROOperation");
             _nextPageFunc = nextPageFunc;
         }
 
         /// <inheritdoc />
-        public override string Id => _operation.Id;
+#pragma warning disable CA1822
+        public override string Id => throw new NotImplementedException();
+#pragma warning restore CA1822
 
         /// <inheritdoc />
         public override AsyncPageable<Product> Value => _operation.Value;
@@ -46,7 +49,7 @@ namespace paging
         public override bool HasValue => _operation.HasValue;
 
         /// <inheritdoc />
-        public override Response GetRawResponse() => _operation.GetRawResponse();
+        public override Response GetRawResponse() => _operation.RawResponse;
 
         /// <inheritdoc />
         public override Response UpdateStatus(CancellationToken cancellationToken = default) => _operation.UpdateStatus(cancellationToken);


### PR DESCRIPTION
Part of the work to [unify LRO](https://github.com/Azure/autorest.csharp/issues/1706)
Uses `OperationInternal` and `OperationInternal<T>` instead of `OperationInternals` and `OperationInternals<T>`.