### PR TITLE
fix(common): `ETag` request header value is not quoted

### DIFF
--- a/src/assets/Generator.Shared/RequestHeaderExtensions.cs
+++ b/src/assets/Generator.Shared/RequestHeaderExtensions.cs
@@ -66,7 +66,7 @@ namespace Azure.Core
 
         public static void Add(this RequestHeaders headers, string name, ETag value)
         {
-            headers.Add(name, value.ToString());
+            headers.Add(name, value.ToString("H"));
         }
 
         public static void Add(this RequestHeaders headers, MatchConditions conditions)

--- a/test/AutoRest.Shared.Tests/Mock/MockRequest.cs
+++ b/test/AutoRest.Shared.Tests/Mock/MockRequest.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Core.Tests
+{
+    public class MockRequest : Request
+    {
+        public MockRequest()
+        {
+            ClientRequestId = Guid.NewGuid().ToString();
+        }
+
+        private readonly Dictionary<string, object> _headers = new();
+        public bool IsDisposed { get; private set; }
+
+        public override RequestContent Content
+        {
+            get { return base.Content; }
+            set
+            {
+                base.Content = value;
+            }
+        }
+
+        protected override void SetHeader(string name, string value) => _headers.Add(name, value);
+
+        protected override void AddHeader(string name, string value) => _headers.Add(name, value);
+
+        protected override bool TryGetHeader(string name, out string value)
+        {
+            var found = _headers.TryGetValue(name, out object obj);
+            value = found ? (string)obj : null;
+            return found;
+        }
+
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        {
+            var found = _headers.TryGetValue(name, out object obj);
+            values = found ? (IEnumerable<string>)obj : null;
+            return found;
+        }
+
+        protected override bool ContainsHeader(string name) => _headers.TryGetValue(name, out _);
+
+        protected override bool RemoveHeader(string name) => _headers.Remove(name);
+
+        protected override IEnumerable<HttpHeader> EnumerateHeaders()
+        {
+            foreach (var header in _headers)
+            {
+                yield return new HttpHeader(header.Key, header.Value.ToString());
+            }
+        }
+
+        public override string ClientRequestId { get; set; }
+
+        public override string ToString() => $"{Method} {Uri}";
+
+        public override void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+}

--- a/test/AutoRest.Shared.Tests/RequestHeaderExtensionsTests.cs
+++ b/test/AutoRest.Shared.Tests/RequestHeaderExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class RequestHeaderExtensionsTests
+    {
+        [TestCaseSource(nameof(ETagRequestHeaderCases))]
+        public void AddETagRequestHeader(string original, string expected)
+        {
+            var request = new MockRequest();
+            request.Headers.Add("If-Match", new ETag(original));
+            Assert.IsTrue(request.Headers.TryGetValue("If-Match", out string value));
+            Assert.AreEqual(expected, value);
+        }
+
+        [TestCaseSource(nameof(ETagRequestHeaderCases))]
+        public void AddETagMatchConditionsRequestHeader(string original, string expected)
+        {
+            var request = new MockRequest();
+            request.Headers.Add(new MatchConditions
+            {
+                IfMatch = new ETag(original),
+                IfNoneMatch = new ETag(original)
+            });
+            Assert.IsTrue(request.Headers.TryGetValue("If-Match", out string ifMatchValue));
+            Assert.IsTrue(request.Headers.TryGetValue("If-None-Match", out string ifNoneMatchValue));
+            Assert.AreEqual(expected, ifMatchValue);
+            Assert.AreEqual(expected, ifNoneMatchValue);
+        }
+
+        [TestCaseSource(nameof(ETagRequestHeaderCases))]
+        public void AddETagRequestConditionsRequestHeader(string original, string expected)
+        {
+            var request = new MockRequest();
+            request.Headers.Add(new RequestConditions
+            {
+                IfMatch = new ETag(original),
+                IfNoneMatch = new ETag(original)
+            });
+            Assert.IsTrue(request.Headers.TryGetValue("If-Match", out string ifMatchValue));
+            Assert.IsTrue(request.Headers.TryGetValue("If-None-Match", out string ifNoneMatchValue));
+            Assert.AreEqual(expected, ifMatchValue);
+            Assert.AreEqual(expected, ifNoneMatchValue);
+        }
+
+        private static readonly object[] ETagRequestHeaderCases =
+        {
+            new string[] { "*", "*" },
+            new string[] { "\"\"", "\"\"" },
+            new string[] { "\"abcedfg\"", "\"abcedfg\"" },
+            new string[] { "W/\"weakETag\"", "W/\"weakETag\"" },
+            new string[] { "abcedfg", "\"abcedfg\"" },
+            new string[] { "abcedfg\"", "\"abcedfg\"\""},
+            new string[] { "\"abcedfg", "\"\"abcedfg\""},
+            new string[] { "W/weakETag\"", "\"W/weakETag\"\"" },
+        };
+    }
+}


### PR DESCRIPTION
- fix a few extension methods of `RequestHeaders.Add()`, using `ETag.ToString("H")` instead of `ToString()`
- add a case to generate specific codes for setting `ETag` type headers
  - instead of using `ETag.ToString()` as the value, use `ETag` itself, so that it will match the overload version of `RequestHeaders.Add()`
- add test cases and update samples

fix #2551

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first