### PR TITLE
New option `skip-serialization-format-xml` to skip Xml format serialization / deserialization

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Communication/StandaloneGeneratorRunner.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Communication/StandaloneGeneratorRunner.cs
@@ -154,6 +154,7 @@ namespace AutoRest.CSharp.AutoRest.Communication
                 ReadOption(root, Configuration.Options.SkipCSProjPackageReference),
                 ReadOption(root, Configuration.Options.Generation1ConvenienceClient),
                 ReadOption(root, Configuration.Options.SingleTopLevelClient),
+                ReadOption(root, Configuration.Options.SkipSerializationFormatXml),
                 ReadStringOption(root, Configuration.Options.ProjectFolder),
                 protocolMethods,
                 MgmtConfiguration.LoadConfiguration(root)

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
@@ -27,9 +27,10 @@ namespace AutoRest.CSharp.Input
             public const string AttachDebuggerFormat = "{0}.attach";
             public const string ProjectFolder = "project-folder";
             public const string ProtocolMethodList = "protocol-method-list";
+            public const string SkipSerializationFormatXml= "skip-serialization-format-xml";
         }
 
-        public static void Initialize(string outputFolder, string? ns, string? name, string[] sharedSourceFolders, bool saveInputs, bool azureArm, bool publicClients, bool modelNamespace, bool headAsBoolean, bool skipCSProjPackageReference, bool generation1ConvenienceClient, bool singleTopLevelClient, string projectFolder, string[] protocolMethodList, MgmtConfiguration mgmtConfiguration)
+        public static void Initialize(string outputFolder, string? ns, string? name, string[] sharedSourceFolders, bool saveInputs, bool azureArm, bool publicClients, bool modelNamespace, bool headAsBoolean, bool skipCSProjPackageReference, bool generation1ConvenienceClient, bool singleTopLevelClient, bool skipSerializationFormatXml, string projectFolder, string[] protocolMethodList, MgmtConfiguration mgmtConfiguration)
         {
             _outputFolder = outputFolder;
             Namespace = ns;
@@ -45,6 +46,7 @@ namespace AutoRest.CSharp.Input
             SingleTopLevelClient = singleTopLevelClient;
             _projectFolder = Path.IsPathRooted(projectFolder) ? Path.GetRelativePath(outputFolder, projectFolder) : projectFolder;
             _protocolMethodList = protocolMethodList;
+            SkipSerializationFormatXml = skipSerializationFormatXml;
             _mgmtConfiguration = mgmtConfiguration;
         }
 
@@ -63,6 +65,7 @@ namespace AutoRest.CSharp.Input
         public static bool SkipCSProjPackageReference { get; private set; }
         public static bool Generation1ConvenienceClient { get; private set; }
         public static bool SingleTopLevelClient { get; private set; }
+        public static bool SkipSerializationFormatXml { get; private set; }
 
         private static string[]? _protocolMethodList;
         public static string[] ProtocolMethodList => _protocolMethodList ?? throw new InvalidOperationException("Configuration has not been initialized");
@@ -88,6 +91,7 @@ namespace AutoRest.CSharp.Input
                 skipCSProjPackageReference: GetOptionValue(autoRest, Options.SkipCSProjPackageReference),
                 generation1ConvenienceClient: GetOptionValue(autoRest, Options.Generation1ConvenienceClient),
                 singleTopLevelClient: GetOptionValue(autoRest, Options.SingleTopLevelClient),
+                skipSerializationFormatXml: GetOptionValue(autoRest, Options.SkipSerializationFormatXml),
                 projectFolder: GetOptionStringValue(autoRest, Options.ProjectFolder, TrimFileSuffix),
                 protocolMethodList: autoRest.GetValue<string[]?>(Options.ProtocolMethodList).GetAwaiter().GetResult() ?? Array.Empty<string>(),
                 mgmtConfiguration: MgmtConfiguration.GetConfiguration(autoRest)
@@ -118,6 +122,8 @@ namespace AutoRest.CSharp.Input
                 case Options.Generation1ConvenienceClient:
                     return false;
                 case Options.SingleTopLevelClient:
+                    return false;
+                case Options.SkipSerializationFormatXml:
                     return false;
                 default:
                     return null;

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -322,6 +322,8 @@ namespace AutoRest.CSharp.Output.Models.Types
         private ObjectSerialization[] BuildSerializations()
         {
             var formats = ObjectSchema.SerializationFormats;
+            if (Configuration.SkipSerializationFormatXml)
+                formats.Remove(KnownMediaType.Xml);
 
             if (ObjectSchema.Extensions != null)
             {

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -300,7 +300,14 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
 
         public OperationSet GetOperationSet(string requestPath) => RawRequestPathToOperationSets[requestPath];
 
-        public RestClientMethod GetRestClientMethod(Operation operation) => RestClientMethods[operation];
+        public RestClientMethod GetRestClientMethod(Operation operation)
+        {
+            if (RestClientMethods.TryGetValue(operation, out var restClientMethod))
+            {
+                return restClientMethod;
+            }
+            throw new Exception($"The {operation.OperationId} method does not exist.");
+        }
 
         public RequestPath GetRequestPath(Operation operation) => OperationsToRequestPaths[operation];
 


### PR DESCRIPTION
Related to https://github.com/Azure/autorest.csharp/issues/1932, not have `xml` is to unblock the ApiManagement.
And confirmed that Java don't support serialization / deserialization for Xml