### PR TITLE
Revert change to pick the last body parameter in case of multipart body

### DIFF
--- a/src/AutoRest.CSharp/LowLevel/Output/OperationMethodChainBuilder.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/OperationMethodChainBuilder.cs
@@ -180,7 +180,7 @@ namespace AutoRest.CSharp.Output.Models
             {
                 switch (operationParameter)
                 {
-                    case { Location: RequestLocation.Body } when bodyParameter == null:
+                    case { Location: RequestLocation.Body }:
                         bodyParameter = operationParameter;
                         break;
                     case { Location: RequestLocation.Header, IsContentType: true } when contentTypeRequestParameter == null:


### PR DESCRIPTION
NOT the correct behavior but it will match what we have in [agrifood](https://github.com/Azure/azure-rest-api-specs/blob/683e3f4849ee1d84629d0d0fa17789e80a9cee08/specification/agfood/data-plane/Microsoft.AgFoodPlatform/preview/2021-03-31-preview/agfood.json#L893)