### PR TITLE
fix plural resource name issue

### DIFF
--- a/src/AutoRest.CSharp/Common/Utilities/StringExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Utilities/StringExtensions.cs
@@ -22,6 +22,7 @@ namespace AutoRest.CSharp.Utilities
             Vocabularies.Default.AddUncountable("data");
             // "S".Singularize() throws exception, github issue link: https://github.com/Humanizr/Humanizer/issues/1154
             Vocabularies.Default.AddUncountable("S");
+            Vocabularies.Default.AddIrregular("redis", "redis");
         }
 
         public static bool IsNullOrEmpty(this string? text) => String.IsNullOrEmpty(text);

--- a/src/AutoRest.CSharp/Mgmt/Decorator/StringExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/StringExtensions.cs
@@ -29,10 +29,9 @@ namespace AutoRest.CSharp.Mgmt.Decorator
         public static string ResourceNameToPlural(this string resourceName)
         {
             var pluralResourceName = resourceName.LastWordToPlural(false);
-            var singularResourceName = resourceName.LastWordToSingular(false);
-            return pluralResourceName != singularResourceName ?
+            return pluralResourceName != resourceName ?
                 pluralResourceName :
-                $"All{pluralResourceName}";
+                $"All{resourceName}";
         }
 
         /// <summary>

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
@@ -234,7 +234,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             var resourceName = string.Empty;
             if (MgmtContext.Library.GetRestClientMethod(operation).IsListMethod(out _))
             {
-                resourceName = operationGroup.Key.IsNullOrEmpty() ? string.Empty : operationGroup.Key.ResourceNameToPlural();
+                resourceName = operationGroup.Key.IsNullOrEmpty() ? string.Empty : operationGroup.Key.LastWordToSingular().ResourceNameToPlural();
                 var opName = operation.MgmtCSharpName(!resourceName.IsNullOrEmpty());
                 // Remove 'By[Resource]' if the method is put in the [Resource] class. For instance, GetByDatabaseDatabaseColumns now becomes GetDatabaseColumns under Database resource class.
                 if (opName.EndsWith($"By{clientResourceName.LastWordToSingular()}"))

--- a/test/AutoRest.TestServer.Tests/Common/StringExtensionsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/StringExtensionsTests.cs
@@ -25,6 +25,8 @@ namespace AutoRest.CSharp.Utilities.Tests
         [TestCase("dataTip", "dataTips")]
         [TestCase("tipData", "tipDatas")]
         [TestCase("da_ta", "da_tas")]
+        [TestCase("redis", "redis")]
+        [TestCase("redis", "redis", false)]
         public void ValidatePluralize(string noun, string expected, bool inputIsKnownToBeSingle = true)
         {
             var plural = noun.ToPlural(inputIsKnownToBeSingle);
@@ -49,6 +51,8 @@ namespace AutoRest.CSharp.Utilities.Tests
         [TestCase("children", "child")]
         [TestCase("data", "data", false)]
         [TestCase("datas", "data", false)]
+        [TestCase("redis", "redis")]
+        [TestCase("redis", "redis", false)]
         public void ValidateSingularize(string noun, string expected, bool inputIsKnownToBePlural = true)
         {
             var singular = noun.ToSingular(inputIsKnownToBePlural);

--- a/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/MgmtListMethodsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/TestProjects/MgmtListMethodsTests.cs
@@ -84,8 +84,8 @@ namespace AutoRest.TestServer.Tests.Mgmt.TestProjects
         [TestCase("FakeParentCollection", "GetAll", true)]
         [TestCase("FakeParentResource", "GetAll", false)]
 
-        [TestCase("MgmtListMethodsExtensions", "UpdateQuotas", true, typeof(SubscriptionResource))]
-        [TestCase("MgmtListMethodsExtensions", "UpdateQuotas", false, typeof(ResourceGroupResource))]
+        [TestCase("MgmtListMethodsExtensions", "UpdateAllQuota", true, typeof(SubscriptionResource))]
+        [TestCase("MgmtListMethodsExtensions", "UpdateAllQuota", false, typeof(ResourceGroupResource))]
         public void ValidateFakesResourceAsAParentListMethods(string className, string methodName, bool exist, params Type[] parameterTypes)
         {
             ValidateListMethods(className, methodName, exist, parameterTypes);

--- a/test/AutoRest.TestServer.Tests/Mgmt/Unit/StringExtensionsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Mgmt/Unit/StringExtensionsTests.cs
@@ -13,6 +13,7 @@ namespace AutoRest.TestServer.Tests.Mgmt
         [TestCase("MetadataRole", "MetadataRoles")]
         [TestCase("KeyInformation", "AllKeyInformation")]
         [TestCase("RoleMetadata", "AllRoleMetadata")]
+        [TestCase("Redis", "AllRedis")]
         public void ValidateResourceNameToPlural(string resourceName, string expected)
         {
             var result = resourceName.ResourceNameToPlural();

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/ZoneResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/ZoneResource.cs
@@ -271,7 +271,7 @@ namespace MgmtExpandResourceTypes
 
         /// <summary> Gets a collection of RecordSetNsResources in the Zone. </summary>
         /// <returns> An object representing collection of RecordSetNsResources and their operations over a RecordSetNsResource. </returns>
-        public virtual RecordSetNsCollection GetRecordSetNs()
+        public virtual RecordSetNsCollection GetAllRecordSetNs()
         {
             return GetCachedClient(Client => new RecordSetNsCollection(Client, Id));
         }
@@ -287,7 +287,7 @@ namespace MgmtExpandResourceTypes
         [ForwardsClientCalls]
         public virtual async Task<Response<RecordSetNsResource>> GetRecordSetNsAsync(string relativeRecordSetName, CancellationToken cancellationToken = default)
         {
-            return await GetRecordSetNs().GetAsync(relativeRecordSetName, cancellationToken).ConfigureAwait(false);
+            return await GetAllRecordSetNs().GetAsync(relativeRecordSetName, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,7 +301,7 @@ namespace MgmtExpandResourceTypes
         [ForwardsClientCalls]
         public virtual Response<RecordSetNsResource> GetRecordSetNs(string relativeRecordSetName, CancellationToken cancellationToken = default)
         {
-            return GetRecordSetNs().Get(relativeRecordSetName, cancellationToken);
+            return GetAllRecordSetNs().Get(relativeRecordSetName, cancellationToken);
         }
 
         /// <summary> Gets a collection of RecordSetPtrResources in the Zone. </summary>

--- a/test/TestProjects/MgmtListMethods/Generated/Extensions/MgmtListMethodsExtensions.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Extensions/MgmtListMethodsExtensions.cs
@@ -614,12 +614,12 @@ namespace MgmtListMethods
         /// <exception cref="ArgumentException"> <paramref name="location"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ArgumentNullException"> <paramref name="location"/> or <paramref name="content"/> is null. </exception>
         /// <returns> An async collection of <see cref="UpdateWorkspaceQuotas" /> that may take multiple service requests to iterate over. </returns>
-        public static AsyncPageable<UpdateWorkspaceQuotas> UpdateQuotasAsync(this SubscriptionResource subscriptionResource, string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
+        public static AsyncPageable<UpdateWorkspaceQuotas> UpdateAllQuotaAsync(this SubscriptionResource subscriptionResource, string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(location, nameof(location));
             Argument.AssertNotNull(content, nameof(content));
 
-            return GetExtensionClient(subscriptionResource).UpdateQuotasAsync(location, content, cancellationToken);
+            return GetExtensionClient(subscriptionResource).UpdateAllQuotaAsync(location, content, cancellationToken);
         }
 
         /// <summary>
@@ -634,12 +634,12 @@ namespace MgmtListMethods
         /// <exception cref="ArgumentException"> <paramref name="location"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="ArgumentNullException"> <paramref name="location"/> or <paramref name="content"/> is null. </exception>
         /// <returns> A collection of <see cref="UpdateWorkspaceQuotas" /> that may take multiple service requests to iterate over. </returns>
-        public static Pageable<UpdateWorkspaceQuotas> UpdateQuotas(this SubscriptionResource subscriptionResource, string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
+        public static Pageable<UpdateWorkspaceQuotas> UpdateAllQuota(this SubscriptionResource subscriptionResource, string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(location, nameof(location));
             Argument.AssertNotNull(content, nameof(content));
 
-            return GetExtensionClient(subscriptionResource).UpdateQuotas(location, content, cancellationToken);
+            return GetExtensionClient(subscriptionResource).UpdateAllQuota(location, content, cancellationToken);
         }
 
         private static ResourceGroupResourceExtensionClient GetExtensionClient(ResourceGroupResource resourceGroupResource)

--- a/test/TestProjects/MgmtListMethods/Generated/Extensions/SubscriptionResourceExtensionClient.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Extensions/SubscriptionResourceExtensionClient.cs
@@ -994,11 +994,11 @@ namespace MgmtListMethods
         /// <param name="content"> Quota update parameters. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> An async collection of <see cref="UpdateWorkspaceQuotas" /> that may take multiple service requests to iterate over. </returns>
-        public virtual AsyncPageable<UpdateWorkspaceQuotas> UpdateQuotasAsync(string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<UpdateWorkspaceQuotas> UpdateAllQuotaAsync(string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
         {
             async Task<Page<UpdateWorkspaceQuotas>> FirstPageFunc(int? pageSizeHint)
             {
-                using var scope = QuotasClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.UpdateQuotas");
+                using var scope = QuotasClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.UpdateAllQuota");
                 scope.Start();
                 try
                 {
@@ -1023,11 +1023,11 @@ namespace MgmtListMethods
         /// <param name="content"> Quota update parameters. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="UpdateWorkspaceQuotas" /> that may take multiple service requests to iterate over. </returns>
-        public virtual Pageable<UpdateWorkspaceQuotas> UpdateQuotas(string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
+        public virtual Pageable<UpdateWorkspaceQuotas> UpdateAllQuota(string location, QuotaUpdateContent content, CancellationToken cancellationToken = default)
         {
             Page<UpdateWorkspaceQuotas> FirstPageFunc(int? pageSizeHint)
             {
-                using var scope = QuotasClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.UpdateQuotas");
+                using var scope = QuotasClientDiagnostics.CreateScope("SubscriptionResourceExtensionClient.UpdateAllQuota");
                 scope.Start();
                 try
                 {


### PR DESCRIPTION
# Description

Considering that the plural form of "Redis" is still "Redis", we should have `GetAllRedis` for the operation that are returning the `RedisCollection` or `Pageable<RedisResource>`

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first