### PR TITLE
Limit the scope of the uri type change

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Decorator/Transformer/FrameworkTypeUpdater.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/Transformer/FrameworkTypeUpdater.cs
@@ -24,9 +24,9 @@ namespace AutoRest.CSharp.Mgmt.Decorator.Transformer
 
                 foreach (var property in objSchema.Properties)
                 {
-                    if (property.CSharpName().EndsWith("Uri", StringComparison.Ordinal))
+                    if (property.CSharpName().EndsWith("Uri", StringComparison.Ordinal) && property.Schema.Type.Equals(AllSchemaTypes.String))
                         property.Schema.Type = AllSchemaTypes.Uri;
-                    if (property.CSharpName().EndsWith("Uris", StringComparison.Ordinal) && property.Schema is ArraySchema arraySchema)
+                    if (property.CSharpName().EndsWith("Uris", StringComparison.Ordinal) && property.Schema is ArraySchema arraySchema && arraySchema.ElementType.Type.Equals(AllSchemaTypes.String))
                         arraySchema.ElementType.Type = AllSchemaTypes.Uri;
                     if (property.CSharpName().EndsWith("Duration", StringComparison.Ordinal) && property.Schema.Type == AllSchemaTypes.String && property.Schema.Extensions?.Format == null)
                         throw new InvalidOperationException($"The {property.Language.Default.Name} property of {objSchema.Name} ends with \"Duration\" but does not use the duration format to be generated as TimeSpan type. Add \"format\": \"duration\" with directive in autorest.md for the property if it's ISO 8601 format like P1DT2H59M59S. Add \"x-ms-format\": \"{XMsFormat.DurationConstant}\" if it's the constant format like 1.2:59:59.5000000. If the property does not conform to a TimeSpan format, please use \"x-ms-client-name\" to rename the property for the client.");


### PR DESCRIPTION
# Description
<i>Previously we will change the schema type to `Uri` if the property's name ends with `Uri`. This works well when the property is a string. However, there are some edge cases that a property uses Uri as the name suffix but is defined as `Object` type. Considering that all the properties marked as `Object` type will share the same schema, this change will result in that all the properties' type is changed to `Uri`, which is unexpected and wrong.</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first