### PR TITLE
Make the serialization constructor of TypeRefrenceType protected

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -150,7 +150,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
             return new ObjectTypeConstructor(
                 Type.Name,
-                IsAbstract ? Protected : Internal,
+                (IsAbstract || ObjectSchema?.Extensions?.MgmtTypeReferenceType == true) ? Protected : Internal,
                 serializationConstructorParameters.ToArray(),
                 serializationInitializers.ToArray(),
                 baseSerializationCtor

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -72,6 +72,10 @@ namespace AutoRest.CSharp.Output.Models.Types
             ObjectSchema.Extensions != null &&
             ObjectSchema.Extensions.MgmtReferenceType;
 
+        public bool IsInheritableCommonType => ObjectSchema != null &&
+            ObjectSchema.Extensions != null &&
+            (ObjectSchema.Extensions.MgmtReferenceType || ObjectSchema.Extensions.MgmtTypeReferenceType);
+
         public override ObjectTypeProperty? AdditionalPropertiesProperty
         {
             get
@@ -150,7 +154,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
             return new ObjectTypeConstructor(
                 Type.Name,
-                (IsAbstract || ObjectSchema?.Extensions?.MgmtTypeReferenceType == true) ? Protected : Internal,
+                IsInheritableCommonType ? Protected : Internal,
                 serializationConstructorParameters.ToArray(),
                 serializationInitializers.ToArray(),
                 baseSerializationCtor

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpoint.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpoint.cs
@@ -22,7 +22,7 @@ namespace Azure.ResourceManager.Fake.Models
         /// <summary> Initializes a new instance of PrivateEndpoint. </summary>
         /// <param name="id"> The ARM identifier for Private Endpoint. </param>
         [SerializationConstructor]
-        internal PrivateEndpoint(ResourceIdentifier id)
+        protected PrivateEndpoint(ResourceIdentifier id)
         {
             Id = id;
         }

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionData.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionData.cs
@@ -29,7 +29,7 @@ namespace Azure.ResourceManager.Fake.Models
         /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
         /// <param name="provisioningState"> The provisioning state of the private endpoint connection resource. </param>
         [SerializationConstructor]
-        internal PrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, ResourceManager.Models.SystemData systemData, PrivateEndpoint privateEndpoint, ReferenceTypesPrivateLinkServiceConnectionState connectionState, ReferenceTypesPrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
+        protected PrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, ResourceManager.Models.SystemData systemData, PrivateEndpoint privateEndpoint, ReferenceTypesPrivateLinkServiceConnectionState connectionState, ReferenceTypesPrivateEndpointConnectionProvisioningState? provisioningState) : base(id, name, resourceType, systemData)
         {
             PrivateEndpoint = privateEndpoint;
             ConnectionState = connectionState;

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionList.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateEndpointConnectionList.cs
@@ -24,7 +24,7 @@ namespace Azure.ResourceManager.Fake.Models
         /// <summary> Initializes a new instance of PrivateEndpointConnectionList. </summary>
         /// <param name="value"> Array of private endpoint connections. </param>
         [SerializationConstructor]
-        internal PrivateEndpointConnectionList(IReadOnlyList<PrivateEndpointConnectionData> value)
+        protected PrivateEndpointConnectionList(IReadOnlyList<PrivateEndpointConnectionData> value)
         {
             Value = value;
         }

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateLinkResourceData.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateLinkResourceData.cs
@@ -32,7 +32,7 @@ namespace Azure.ResourceManager.Fake.Models
         /// <param name="requiredMembers"> The private link resource required member names. </param>
         /// <param name="requiredZoneNames"> The private link resource Private link DNS zone name. </param>
         [SerializationConstructor]
-        internal PrivateLinkResourceData(ResourceIdentifier id, string name, ResourceType resourceType, ResourceManager.Models.SystemData systemData, string groupId, IReadOnlyList<string> requiredMembers, IReadOnlyList<string> requiredZoneNames) : base(id, name, resourceType, systemData)
+        protected PrivateLinkResourceData(ResourceIdentifier id, string name, ResourceType resourceType, ResourceManager.Models.SystemData systemData, string groupId, IReadOnlyList<string> requiredMembers, IReadOnlyList<string> requiredZoneNames) : base(id, name, resourceType, systemData)
         {
             GroupId = groupId;
             RequiredMembers = requiredMembers;

--- a/test/TestProjects/ReferenceTypes/Generated/Models/PrivateLinkResourceList.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/PrivateLinkResourceList.cs
@@ -24,7 +24,7 @@ namespace Azure.ResourceManager.Fake.Models
         /// <summary> Initializes a new instance of PrivateLinkResourceList. </summary>
         /// <param name="value"> Array of private link resources. </param>
         [SerializationConstructor]
-        internal PrivateLinkResourceList(IReadOnlyList<PrivateLinkResourceData> value)
+        protected PrivateLinkResourceList(IReadOnlyList<PrivateLinkResourceData> value)
         {
             Value = value;
         }

--- a/test/TestProjects/ReferenceTypes/Generated/Models/ReferenceTypesPrivateLinkServiceConnectionState.cs
+++ b/test/TestProjects/ReferenceTypes/Generated/Models/ReferenceTypesPrivateLinkServiceConnectionState.cs
@@ -24,7 +24,7 @@ namespace Azure.ResourceManager.Fake.Models
         /// <param name="description"> The reason for approval/rejection of the connection. </param>
         /// <param name="actionsRequired"> A message indicating if changes on the service provider require any updates on the consumer. </param>
         [SerializationConstructor]
-        internal ReferenceTypesPrivateLinkServiceConnectionState(ReferenceTypesPrivateEndpointServiceConnectionStatus? status, string description, string actionsRequired)
+        protected ReferenceTypesPrivateLinkServiceConnectionState(ReferenceTypesPrivateEndpointServiceConnectionStatus? status, string description, string actionsRequired)
         {
             Status = status;
             Description = description;


### PR DESCRIPTION
# Description
A `TypeReferenceType` is supposed to be used in any occasions, such as parameter, property, base type, response type. When used as base type, the `internal` serialization constructor will cause a child type from some other RP package unable to access it. This PR changes the  serialization constructor of `TypeRefrenceType` to be `protected` to solve the issue.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first