### PR TITLE
Uptake WaitForCompletionResponse diagnostic scope

### DIFF
--- a/src/assets/Generator.Shared/ProtocolOperationHelpers.cs
+++ b/src/assets/Generator.Shared/ProtocolOperationHelpers.cs
@@ -89,7 +89,7 @@ namespace Azure.Core
             {
                 _operation = operation;
                 _diagnostics = diagnostics;
-                _waitForCompletionScopeName = $"{operationName}.{nameof(WaitForCompletionResponse)}";
+                _waitForCompletionScopeName = $"{operationName}.{nameof(WaitForCompletion)}";
                 _updateStatusScopeName = $"{operationName}.{nameof(UpdateStatus)}";
                 _convertFunc = convertFunc;
                 _response = null;

--- a/test/AutoRest.TestServerLowLevel.Tests/dpg-customization.cs
+++ b/test/AutoRest.TestServerLowLevel.Tests/dpg-customization.cs
@@ -103,7 +103,7 @@ namespace AutoRest.TestServer.Tests
             CollectionAssert.IsEmpty(diagnosticListener.Scopes);
 
             await result.WaitForCompletionAsync();
-            diagnosticListener.AssertAndRemoveScope("DPGClient.Lro.WaitForCompletionResponse");
+            diagnosticListener.AssertAndRemoveScope("DPGClient.Lro.WaitForCompletion");
             CollectionAssert.IsEmpty(diagnosticListener.Scopes);
 
             JsonData responseBody = JsonData.FromBytes(result.Value.ToMemory());
@@ -121,7 +121,7 @@ namespace AutoRest.TestServer.Tests
             CollectionAssert.IsEmpty(diagnosticListener.Scopes);
 
             await lro.WaitForCompletionAsync();
-            diagnosticListener.AssertAndRemoveScope("DPGClient.LroValue.WaitForCompletionResponse");
+            diagnosticListener.AssertAndRemoveScope("DPGClient.LroValue.WaitForCompletion");
             CollectionAssert.IsEmpty(diagnosticListener.Scopes);
             Assert.AreEqual("model", $"{lro.Value.Received}");
         });


### PR DESCRIPTION
Continue of https://github.com/Azure/azure-sdk-for-net/pull/29033 
Fix #2236