### PR TITLE
fix(dpg): `ClientOptions.ServiceVersion` should be pascal case

### DIFF
--- a/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClientOptions.cs
+++ b/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.AI.DocumentTranslation
     /// <summary> Client options for DocumentTranslationClient. </summary>
     public partial class DocumentTranslationClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.Vv1_0_Preview_1;
+        private const ServiceVersion LatestVersion = ServiceVersion.V1_0_Preview_1;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "v1.0-preview.1". </summary>
-            Vv1_0_Preview_1 = 1,
+            V1_0_Preview_1 = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.AI.DocumentTranslation
         {
             Version = version switch
             {
-                ServiceVersion.Vv1_0_Preview_1 => "v1.0-preview.1",
+                ServiceVersion.V1_0_Preview_1 => "v1.0-preview.1",
                 _ => throw new NotSupportedException()
             };
         }

--- a/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClientOptions.cs
+++ b/samples/Azure.AI.DocumentTranslation/Generated/DocumentTranslationClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.AI.DocumentTranslation
     /// <summary> Client options for DocumentTranslationClient. </summary>
     public partial class DocumentTranslationClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.Vv1_0_preview_1;
+        private const ServiceVersion LatestVersion = ServiceVersion.Vv1_0_Preview_1;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "v1.0-preview.1". </summary>
-            Vv1_0_preview_1 = 1,
+            Vv1_0_Preview_1 = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.AI.DocumentTranslation
         {
             Version = version switch
             {
-                ServiceVersion.Vv1_0_preview_1 => "v1.0-preview.1",
+                ServiceVersion.Vv1_0_Preview_1 => "v1.0-preview.1",
                 _ => throw new NotSupportedException()
             };
         }

--- a/samples/Azure.Analytics.Purview.Account/Generated/PurviewAccountsClientOptions.cs
+++ b/samples/Azure.Analytics.Purview.Account/Generated/PurviewAccountsClientOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Analytics.Purview.Account
     /// <summary> Client options for PurviewAccountsClient. </summary>
     public partial class PurviewAccountsClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2019_11_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2019-11-01-preview". </summary>
-            V2019_11_01_preview = 1,
+            V2019_11_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace Azure.Analytics.Purview.Account
         {
             Version = version switch
             {
-                ServiceVersion.V2019_11_01_preview => "2019-11-01-preview",
+                ServiceVersion.V2019_11_01_Preview => "2019-11-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/samples/CognitiveServices.TextAnalytics/Generated/CognitiveServicesTextAnalyticsClientOptions.cs
+++ b/samples/CognitiveServices.TextAnalytics/Generated/CognitiveServicesTextAnalyticsClientOptions.cs
@@ -13,13 +13,13 @@ namespace CognitiveServices.TextAnalytics
     /// <summary> Client options for CognitiveServicesTextAnalyticsClient. </summary>
     public partial class CognitiveServicesTextAnalyticsClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.Vv3_0;
+        private const ServiceVersion LatestVersion = ServiceVersion.V3_0;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "v3.0". </summary>
-            Vv3_0 = 1,
+            V3_0 = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace CognitiveServices.TextAnalytics
         {
             Version = version switch
             {
-                ServiceVersion.Vv3_0 => "v3.0",
+                ServiceVersion.V3_0 => "v3.0",
                 _ => throw new NotSupportedException()
             };
         }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ClientOptionsTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ClientOptionsTypeProvider.cs
@@ -5,14 +5,16 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 
 namespace AutoRest.CSharp.Output.Models.Types
 {
     internal sealed class ClientOptionsTypeProvider : TypeProvider
     {
-        private static TextInfo TextInfo = new CultureInfo("en-us", false).TextInfo;
+        private static TextInfo TextInfo = CultureInfo.InvariantCulture.TextInfo;
+
         public FormattableString Description { get; }
-        public IReadOnlyList<ApiVersion> ApiVersions { get;}
+        public IReadOnlyList<ApiVersion> ApiVersions { get; }
         protected override string DefaultName { get; }
         protected override string DefaultAccessibility { get; }
 
@@ -34,12 +36,17 @@ namespace AutoRest.CSharp.Output.Models.Types
                 .Select(v => v.Version)
                 .Distinct()
                 .OrderBy(v => v)
-                .Select((v, i) => new ApiVersion(ToVersionProperty(v), $"Service version \"{v}\"", i + 1, v))
+                .Select((v, i) => new ApiVersion(NormalizeVersion(v), $"Service version \"{v}\"", i + 1, v))
                 .ToArray();
         }
 
         public record ApiVersion(string Name, string Description, int Value, string StringValue);
 
-        private static string ToVersionProperty(string s) => TextInfo.ToTitleCase("V" + s.Replace(".", "_").Replace('-', '_'));
+        internal static string NormalizeVersion(string version) =>
+            TextInfo.ToTitleCase(new StringBuilder("V")
+                .Append(version.StartsWith("v", true, CultureInfo.InvariantCulture) ? version.Substring(1) : version)
+                .Replace('-', '_')
+                .Replace('.', '_')
+                .ToString());
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ClientOptionsTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ClientOptionsTypeProvider.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace AutoRest.CSharp.Output.Models.Types
 {
     internal sealed class ClientOptionsTypeProvider : TypeProvider
     {
+        private static TextInfo TextInfo = new CultureInfo("en-us", false).TextInfo;
         public FormattableString Description { get; }
         public IReadOnlyList<ApiVersion> ApiVersions { get;}
         protected override string DefaultName { get; }
@@ -38,6 +40,6 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         public record ApiVersion(string Name, string Description, int Value, string StringValue);
 
-        private static string ToVersionProperty(string s) => "V" + s.Replace(".", "_").Replace('-', '_');
+        private static string ToVersionProperty(string s) => TextInfo.ToTitleCase("V" + s.Replace(".", "_").Replace('-', '_'));
     }
 }

--- a/test/AutoRest.TestServer.Tests/Common/Output/Models/Types/ClientOptionsTypeProviderTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/Output/Models/Types/ClientOptionsTypeProviderTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+using AutoRest.CSharp.Output.Models.Types;
+
+namespace AutoRest.CSharp.Output.Models.Types
+{
+    public class ClientOptionsTypeProviderTests
+    {
+        [TestCase("0.1", "V0_1")]
+        [TestCase("1.0.0", "V1_0_0")]
+        [TestCase("1.0.0.1", "V1_0_0_1")]
+        [TestCase("1.0.0.1-beta1", "V1_0_0_1_Beta1")]
+        [TestCase("1.0.0.1-beta-1", "V1_0_0_1_Beta_1")]
+        [TestCase("Version-1.0.0.1-beta-1", "Version_1_0_0_1_Beta_1")]
+        [TestCase("version-1.0.0.1-beta.1", "Version_1_0_0_1_Beta_1")]
+        [TestCase("version.1.0.0.1-beta-1", "Version_1_0_0_1_Beta_1")]
+        [TestCase("1.0.0.1-beta-1", "V1_0_0_1_Beta_1")]
+        [TestCase("2021-06-01", "V2021_06_01")]
+        [TestCase("2021-06", "V2021_06")]
+        [TestCase("2021-06-01-beta-1", "V2021_06_01_Beta_1")]
+        [TestCase("2021-06-01-preview2", "V2021_06_01_Preview2")]
+        [TestCase("v2021-06-01", "V2021_06_01")]
+        [TestCase("V2021-06-01-preview", "V2021_06_01_Preview")]
+        [TestCase("Ver2021-06-01-preview", "Ver2021_06_01_Preview")]
+        [TestCase("Ver-2021-06-01-preview", "Ver_2021_06_01_Preview")]
+        [TestCase("Ver.2021-06-01-preview", "Ver_2021_06_01_Preview")]
+        public void NormalizeVersion(string input, string expected)
+        {
+            Assert.AreEqual(expected, ClientOptionsTypeProvider.NormalizeVersion(input));
+        }
+    }
+
+}

--- a/test/TestProjects/BodyAndPath-LowLevel/Generated/BodyAndPathClientOptions.cs
+++ b/test/TestProjects/BodyAndPath-LowLevel/Generated/BodyAndPathClientOptions.cs
@@ -13,13 +13,13 @@ namespace BodyAndPath_LowLevel
     /// <summary> Client options for BodyAndPathClient. </summary>
     public partial class BodyAndPathClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2014_04_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2014_04_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2014-04-01-preview". </summary>
-            V2014_04_01_preview = 1,
+            V2014_04_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace BodyAndPath_LowLevel
         {
             Version = version switch
             {
-                ServiceVersion.V2014_04_01_preview => "2014-04-01-preview",
+                ServiceVersion.V2014_04_01_Preview => "2014-04-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjects/azure-special-properties/Generated/AutoRestAzureSpecialParametersTestClientOptions.cs
+++ b/test/TestServerProjects/azure-special-properties/Generated/AutoRestAzureSpecialParametersTestClientOptions.cs
@@ -13,13 +13,13 @@ namespace azure_special_properties
     /// <summary> Client options for AutoRestAzureSpecialParametersTestClient. </summary>
     public partial class AutoRestAzureSpecialParametersTestClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2015_07_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2015_07_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2015-07-01-preview". </summary>
-            V2015_07_01_preview = 1,
+            V2015_07_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace azure_special_properties
         {
             Version = version switch
             {
-                ServiceVersion.V2015_07_01_preview => "2015-07-01-preview",
+                ServiceVersion.V2015_07_01_Preview => "2015-07-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjects/media_types/Generated/MediaTypesClientOptions.cs
+++ b/test/TestServerProjects/media_types/Generated/MediaTypesClientOptions.cs
@@ -13,13 +13,13 @@ namespace media_types
     /// <summary> Client options for MediaTypesClient. </summary>
     public partial class MediaTypesClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2_0_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2_0_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2.0-preview". </summary>
-            V2_0_preview = 1,
+            V2_0_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace media_types
         {
             Version = version switch
             {
-                ServiceVersion.V2_0_preview => "2.0-preview",
+                ServiceVersion.V2_0_Preview => "2.0-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjects/non-string-enum/Generated/NonStringEnumsClientOptions.cs
+++ b/test/TestServerProjects/non-string-enum/Generated/NonStringEnumsClientOptions.cs
@@ -13,13 +13,13 @@ namespace non_string_enum
     /// <summary> Client options for NonStringEnumsClient. </summary>
     public partial class NonStringEnumsClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2_0_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2_0_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2.0-preview". </summary>
-            V2_0_preview = 1,
+            V2_0_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace non_string_enum
         {
             Version = version switch
             {
-                ServiceVersion.V2_0_preview => "2.0-preview",
+                ServiceVersion.V2_0_Preview => "2.0-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjects/subscriptionId-apiVersion/Generated/MicrosoftAzureTestUrlClientOptions.cs
+++ b/test/TestServerProjects/subscriptionId-apiVersion/Generated/MicrosoftAzureTestUrlClientOptions.cs
@@ -13,13 +13,13 @@ namespace subscriptionId_apiVersion
     /// <summary> Client options for MicrosoftAzureTestUrlClient. </summary>
     public partial class MicrosoftAzureTestUrlClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2014_04_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2014_04_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2014-04-01-preview". </summary>
-            V2014_04_01_preview = 1,
+            V2014_04_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace subscriptionId_apiVersion
         {
             Version = version switch
             {
-                ServiceVersion.V2014_04_01_preview => "2014-04-01-preview",
+                ServiceVersion.V2014_04_01_Preview => "2014-04-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjectsLowLevel/media_types/Generated/MediaTypesClientOptions.cs
+++ b/test/TestServerProjectsLowLevel/media_types/Generated/MediaTypesClientOptions.cs
@@ -13,13 +13,13 @@ namespace media_types_LowLevel
     /// <summary> Client options for MediaTypesClient. </summary>
     public partial class MediaTypesClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2_0_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2_0_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2.0-preview". </summary>
-            V2_0_preview = 1,
+            V2_0_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace media_types_LowLevel
         {
             Version = version switch
             {
-                ServiceVersion.V2_0_preview => "2.0-preview",
+                ServiceVersion.V2_0_Preview => "2.0-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjectsLowLevel/security-aad/Generated/AutorestSecurityAadClientOptions.cs
+++ b/test/TestServerProjectsLowLevel/security-aad/Generated/AutorestSecurityAadClientOptions.cs
@@ -13,13 +13,13 @@ namespace security_aad_LowLevel
     /// <summary> Client options for AutorestSecurityAadClient. </summary>
     public partial class AutorestSecurityAadClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2022-03-01-preview". </summary>
-            V2022_03_01_preview = 1,
+            V2022_03_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace security_aad_LowLevel
         {
             Version = version switch
             {
-                ServiceVersion.V2022_03_01_preview => "2022-03-01-preview",
+                ServiceVersion.V2022_03_01_Preview => "2022-03-01-preview",
                 _ => throw new NotSupportedException()
             };
         }

--- a/test/TestServerProjectsLowLevel/security-key/Generated/AutorestSecurityKeyClientOptions.cs
+++ b/test/TestServerProjectsLowLevel/security-key/Generated/AutorestSecurityKeyClientOptions.cs
@@ -13,13 +13,13 @@ namespace security_key_LowLevel
     /// <summary> Client options for AutorestSecurityKeyClient. </summary>
     public partial class AutorestSecurityKeyClientOptions : ClientOptions
     {
-        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2022_03_01_Preview;
 
         /// <summary> The version of the service to use. </summary>
         public enum ServiceVersion
         {
             /// <summary> Service version "2022-03-01-preview". </summary>
-            V2022_03_01_preview = 1,
+            V2022_03_01_Preview = 1,
         }
 
         internal string Version { get; }
@@ -29,7 +29,7 @@ namespace security_key_LowLevel
         {
             Version = version switch
             {
-                ServiceVersion.V2022_03_01_preview => "2022-03-01-preview",
+                ServiceVersion.V2022_03_01_Preview => "2022-03-01-preview",
                 _ => throw new NotSupportedException()
             };
         }


### PR DESCRIPTION
# Description

For `ApiVersion` like `2020-10-01-preview`, the generator right now generates `ServiceVersion` like `V2020_10_01_preview` which will trigger Azure SDk error AZC0016 because not all nouns in the name are upper case.
This commit will fix this issue by invoking `TextInfo.ToTitleCase` which will make sure the name is in pascal case.

Fix #1524

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first