### PR TITLE
Fix #2428: Exception thrown when Writing null value in Dictionary

### DIFF
--- a/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
+++ b/src/assets/Generator.Shared/Utf8JsonWriterExtensions.cs
@@ -26,11 +26,6 @@ namespace Azure.Core
         public static void WriteStringValue(this Utf8JsonWriter writer, char value) =>
             writer.WriteStringValue(value.ToString(CultureInfo.InvariantCulture));
 
-        public static void WriteObjectValue(this Utf8JsonWriter writer, IUtf8JsonSerializable value)
-        {
-            value.Write(writer);
-        }
-
         public static void WriteNonEmptyArray(this Utf8JsonWriter writer, string name, string[] values)
         {
             if (values.Any())
@@ -75,7 +70,7 @@ namespace Azure.Core
                     writer.WriteNullValue();
                     break;
                 case IUtf8JsonSerializable serializable:
-                    writer.WriteObjectValue(serializable);
+                    serializable.Write(writer);
                     break;
                 case byte[] bytes:
                     writer.WriteBase64StringValue(bytes);

--- a/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
+++ b/test/AutoRest.Shared.Tests/WriterExtensionTests.cs
@@ -74,6 +74,19 @@ namespace Azure.Core.Tests
             Assert.True (content.didWrite);
         }
 
+        [Test]
+        public static void WriteObjectValueNullIUtf8JsonSerializable ()
+        {
+            using MemoryStream stream = new MemoryStream ();
+            using Utf8JsonWriter writer = new Utf8JsonWriter (stream);
+
+            TestSerialize content = null;
+            writer.WriteObjectValue(content);
+
+            writer.Flush();
+            Assert.AreEqual("null", System.Text.Encoding.UTF8.GetString(stream.ToArray()));
+        }
+
         internal class TestSerialize : IUtf8JsonSerializable
         {
             internal bool didWrite = false;


### PR DESCRIPTION
Method in question had the same name as the more general `WriteObjectValue(this Utf8JsonWriter writer, object value)`