### PR TITLE
feat(dpg): reverse sequence of fields and constructors

### DIFF
--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelModelWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelModelWriter.cs
@@ -24,12 +24,13 @@ namespace AutoRest.CSharp.Generation.Writers
                 using (writer.Scope($"{model.Declaration.Accessibility} partial class {model.Type:D}"))
                 {
                     // TODO: add inherits or implements
-                    WriteFields(writer, model);
                     WriteConstructor(writer, model.PublicConstructor, model);
                     if (model.PublicConstructor != model.SerializationConstructor)
                     {
                         WriteConstructor(writer, model.SerializationConstructor, model);
                     }
+                    writer.Line();
+                    WriteFields(writer, model);
                 }
             }
         }
@@ -54,7 +55,7 @@ namespace AutoRest.CSharp.Generation.Writers
                 {
                     var field = model.GetFieldByParameterName(parameter.Name);
                     writer
-                        .Append($"{field.Name:I} = {parameter.Name:I}")
+                        .Append($"{field.Declaration.RequestedName:I} = {parameter.Name:I}")
                         .WriteConversion(parameter.Type, field.Type)
                         .LineRaw(";");
                 }

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelModelWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelModelWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using AutoRest.CSharp.Output.Models;
@@ -21,7 +22,8 @@ namespace AutoRest.CSharp.Generation.Writers
                 // TODO: need add @doc/@summary support
                 //writer.WriteXmlDocumentationSummary($"{model.Summary});
                 // TODO: do we have a case to generate struct?
-                using (writer.Scope($"{model.Declaration.Accessibility} partial class {model.Type:D}"))
+                var scopeDeclarations = new CodeWriterScopeDeclarations(model.Fields.Select(f => f.Declaration));
+                using (writer.Scope($"{model.Declaration.Accessibility} partial class {model.Type:D}", scopeDeclarations: scopeDeclarations))
                 {
                     // TODO: add inherits or implements
                     WriteConstructor(writer, model.PublicConstructor, model);
@@ -30,16 +32,16 @@ namespace AutoRest.CSharp.Generation.Writers
                         WriteConstructor(writer, model.SerializationConstructor, model);
                     }
                     writer.Line();
-                    WriteFields(writer, model);
+                    WriteFields(writer, model.Fields);
                 }
             }
         }
 
-        private static void WriteFields(CodeWriter writer, ModelTypeProvider model)
+        private static void WriteFields(CodeWriter writer, IReadOnlyList<FieldDeclaration> fields)
         {
-            foreach (var field in model.Fields)
+            foreach (var field in fields)
             {
-                writer.WriteField(field);
+                writer.WriteField(field, declareInCurrentScope: false);
             }
             writer.Line();
         }
@@ -55,7 +57,7 @@ namespace AutoRest.CSharp.Generation.Writers
                 {
                     var field = model.GetFieldByParameterName(parameter.Name);
                     writer
-                        .Append($"{field.Declaration.RequestedName:I} = {parameter.Name:I}")
+                        .Append($"{field.Name:I} = {parameter.Name:I}")
                         .WriteConversion(parameter.Type, field.Type)
                         .LineRaw(";");
                 }

--- a/test/AutoRest.TestServerLowLevel.Tests/LowLevel/Generation/ModelWriterTests.cs
+++ b/test/AutoRest.TestServerLowLevel.Tests/LowLevel/Generation/ModelWriterTests.cs
@@ -110,12 +110,6 @@ namespace Cadl.TestServer.InputBasic
 {
 public partial class InputModel
 {
-/// <summary> Required string, illustrating a reference type property. </summary>
-public string RequiredString{ get; }
-
-/// <summary> Required int, illustrating a value type property. </summary>
-public int RequiredInt{ get; }
-
 /// <summary> Initializes a new instance of InputModel. </summary>
 /// <param name=""requiredString""> Required string, illustrating a reference type property. </param>
 /// <param name=""requiredInt""> Required int, illustrating a value type property. </param>
@@ -127,6 +121,12 @@ global::Azure.Core.Argument.AssertNotNull(requiredString, nameof(requiredString)
 RequiredString = requiredString;
 RequiredInt = requiredInt;
 }
+
+/// <summary> Required string, illustrating a reference type property. </summary>
+public string RequiredString{ get; }
+
+/// <summary> Required int, illustrating a value type property. </summary>
+public int RequiredInt{ get; }
 }
 }
 "
@@ -148,25 +148,6 @@ namespace Cadl.TestServer.PrimitiveProperties
 {
 public partial class PrimitivePropertyModel
 {
-public string RequiredString{ get; set; }
-
-public int RequiredInt{ get; set; }
-
-public long RequiredLong{ get; set; }
-
-public long RequiredSafeInt{ get; set; }
-
-public float RequiredFloat{ get; set; }
-
-public double RequiredDouble{ get; set; }
-
-/// <summary> Illustrate a zonedDateTime body parameter, serialized as (https://datatracker.ietf.org/doc/html/rfc3339). </summary>
-public global::System.DateTimeOffset RequiredBodyDateTime{ get; set; }
-
-public global::System.TimeSpan RequiredDuration{ get; set; }
-
-public bool RequiredBoolean{ get; set; }
-
 /// <summary> Initializes a new instance of PrimitivePropertyModel. </summary>
 /// <param name=""requiredString""></param>
 /// <param name=""requiredInt""></param>
@@ -192,6 +173,25 @@ RequiredBodyDateTime = requiredBodyDateTime;
 RequiredDuration = requiredDuration;
 RequiredBoolean = requiredBoolean;
 }
+
+public string RequiredString{ get; set; }
+
+public int RequiredInt{ get; set; }
+
+public long RequiredLong{ get; set; }
+
+public long RequiredSafeInt{ get; set; }
+
+public float RequiredFloat{ get; set; }
+
+public double RequiredDouble{ get; set; }
+
+/// <summary> Illustrate a zonedDateTime body parameter, serialized as (https://datatracker.ietf.org/doc/html/rfc3339). </summary>
+public global::System.DateTimeOffset RequiredBodyDateTime{ get; set; }
+
+public global::System.TimeSpan RequiredDuration{ get; set; }
+
+public bool RequiredBoolean{ get; set; }
 }
 }
 ",
@@ -324,12 +324,6 @@ namespace Cadl.TestServer.CollectionPropertiesBasic
 {
 public partial class RoundTripModel
 {
-/// <summary> Required collection of strings, illustrating a collection of reference types. </summary>
-public global::System.Collections.Generic.IList<string> RequiredStringList{ get; }
-
-/// <summary> Required collection of ints, illustrating a collection of value types. </summary>
-public global::System.Collections.Generic.IList<int> RequiredIntList{ get; }
-
 /// <summary> Initializes a new instance of RoundTripModel. </summary>
 /// <param name=""requiredStringList""> Required collection of strings, illustrating a collection of reference types. </param>
 /// <param name=""requiredIntList""> Required collection of ints, illustrating a collection of value types. </param>
@@ -354,6 +348,12 @@ global::Azure.Core.Argument.AssertNotNull(requiredIntList, nameof(requiredIntLis
 RequiredStringList = requiredStringList;
 RequiredIntList = requiredIntList;
 }
+
+/// <summary> Required collection of strings, illustrating a collection of reference types. </summary>
+public global::System.Collections.Generic.IList<string> RequiredStringList{ get; }
+
+/// <summary> Required collection of ints, illustrating a collection of value types. </summary>
+public global::System.Collections.Generic.IList<int> RequiredIntList{ get; }
 }
 }
 ",

--- a/test/TestProjects/CadlFirstTest/Generated/RoundTripModel.cs
+++ b/test/TestProjects/CadlFirstTest/Generated/RoundTripModel.cs
@@ -15,21 +15,6 @@ namespace CadlFirstTest
 {
     public partial class RoundTripModel
     {
-        /// <summary> Required string, illustrating a reference type property. </summary>
-        public string RequiredString { get; set; }
-
-        /// <summary> Required int, illustrating a value type property. </summary>
-        public int RequiredInt { get; set; }
-
-        /// <summary> Required collection of enums. </summary>
-        public IList<SimpleEnum> RequiredCollection { get; }
-
-        /// <summary> Required dictionary of enums. </summary>
-        public IDictionary<string, ExtensibleEnum> RequiredDictionary { get; }
-
-        /// <summary> Required dictionary of enums. </summary>
-        public Thing RequiredModel { get; set; }
-
         /// <summary> Initializes a new instance of RoundTripModel. </summary>
         /// <param name="requiredString"> Required string, illustrating a reference type property. </param>
         /// <param name="requiredInt"> Required int, illustrating a value type property. </param>
@@ -70,5 +55,20 @@ namespace CadlFirstTest
             RequiredDictionary = requiredDictionary;
             RequiredModel = requiredModel;
         }
+
+        /// <summary> Required string, illustrating a reference type property. </summary>
+        public string RequiredString { get; set; }
+
+        /// <summary> Required int, illustrating a value type property. </summary>
+        public int RequiredInt { get; set; }
+
+        /// <summary> Required collection of enums. </summary>
+        public IList<SimpleEnum> RequiredCollection { get; }
+
+        /// <summary> Required dictionary of enums. </summary>
+        public IDictionary<string, ExtensibleEnum> RequiredDictionary { get; }
+
+        /// <summary> Required dictionary of enums. </summary>
+        public Thing RequiredModel { get; set; }
     }
 }

--- a/test/TestProjects/CadlFirstTest/Generated/Thing.cs
+++ b/test/TestProjects/CadlFirstTest/Generated/Thing.cs
@@ -12,8 +12,6 @@ namespace CadlFirstTest
 {
     public partial class Thing
     {
-        public string Name { get; set; }
-
         /// <summary> Initializes a new instance of Thing. </summary>
         /// <param name="name"></param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
@@ -23,5 +21,7 @@ namespace CadlFirstTest
 
             Name = name;
         }
+
+        public string Name { get; set; }
     }
 }

--- a/test/TestProjects/CadlPetStore/Generated/Pet.cs
+++ b/test/TestProjects/CadlPetStore/Generated/Pet.cs
@@ -12,12 +12,6 @@ namespace CadlPetStore
 {
     public partial class Pet
     {
-        public string Name { get; }
-
-        public string Tag { get; }
-
-        public int Age { get; }
-
         /// <summary> Initializes a new instance of Pet. </summary>
         /// <param name="name"></param>
         /// <param name="tag"></param>
@@ -32,5 +26,11 @@ namespace CadlPetStore
             Tag = tag;
             Age = age;
         }
+
+        public string Name { get; }
+
+        public string Tag { get; }
+
+        public int Age { get; }
     }
 }


### PR DESCRIPTION
according to csharp coding styles, we should put constructor definitions before fields declaration: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first