### PR TITLE
Revert "Fix #2323: [Bug] Api-Version not being attached during pagination (#2397)"

### DIFF
--- a/samples/AppConfiguration/Generated/AppConfigurationRestClient.cs
+++ b/samples/AppConfiguration/Generated/AppConfigurationRestClient.cs
@@ -1268,7 +1268,6 @@ namespace AppConfiguration
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             if (_syncToken != null)
             {
@@ -1352,7 +1351,6 @@ namespace AppConfiguration
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             if (_syncToken != null)
             {
@@ -1440,7 +1438,6 @@ namespace AppConfiguration
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             if (_syncToken != null)
             {
@@ -1526,7 +1523,6 @@ namespace AppConfiguration
             var uri = new RawRequestUriBuilder();
             uri.AppendRaw(_endpoint, false);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             if (_syncToken != null)
             {

--- a/samples/Azure.Analytics.Purview.Account/Generated/PurviewAccountCollections.cs
+++ b/samples/Azure.Analytics.Purview.Account/Generated/PurviewAccountCollections.cs
@@ -817,7 +817,6 @@ namespace Azure.Analytics.Purview.Account
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/samples/Azure.Analytics.Purview.Account/Generated/PurviewAccountsClient.cs
+++ b/samples/Azure.Analytics.Purview.Account/Generated/PurviewAccountsClient.cs
@@ -1727,7 +1727,6 @@ namespace Azure.Analytics.Purview.Account
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;
@@ -1741,7 +1740,6 @@ namespace Azure.Analytics.Purview.Account
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/samples/Azure.Management.Storage/Generated/RestOperations/BlobContainersRestOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/RestOperations/BlobContainersRestOperations.cs
@@ -1325,7 +1325,6 @@ namespace Azure.Management.Storage
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.Management.Storage/Generated/RestOperations/DeletedAccountsRestOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/RestOperations/DeletedAccountsRestOperations.cs
@@ -192,7 +192,6 @@ namespace Azure.Management.Storage
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.Management.Storage/Generated/RestOperations/EncryptionScopesRestOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/RestOperations/EncryptionScopesRestOperations.cs
@@ -398,7 +398,6 @@ namespace Azure.Management.Storage
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.Management.Storage/Generated/RestOperations/FileSharesRestOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/RestOperations/FileSharesRestOperations.cs
@@ -705,7 +705,6 @@ namespace Azure.Management.Storage
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.Management.Storage/Generated/RestOperations/StorageAccountsRestOperations.cs
+++ b/samples/Azure.Management.Storage/Generated/RestOperations/StorageAccountsRestOperations.cs
@@ -1291,7 +1291,6 @@ namespace Azure.Management.Storage
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1360,7 +1359,6 @@ namespace Azure.Management.Storage
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceIPConfigurationsRestClient.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceIPConfigurationsRestClient.cs
@@ -230,7 +230,6 @@ namespace Azure.Network.Management.Interface
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceLoadBalancersRestClient.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceLoadBalancersRestClient.cs
@@ -135,7 +135,6 @@ namespace Azure.Network.Management.Interface
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsRestClient.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfaceTapConfigurationsRestClient.cs
@@ -420,7 +420,6 @@ namespace Azure.Network.Management.Interface
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesRestClient.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/NetworkInterfacesRestClient.cs
@@ -683,7 +683,6 @@ namespace Azure.Network.Management.Interface
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;
@@ -751,7 +750,6 @@ namespace Azure.Network.Management.Interface
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/AvailabilitySetsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/AvailabilitySetsRestOperations.cs
@@ -593,7 +593,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -664,7 +663,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/DedicatedHostGroupsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/DedicatedHostGroupsRestOperations.cs
@@ -516,7 +516,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -589,7 +588,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/DedicatedHostsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/DedicatedHostsRestOperations.cs
@@ -461,7 +461,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/ImagesRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/ImagesRestOperations.cs
@@ -500,7 +500,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -573,7 +572,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/ProximityPlacementGroupsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/ProximityPlacementGroupsRestOperations.cs
@@ -514,7 +514,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -583,7 +582,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/SshPublicKeysRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/SshPublicKeysRestOperations.cs
@@ -589,7 +589,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -658,7 +657,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/UsageRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/UsageRestOperations.cs
@@ -116,7 +116,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachineScaleSetExtensionsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachineScaleSetExtensionsRestOperations.cs
@@ -463,7 +463,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachineScaleSetVMsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachineScaleSetVMsRestOperations.cs
@@ -1270,7 +1270,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachineScaleSetsRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachineScaleSetsRestOperations.cs
@@ -1759,7 +1759,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1832,7 +1831,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1901,7 +1899,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1978,7 +1975,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachinesRestOperations.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/RestOperations/VirtualMachinesRestOperations.cs
@@ -1758,7 +1758,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1829,7 +1828,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1902,7 +1900,6 @@ namespace Azure.ResourceManager.Sample
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
@@ -166,9 +166,6 @@ namespace AutoRest.CSharp.Input
     internal partial class RequestParameter
     {
         public bool IsResourceParameter => Convert.ToBoolean(Extensions.GetValue<string>("x-ms-resource-identifier"));
-        public bool IsEndpointParameter => Origin == "modelerfour:synthesized/host";
-        public bool IsContentTypeParameter => Origin == "modelerfour:synthesized/content-type";
-        public bool IsApiVersionParameter => Origin == "modelerfour:synthesized/api-version";
 
         public HttpParameterIn In => Protocol.Http is HttpParameter httpParameter ? httpParameter.In : HttpParameterIn.None;
         public bool IsFlattened => Flattened ?? false;

--- a/src/AutoRest.CSharp/Common/Output/Models/Requests/QueryParameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Requests/QueryParameter.cs
@@ -5,5 +5,23 @@ using AutoRest.CSharp.Output.Models.Serialization;
 
 namespace AutoRest.CSharp.Output.Models.Requests
 {
-    internal record QueryParameter(string Name, ReferenceOrConstant Value, RequestParameterSerializationStyle SerializationStyle, bool Escape, SerializationFormat SerializationFormat, bool Explode, bool IsApiVersion);
+    internal class QueryParameter
+    {
+        public QueryParameter(string name, ReferenceOrConstant value, RequestParameterSerializationStyle serializationStyle, bool escape, SerializationFormat serializationFormat, bool explode)
+        {
+            Name = name;
+            Value = value;
+            SerializationStyle = serializationStyle;
+            Escape = escape;
+            SerializationFormat = serializationFormat;
+            Explode = explode;
+        }
+
+        public string Name { get; }
+        public ReferenceOrConstant Value { get; }
+        public RequestParameterSerializationStyle SerializationStyle { get; }
+        public SerializationFormat SerializationFormat { get; }
+        public bool Escape { get; }
+        public bool Explode { get; }
+    }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/RestClientBuilder.cs
@@ -284,7 +284,7 @@ namespace AutoRest.CSharp.Output.Models
                         pathParametersMap.Add(parameterName, new PathSegment(reference, escape, serializationFormat, isRaw: false));
                         break;
                     case HttpParameterIn.Query:
-                        queryParameters.Add(new QueryParameter(parameterName, reference, GetSerializationStyle(requestParameter), escape, serializationFormat, GetExplode(requestParameter), requestParameter.IsApiVersionParameter));
+                        queryParameters.Add(new QueryParameter(parameterName, reference, GetSerializationStyle(requestParameter), escape, serializationFormat, GetExplode(requestParameter)));
                         break;
                     case HttpParameterIn.Header:
                         var headerName = requestParameter.Extensions?.HeaderCollectionPrefix ?? parameterName;
@@ -583,7 +583,7 @@ namespace AutoRest.CSharp.Output.Models
         public virtual Parameter BuildConstructorParameter(RequestParameter requestParameter)
         {
             var parameter = BuildParameter(requestParameter);
-            if (!requestParameter.IsEndpointParameter)
+            if (!IsEndpointParameter(requestParameter))
             {
                 return parameter;
             }
@@ -601,6 +601,12 @@ namespace AutoRest.CSharp.Output.Models
 
         protected static bool IsMethodParameter(RequestParameter requestParameter)
             => requestParameter.Implementation == ImplementationLocation.Method && requestParameter.Schema is not ConstantSchema && !requestParameter.IsFlattened && requestParameter.GroupedBy == null;
+
+        public static bool IsEndpointParameter(RequestParameter requestParameter)
+            => requestParameter.Origin == "modelerfour:synthesized/host";
+
+        public static bool IsContentTypeParameter(RequestParameter requestParameter)
+            => requestParameter.Origin == "modelerfour:synthesized/content-type";
 
         public static bool IsIgnoredHeaderParameter(RequestParameter requestParameter)
             => requestParameter.In == HttpParameterIn.Header && IgnoredRequestHeader.Contains(GetRequestParameterName(requestParameter));
@@ -644,7 +650,7 @@ namespace AutoRest.CSharp.Output.Models
             var request = new Request(
                 RequestMethod.Get,
                 pathSegments,
-                method.Request.Query.Where(p => p.IsApiVersion).ToArray(),
+                Array.Empty<QueryParameter>(),
                 method.Request.Headers,
                 null);
 

--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -50,7 +50,7 @@ namespace AutoRest.CSharp.Output.Models.Shared
                 defaultValue,
                 validation,
                 initializer,
-                IsApiVersionParameter: requestParameter.IsApiVersionParameter,
+                IsApiVersionParameter: requestParameter.Origin == "modelerfour:synthesized/api-version",
                 IsResourceIdentifier: requestParameter.IsResourceParameter,
                 SkipUrlEncoding: skipUrlEncoding,
                 RequestLocation: requestLocation);

--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelOutputLibraryFactory.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelOutputLibraryFactory.cs
@@ -120,7 +120,7 @@ namespace AutoRest.CSharp.Output.Models
             {
                 var clientName = ClientBuilder.GetClientPrefix(context.DefaultLibraryName, context) + ClientBuilder.GetClientSuffix(context);
                 var clientNamespace = context.DefaultNamespace;
-                var endpointParameter = context.CodeModel.GlobalParameters.FirstOrDefault(p => p.IsEndpointParameter);
+                var endpointParameter = context.CodeModel.GlobalParameters.FirstOrDefault(RestClientBuilder.IsEndpointParameter);
                 var clientParameters = endpointParameter != null ? new[] { endpointParameter } : Array.Empty<RequestParameter>();
 
                 topLevelClientInfo = new ClientInfo(clientName, clientNamespace, clientParameters);

--- a/test/TestProjects/MgmtCollectionParent/Generated/RestOperations/ComputeManagementRestOperations.cs
+++ b/test/TestProjects/MgmtCollectionParent/Generated/RestOperations/ComputeManagementRestOperations.cs
@@ -285,7 +285,6 @@ namespace MgmtCollectionParent
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -356,7 +355,6 @@ namespace MgmtCollectionParent
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RestOperations/RecordSetsRestOperations.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RestOperations/RecordSetsRestOperations.cs
@@ -711,7 +711,6 @@ namespace MgmtExpandResourceTypes
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -794,7 +793,6 @@ namespace MgmtExpandResourceTypes
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -875,7 +873,6 @@ namespace MgmtExpandResourceTypes
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RestOperations/ZonesRestOperations.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RestOperations/ZonesRestOperations.cs
@@ -549,7 +549,6 @@ namespace MgmtExpandResourceTypes
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -624,7 +623,6 @@ namespace MgmtExpandResourceTypes
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtExtensionResource/Generated/RestOperations/PolicyDefinitionsRestOperations.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/RestOperations/PolicyDefinitionsRestOperations.cs
@@ -780,7 +780,6 @@ namespace MgmtExtensionResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -853,7 +852,6 @@ namespace MgmtExtensionResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -920,7 +918,6 @@ namespace MgmtExtensionResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/RestOperations/SharedGalleriesRestOperations.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/RestOperations/SharedGalleriesRestOperations.cs
@@ -206,7 +206,6 @@ namespace MgmtHierarchicalNonResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/RestOperations/SharedGalleryImageVersionsRestOperations.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/RestOperations/SharedGalleryImageVersionsRestOperations.cs
@@ -226,7 +226,6 @@ namespace MgmtHierarchicalNonResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/RestOperations/SharedGalleryImagesRestOperations.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/RestOperations/SharedGalleryImagesRestOperations.cs
@@ -214,7 +214,6 @@ namespace MgmtHierarchicalNonResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorWithLocsRestOperations.cs
@@ -426,7 +426,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -499,7 +498,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -568,7 +566,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorWithNonResChWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorWithNonResChWithLocsRestOperations.cs
@@ -505,7 +505,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -578,7 +577,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorWithNonResChesRestOperations.cs
@@ -432,7 +432,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -505,7 +504,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithAncestorsRestOperations.cs
@@ -353,7 +353,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -426,7 +425,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentWithNonResChesRestOperations.cs
@@ -365,7 +365,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakeParentsRestOperations.cs
@@ -286,7 +286,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/FakesRestOperations.cs
@@ -280,7 +280,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGroupParentsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGroupParentsRestOperations.cs
@@ -268,7 +268,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGrpParentWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGrpParentWithLocsRestOperations.cs
@@ -268,7 +268,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGrpParentWithNonResChWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGrpParentWithNonResChWithLocsRestOperations.cs
@@ -341,7 +341,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGrpParentWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/MgmtGrpParentWithNonResChesRestOperations.cs
@@ -341,7 +341,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorWithLocsRestOperations.cs
@@ -426,7 +426,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -499,7 +498,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -568,7 +566,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorWithNonResChWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorWithNonResChWithLocsRestOperations.cs
@@ -438,7 +438,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -511,7 +510,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorWithNonResChesRestOperations.cs
@@ -438,7 +438,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -511,7 +510,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithAncestorsRestOperations.cs
@@ -353,7 +353,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/ResGrpParentWithNonResChesRestOperations.cs
@@ -365,7 +365,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentWithLocsRestOperations.cs
@@ -268,7 +268,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentWithNonResChWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentWithNonResChWithLocsRestOperations.cs
@@ -341,7 +341,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentWithNonResChesRestOperations.cs
@@ -341,7 +341,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/SubParentsRestOperations.cs
@@ -268,7 +268,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentWithLocsRestOperations.cs
@@ -268,7 +268,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentWithNonResChWithLocsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentWithNonResChWithLocsRestOperations.cs
@@ -341,7 +341,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentWithNonResChesRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentWithNonResChesRestOperations.cs
@@ -341,7 +341,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantParentsRestOperations.cs
@@ -268,7 +268,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantTestsRestOperations.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/RestOperations/TenantTestsRestOperations.cs
@@ -246,7 +246,6 @@ namespace MgmtListMethods
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/DiskEncryptionSetsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/DiskEncryptionSetsRestOperations.cs
@@ -494,7 +494,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -567,7 +566,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/ManagedHsmsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/ManagedHsmsRestOperations.cs
@@ -725,7 +725,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -800,7 +799,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -871,7 +869,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/MhsmPrivateEndpointConnectionsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/MhsmPrivateEndpointConnectionsRestOperations.cs
@@ -382,7 +382,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/PrivateEndpointConnectionsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/PrivateEndpointConnectionsRestOperations.cs
@@ -384,7 +384,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/RoleAssignmentsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/RoleAssignmentsRestOperations.cs
@@ -601,7 +601,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -690,7 +689,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -765,7 +763,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -836,7 +833,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/TenantActivityLogsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/TenantActivityLogsRestOperations.cs
@@ -112,7 +112,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/VaultsRestOperations.cs
+++ b/test/TestProjects/MgmtMockTest/src/Generated/RestOperations/VaultsRestOperations.cs
@@ -898,7 +898,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -973,7 +972,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1044,7 +1042,6 @@ namespace MgmtMockTest
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/AnotherChildrenRestOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/AnotherChildrenRestOperations.cs
@@ -468,7 +468,6 @@ namespace MgmtMultipleParentResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/AnotherParentsRestOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/AnotherParentsRestOperations.cs
@@ -438,7 +438,6 @@ namespace MgmtMultipleParentResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/ChildrenRestOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/ChildrenRestOperations.cs
@@ -498,7 +498,6 @@ namespace MgmtMultipleParentResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/SubParentsRestOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/SubParentsRestOperations.cs
@@ -468,7 +468,6 @@ namespace MgmtMultipleParentResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/TheParentsRestOperations.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/RestOperations/TheParentsRestOperations.cs
@@ -438,7 +438,6 @@ namespace MgmtMultipleParentResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtOptionalConstant/Generated/RestOperations/OptionalsRestOperations.cs
+++ b/test/TestProjects/MgmtOptionalConstant/Generated/RestOperations/OptionalsRestOperations.cs
@@ -512,7 +512,6 @@ namespace MgmtOptionalConstant
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -585,7 +584,6 @@ namespace MgmtOptionalConstant
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtParamOrdering/Generated/RestOperations/AvailabilitySetsRestOperations.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/RestOperations/AvailabilitySetsRestOperations.cs
@@ -514,7 +514,6 @@ namespace MgmtParamOrdering
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -585,7 +584,6 @@ namespace MgmtParamOrdering
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtParamOrdering/Generated/RestOperations/DedicatedHostsRestOperations.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/RestOperations/DedicatedHostsRestOperations.cs
@@ -461,7 +461,6 @@ namespace MgmtParamOrdering
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtParamOrdering/Generated/RestOperations/VirtualMachineScaleSetsRestOperations.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/RestOperations/VirtualMachineScaleSetsRestOperations.cs
@@ -699,7 +699,6 @@ namespace MgmtParamOrdering
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtParent/Generated/RestOperations/AvailabilitySetsRestOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/RestOperations/AvailabilitySetsRestOperations.cs
@@ -514,7 +514,6 @@ namespace MgmtParent
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -585,7 +584,6 @@ namespace MgmtParent
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtParent/Generated/RestOperations/DedicatedHostsRestOperations.cs
+++ b/test/TestProjects/MgmtParent/Generated/RestOperations/DedicatedHostsRestOperations.cs
@@ -461,7 +461,6 @@ namespace MgmtParent
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtRenameRules/Generated/RestOperations/ImagesRestOperations.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/RestOperations/ImagesRestOperations.cs
@@ -500,7 +500,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -573,7 +572,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachineScaleSetExtensionsRestOperations.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachineScaleSetExtensionsRestOperations.cs
@@ -463,7 +463,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachineScaleSetVMsRestOperations.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachineScaleSetVMsRestOperations.cs
@@ -1270,7 +1270,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachineScaleSetsRestOperations.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachineScaleSetsRestOperations.cs
@@ -1759,7 +1759,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1832,7 +1831,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1901,7 +1899,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1978,7 +1975,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachinesRestOperations.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/RestOperations/VirtualMachinesRestOperations.cs
@@ -1550,7 +1550,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1621,7 +1620,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -1694,7 +1692,6 @@ namespace MgmtRenameRules
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtResourceName/Generated/RestOperations/ProviderRestOperations.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/RestOperations/ProviderRestOperations.cs
@@ -182,7 +182,6 @@ namespace MgmtResourceName
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtScopeResource/Generated/RestOperations/DeploymentRestOperations.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/RestOperations/DeploymentRestOperations.cs
@@ -202,7 +202,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtScopeResource/Generated/RestOperations/DeploymentsRestOperations.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/RestOperations/DeploymentsRestOperations.cs
@@ -986,7 +986,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtScopeResource/Generated/RestOperations/FakePolicyAssignmentsRestOperations.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/RestOperations/FakePolicyAssignmentsRestOperations.cs
@@ -629,7 +629,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -706,7 +705,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -799,7 +797,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -872,7 +869,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtScopeResource/Generated/RestOperations/ResourceLinksRestOperations.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/RestOperations/ResourceLinksRestOperations.cs
@@ -386,7 +386,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);
@@ -457,7 +456,6 @@ namespace MgmtScopeResource
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/RestOperations/SubscriptionsRestOperations.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/RestOperations/SubscriptionsRestOperations.cs
@@ -368,7 +368,6 @@ namespace MgmtSubscriptionNameParameter
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeDecimalModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeDecimalModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeDoubleModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeDoubleModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeFloatModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeFloatModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeInt32ModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeInt32ModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeInt64ModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeInt64ModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeIntegerModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeIntegerModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeNumericModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeNumericModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/Pagination/Generated/RestOperations/PageSizeStringModelsRestOperations.cs
+++ b/test/TestProjects/Pagination/Generated/RestOperations/PageSizeStringModelsRestOperations.cs
@@ -286,7 +286,6 @@ namespace Pagination
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/ResourceRename/Generated/RestOperations/SshPublicKeysRestOperations.cs
+++ b/test/TestProjects/ResourceRename/Generated/RestOperations/SshPublicKeysRestOperations.cs
@@ -359,7 +359,6 @@ namespace ResourceRename
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/SubscriptionExtensions/Generated/RestOperations/OvensRestOperations.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/RestOperations/OvensRestOperations.cs
@@ -282,7 +282,6 @@ namespace SubscriptionExtensions
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             _userAgent.Apply(message);

--- a/test/TestProjects/XmlDeserialization/Generated/RestOperations/XmlDeserializationRestOperations.cs
+++ b/test/TestProjects/XmlDeserialization/Generated/RestOperations/XmlDeserializationRestOperations.cs
@@ -471,7 +471,6 @@ namespace XmlDeserialization
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendRawNextLink(nextLink, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, application/xml");
             _userAgent.Apply(message);


### PR DESCRIPTION
`RequestUriBuilder.AppendQuery` allows multiple query parameters with the same name, so simply calling `AppendQuery("api-version", _apiVersion, true);` can create URI that has more than one version if `nextLink` already has it. Reverting the change until this is clarified with architects.