### PR TITLE
[CODEOWNERS] Unify files and update owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,32 @@
 ################
 
 # Git Hub bot rules
-/.github/CODEOWNERS  @jsquire @ronniegeraghty
-/.github/fabricbot.json  @jsquire @ronniegeraghty
+/.github/CODEOWNERS                           @jsquire @ronniegeraghty
+/.github/fabricbot.json                       @jsquire @ronniegeraghty
+
+#####################
+# Code Generation
+#####################
+
+# Catch all
+*                                              @AlexanderSher @lirenhe @chunyu3 
+
+# Data Plane Reviewers
+/samples/AppConfiguration/                     @annelo-msft
+/samples/Azure.AI.*/                           @annelo-msft
+/samples/Azure.Analytics.*/                    @annelo-msft
+/samples/Azure.Storage.*/                      @annelo-msft
+/samples/Cognitive*/                           @annelo-msft
+/src/assets/Generator.Shared/                  @annelo-msft
+/src/AutoRest.CSharp/DataPlane/                @annelo-msft
+/src/AutoRest.CSharp/LowLevel/                 @annelo-msft
+/test/AutoRest.TestServer.Tests/               @annelo-msft
+/test/AutoRest.TestServerLowLevel.Tests/       @annelo-msft
+
+# Management CSharp CodeReviewers
+/samples/Azure.Management.Storage/             @allenjzhang @m-nash
+/samples/Azure.Network.Management.Interface/   @allenjzhang @m-nash
+/samples/Azure.ResourceManager.*/              @allenjzhang @m-nash
+/src/AutoRest.CSharp/Mgmt/                     @allenjzhang @m-nash
+/src/AutoRest.CSharp/Common/                   @allenjzhang @m-nash
+/test/AutoRest.TestServer.Tests/Mgmt/          @allenjzhang @m-nash


### PR DESCRIPTION
# Summary

The focus of these changes is to combine the two CODEOWNERS files that are in the repository and updates owners to account for organizational changes.   Once this merges, I'll delete the [redundant file](https://github.com/Azure/autorest.csharp/blob/feature/v3/CODEOWNERS).

