### PR TITLE
Auto-correct the type of `location` parameter from `string` to `AzureLocatoin` for `CreateResourceIdentifier` method

### DIFF
--- a/eng/DownloadSharedSource.ps1
+++ b/eng/DownloadSharedSource.ps1
@@ -15,7 +15,7 @@ function DownloadAll([string[]]$files, [string]$baseUrl, [string]$downloadPath)
 $downloadPath = Resolve-Path (Join-Path $PSScriptRoot '..' 'src' 'assets' 'Azure.Core.Shared')
 Get-ChildItem $downloadPath -Filter *.cs | Remove-Item;
 $files = @('AsyncLockWithValue.cs', 'ClientDiagnostics.cs', 'DiagnosticScope.cs', 'DiagnosticScopeFactory.cs', 'ContentTypeUtilities.cs', 'HttpMessageSanitizer.cs',
-    'OperationInternalBase.cs', 'OperationInternal.cs', 'OperationInternalOfT.cs', 'TaskExtensions.cs', 'Argument.cs', 'Multipart/MultipartFormDataContent.cs',
+    'OperationInternalBase.cs', 'OperationInternal.cs', 'VoidValue.cs', 'OperationInternalOfT.cs', 'TaskExtensions.cs', 'Argument.cs', 'Multipart/MultipartFormDataContent.cs',
     'Multipart/MultipartContent.cs', 'AzureKeyCredentialPolicy.cs', 'AppContextSwitchHelper.cs',
     'ConstantDelayStrategy.cs', 'DelayStrategy.cs', 'ExponentialDelayStrategy.cs', 'OperationPoller.cs', 'RetryAfterDelayStrategy.cs',
     'ForwardsClientCallsAttribute.cs', 'AsyncLockWithValue.cs')

--- a/samples/Azure.Management.Storage/Generated/BlobInventoryPolicyResource.cs
+++ b/samples/Azure.Management.Storage/Generated/BlobInventoryPolicyResource.cs
@@ -26,7 +26,7 @@ namespace Azure.Management.Storage
     public partial class BlobInventoryPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BlobInventoryPolicyResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string blobInventoryPolicyName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, BlobInventoryPolicyName blobInventoryPolicyName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies/{blobInventoryPolicyName}";
             return new ResourceIdentifier(resourceId);

--- a/samples/Azure.Management.Storage/Generated/DeletedAccountResource.cs
+++ b/samples/Azure.Management.Storage/Generated/DeletedAccountResource.cs
@@ -26,7 +26,7 @@ namespace Azure.Management.Storage
     public partial class DeletedAccountResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeletedAccountResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string deletedAccountName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string deletedAccountName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/deletedAccounts/{deletedAccountName}";
             return new ResourceIdentifier(resourceId);

--- a/samples/Azure.Management.Storage/Generated/ManagementPolicyResource.cs
+++ b/samples/Azure.Management.Storage/Generated/ManagementPolicyResource.cs
@@ -26,7 +26,7 @@ namespace Azure.Management.Storage
     public partial class ManagementPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ManagementPolicyResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string managementPolicyName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, ManagementPolicyName managementPolicyName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}";
             return new ResourceIdentifier(resourceId);

--- a/samples/Azure.Management.Storage/Generated/Models/ManagementPolicyName.cs
+++ b/samples/Azure.Management.Storage/Generated/Models/ManagementPolicyName.cs
@@ -11,7 +11,7 @@ using System.ComponentModel;
 namespace Azure.Management.Storage.Models
 {
     /// <summary> The ManagementPolicyName. </summary>
-    internal readonly partial struct ManagementPolicyName : IEquatable<ManagementPolicyName>
+    public readonly partial struct ManagementPolicyName : IEquatable<ManagementPolicyName>
     {
         private readonly string _value;
 

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageResource.cs
@@ -27,7 +27,7 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string publisherName, string type, string version)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";
             return new ResourceIdentifier(resourceId);

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceWriter.cs
@@ -39,10 +39,12 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
         private void WriteCreateResourceIdentifierMethods()
         {
+            var method = This.CreateResourceIdentifierMethodSignature();
+            _writer.WriteXmlDocumentationSummary($"{method.Description}");
+            var parameterList = string.Join(", ", method.Parameters.Select(param => $"{param.Type.Name} {param.Name}"));
+
             var requestPath = This.RequestPath;
-            _writer.WriteXmlDocumentationSummary($"Generate the resource identifier of a <see cref=\"{This.Type}\"/> instance.");
-            var parameterList = string.Join(", ", requestPath.Where(segment => segment.IsReference).Select(segment => $"string {segment.ReferenceName}"));
-            using (_writer.Scope($"public static {typeof(Azure.Core.ResourceIdentifier)} CreateResourceIdentifier({parameterList})"))
+            using (_writer.Scope($"public static {method.ReturnType?.Name} {method.Name}({parameterList})"))
             {
                 // Storage has inconsistent definitions:
                 // - https://github.com/Azure/azure-rest-api-specs/blob/719b74f77b92eb1ec3814be6c4488bcf6b651733/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json#L58
@@ -50,7 +52,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 // so here we have to use `Seqment.BuildSerializedSegments` instead of `RequestPath.SerializedPath` which could be from `RestClientMethod.Operation.GetHttpPath`
                 // If first segment is "{var}", then we should not add leading "/". Instead, we should let callers to specify, e.g. "{scope}/providers/Microsoft.Resources/..." v.s. "/subscriptions/{subscriptionId}/..."
                 _writer.Line($"var resourceId = $\"{Segment.BuildSerializedSegments(requestPath, !requestPath.Any() || requestPath.First().IsConstant)}\";");
-                _writer.Line($"return new {typeof(Azure.Core.ResourceIdentifier)}(resourceId);");
+                _writer.Line($"return new {method.ReturnType?.Name}(resourceId);");
             }
         }
 

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -388,6 +388,18 @@ namespace AutoRest.CSharp.Mgmt.Output
             return FormattableStringHelpers.Join(lines, "\r\n");
         }
 
+        private static Type? ToFormatTypeByName(string? name) => name switch
+        {
+            "location" => typeof(AzureLocation),
+            _ => null
+        };
+
+        private Parameter CreateResourceIdentifierParameter(Segment segment)
+        {
+            CSharpType ctype = ToFormatTypeByName(segment.Reference.Name) is Type type ? new CSharpType(type, false) : segment.Reference.Type;
+            return new Parameter(segment.Reference.Name, null, ctype, null, ValidationType.AssertNotNull, null);
+        }
+
         /// <summary>
         /// Returns the different method signature for different base path of this resource
         /// </summary>
@@ -400,7 +412,7 @@ namespace AutoRest.CSharp.Mgmt.Output
                     Modifiers: Public | Static,
                     ReturnType: typeof(ResourceIdentifier),
                     ReturnDescription: null,
-                    Parameters: RequestPath.Where(segment => segment.IsReference).Select(segment => new Parameter(segment.Reference.Name, null, segment.Reference.Type, null, ValidationType.AssertNotNull, null)).ToArray());
+                    Parameters: RequestPath.Where(segment => segment.IsReference).Select(segment => CreateResourceIdentifierParameter(segment)).ToArray());
         }
 
         public FormattableString ResourceDataIdExpression(FormattableString dataExpression)

--- a/src/assets/Azure.Core.Shared/OperationInternal.cs
+++ b/src/assets/Azure.Core.Shared/OperationInternal.cs
@@ -110,8 +110,6 @@ namespace Azure.Core
         protected override async ValueTask<Response> UpdateStatusAsync(bool async, CancellationToken cancellationToken) =>
             async ? await _internalOperation.UpdateStatusAsync(cancellationToken).ConfigureAwait(false) : _internalOperation.UpdateStatus(cancellationToken);
 
-        private readonly struct VoidValue { }
-
         // Wrapper type that converts OperationState to OperationState<T> and can be passed to `OperationInternal<T>` constructor.
         private class OperationToOperationOfTProxy : IOperation<VoidValue>
         {

--- a/src/assets/Azure.Core.Shared/VoidValue.cs
+++ b/src/assets/Azure.Core.Shared/VoidValue.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json;
+
+namespace Azure.Core
+{
+    internal readonly struct VoidValue { }
+}

--- a/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/TestProjectTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.ComponentModel;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -732,13 +733,33 @@ namespace AutoRest.TestServer.Tests.Mgmt.TestProjects
             }
         }
 
+        private object? GetFirstVauleFromExtensibleEnumType(Type type)
+        {
+            foreach (FieldInfo f in type.GetRuntimeFields())
+            {
+                if (f.IsStatic && f.FieldType == type)
+                    return f.GetValue(null);
+            }
+            // Empty? should throw exception
+            return null;
+        }
+
         private ResourceIdentifier GetSampleResourceId(Type operation)
         {
             var createIdMethod = operation.GetMethod("CreateResourceIdentifier", BindingFlags.Static | BindingFlags.Public);
-            List<string> keys = new List<string>();
+            List<object> keys = new List<object>();
             foreach (var p in createIdMethod.GetParameters())
             {
-                keys.Add(GetSampleKey(p.Name));
+                if (p.ParameterType == typeof(string))
+                {
+                    keys.Add(GetSampleKey(p.Name));
+                }
+                else
+                {
+                    object val = GetFirstVauleFromExtensibleEnumType(p.ParameterType);
+                    Assert.IsNotNull(val);
+                    keys.Add(val);
+                }
             }
             return createIdMethod.Invoke(null, keys.ToArray()) as ResourceIdentifier;
         }

--- a/test/TestProjects/MgmtCollectionParent/Generated/OrderResource.cs
+++ b/test/TestProjects/MgmtCollectionParent/Generated/OrderResource.cs
@@ -26,7 +26,7 @@ namespace MgmtCollectionParent
     public partial class OrderResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="OrderResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string location, string orderName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, AzureLocation location, string orderName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/locations/{location}/orders/{orderName}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/SharedGalleryResource.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/SharedGalleryResource.cs
@@ -27,7 +27,7 @@ namespace MgmtHierarchicalNonResource
     public partial class SharedGalleryResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SharedGalleryResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string galleryUniqueName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string galleryUniqueName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/sharedGalleries/{galleryUniqueName}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtKeyvault/src/Generated/DeletedManagedHsmResource.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/DeletedManagedHsmResource.cs
@@ -26,7 +26,7 @@ namespace MgmtKeyvault
     public partial class DeletedManagedHsmResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeletedManagedHsmResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string name)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedManagedHSMs/{name}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtKeyvault/src/Generated/DeletedVaultResource.cs
+++ b/test/TestProjects/MgmtKeyvault/src/Generated/DeletedVaultResource.cs
@@ -26,7 +26,7 @@ namespace MgmtKeyvault
     public partial class DeletedVaultResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeletedVaultResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string vaultName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string vaultName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/BarResource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/BarResource.cs
@@ -28,7 +28,7 @@ namespace MgmtNonStringPathVariable
     public partial class BarResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BarResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string barName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, int barName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/bars/{barName}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/FakeResource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/FakeResource.cs
@@ -28,7 +28,7 @@ namespace MgmtNonStringPathVariable
     public partial class FakeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string fakeName)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, FakeNameAsEnum fakeName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/fakes/{fakeName}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtParamOrdering/Generated/VirtualMachineExtensionImageResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/VirtualMachineExtensionImageResource.cs
@@ -27,7 +27,7 @@ namespace MgmtParamOrdering
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string publisherName, string type, string version)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";
             return new ResourceIdentifier(resourceId);

--- a/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageResource.cs
+++ b/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageResource.cs
@@ -27,7 +27,7 @@ namespace MgmtParent
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
-        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string location, string publisherName, string type, string version)
+        public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";
             return new ResourceIdentifier(resourceId);


### PR DESCRIPTION
Change on sdk side is https://github.com/Azure/azure-sdk-for-net/pull/29153