### PR TITLE
Fix CanBeInitializedInline and GetParameterInitializer

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -125,6 +125,11 @@ namespace AutoRest.CSharp.Generation.Types
         {
             Debug.Assert(defaultValue.HasValue);
 
+            if (!type.Equals(defaultValue.Value.Type) && !CanBeInitializedInline(defaultValue.Value.Type, defaultValue))
+            {
+                return false;
+            }
+
             if (type.Equals(typeof(string)))
             {
                 return true;

--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -39,7 +39,7 @@ namespace AutoRest.CSharp.Output.Models.Shared
 
             if (defaultValue != null && operationParameter.Kind != InputOperationParameterKind.Constant && !TypeFactory.CanBeInitializedInline(type, defaultValue))
             {
-                initializer = GetParameterInitializer(type, defaultValue.Value);
+                initializer = type.GetParameterInitializer(defaultValue.Value);
                 type = type.WithNullable(true);
                 defaultValue = Constant.Default(type);
             }
@@ -66,16 +66,6 @@ namespace AutoRest.CSharp.Output.Models.Shared
                 IsResourceIdentifier: operationParameter.IsResourceParameter,
                 SkipUrlEncoding: skipUrlEncoding,
                 RequestLocation: requestLocation);
-        }
-
-        public static FormattableString? GetParameterInitializer(CSharpType parameterType, Constant? defaultValue)
-        {
-            if (TypeFactory.IsCollectionType(parameterType) && (defaultValue == null || TypeFactory.IsCollectionType(defaultValue.Value.Type)))
-            {
-                defaultValue = Constant.NewInstanceOf(TypeFactory.GetImplementationType(parameterType).WithNullable(false));
-            }
-
-            return defaultValue?.GetConstantFormattable();
         }
 
         public static string CreateDescription(InputParameter operationParameter, CSharpType type, IEnumerable<string>? values)
@@ -119,7 +109,7 @@ namespace AutoRest.CSharp.Output.Models.Shared
 
             if (defaultValue != null && !TypeFactory.CanBeInitializedInline(type, defaultValue))
             {
-                initializer = GetParameterInitializer(type, defaultValue.Value);
+                initializer = type.GetParameterInitializer(defaultValue.Value);
                 type = type.WithNullable(true);
                 defaultValue = Constant.Default(type);
             }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelFactoryTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelFactoryTypeProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using AutoRest.CSharp.Common.Input;
 using AutoRest.CSharp.Common.Output.Builders;
 using AutoRest.CSharp.Generation.Types;
+using AutoRest.CSharp.Generation.Writers;
 using AutoRest.CSharp.Input.Source;
 using AutoRest.CSharp.Output.Models.Shared;
 using Configuration = AutoRest.CSharp.Input.Configuration;
@@ -65,7 +66,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                 {
                     Type = inputType,
                     DefaultValue = Constant.Default(inputType),
-                    Initializer = Parameter.GetParameterInitializer(inputType, ctorParameter.DefaultValue)
+                    Initializer = inputType.GetParameterInitializer(ctorParameter.DefaultValue)
                 };
             }
 

--- a/src/AutoRest.CSharp/LowLevel/AutoRest/DpgOutputLibrary.cs
+++ b/src/AutoRest.CSharp/LowLevel/AutoRest/DpgOutputLibrary.cs
@@ -14,6 +14,7 @@ namespace AutoRest.CSharp.Output.Models.Types
     {
         private readonly IReadOnlyDictionary<InputEnumType, EnumType> _enums;
         private readonly IReadOnlyDictionary<InputModelType, Func<ModelTypeProvider>> _modelFactories;
+        private readonly bool _isCadlInput;
 
         public TypeFactory TypeFactory { get; }
         public IEnumerable<EnumType> Enums => _enums.Values;
@@ -21,19 +22,30 @@ namespace AutoRest.CSharp.Output.Models.Types
         public IReadOnlyList<LowLevelClient> RestClients { get; }
         public ClientOptionsTypeProvider ClientOptions { get; }
 
-        public DpgOutputLibrary(IReadOnlyDictionary<InputEnumType, EnumType> enums, IReadOnlyDictionary<InputModelType, Func<ModelTypeProvider>> modelFactories, IReadOnlyList<LowLevelClient> restClients, ClientOptionsTypeProvider clientOptions)
+        public DpgOutputLibrary(IReadOnlyDictionary<InputEnumType, EnumType> enums, IReadOnlyDictionary<InputModelType, Func<ModelTypeProvider>> modelFactories, IReadOnlyList<LowLevelClient> restClients, ClientOptionsTypeProvider clientOptions, bool isCadlInput)
         {
             TypeFactory = new TypeFactory(this);
             _enums = enums;
             _modelFactories = modelFactories;
+            _isCadlInput = isCadlInput;
             RestClients = restClients;
             ClientOptions = clientOptions;
         }
 
         public override CSharpType ResolveEnum(InputEnumType enumType)
-            => _enums.TryGetValue(enumType, out var typeProvider)
-                ? typeProvider.Type
-                : throw new InvalidOperationException($"No {nameof(EnumType)} has been created for `{enumType.Name}` {nameof(InputEnumType)}.");
+        {
+            if (!_isCadlInput)
+            {
+                return TypeFactory.CreateType(enumType.EnumValueType);
+            }
+
+            if (_enums.TryGetValue(enumType, out var typeProvider))
+            {
+                return typeProvider.Type;
+            }
+
+            throw new InvalidOperationException($"No {nameof(EnumType)} has been created for `{enumType.Name}` {nameof(InputEnumType)}.");
+        }
 
         public override CSharpType ResolveModel(InputModelType model)
             => _modelFactories.TryGetValue(model, out var modelFactory) ? modelFactory().Type : new CSharpType(typeof(object), model.IsNullable);

--- a/src/AutoRest.CSharp/LowLevel/AutoRest/LowLevelTarget.cs
+++ b/src/AutoRest.CSharp/LowLevel/AutoRest/LowLevelTarget.cs
@@ -14,27 +14,23 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         {
             var library = new DpgOutputLibraryBuilder(inputNamespace, sourceInputModel).Build(cadlInput);
 
-            // Generate types only for CADL input
-            if (cadlInput)
+            foreach (var enumType in library.Enums)
             {
-                foreach (var enumType in library.Enums)
+                if (enumType.IsExtendable)
                 {
-                    if (enumType.IsExtendable)
-                    {
-                        var codeWriter = new CodeWriter();
-                        ModelWriter.WriteExtendableEnum(codeWriter, enumType);
-                        project.AddGeneratedFile($"{enumType.Type.Name}.cs", codeWriter.ToString());
-                    }
-                    else
-                    {
-                        var codeWriter = new CodeWriter();
-                        ModelWriter.WriteEnum(codeWriter, enumType);
-                        project.AddGeneratedFile($"{enumType.Type.Name}.cs", codeWriter.ToString());
+                    var codeWriter = new CodeWriter();
+                    ModelWriter.WriteExtendableEnum(codeWriter, enumType);
+                    project.AddGeneratedFile($"{enumType.Type.Name}.cs", codeWriter.ToString());
+                }
+                else
+                {
+                    var codeWriter = new CodeWriter();
+                    ModelWriter.WriteEnum(codeWriter, enumType);
+                    project.AddGeneratedFile($"{enumType.Type.Name}.cs", codeWriter.ToString());
 
-                        var serializationWriter = new CodeWriter();
-                        SerializationWriter.WriteEnumSerialization(serializationWriter, enumType);
-                        project.AddGeneratedFile($"{enumType.Type.Name}.Serialization.cs", serializationWriter.ToString());
-                    }
+                    var serializationWriter = new CodeWriter();
+                    SerializationWriter.WriteEnumSerialization(serializationWriter, enumType);
+                    project.AddGeneratedFile($"{enumType.Type.Name}.Serialization.cs", serializationWriter.ToString());
                 }
             }
 

--- a/src/AutoRest.CSharp/LowLevel/Output/DpgOutputLibraryBuilder.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/DpgOutputLibraryBuilder.cs
@@ -49,11 +49,11 @@ namespace AutoRest.CSharp.Output.Models
             var modelFactories = new Dictionary<InputModelType, Func<ModelTypeProvider>>();
             var clients = new List<LowLevelClient>();
 
-            var library = new DpgOutputLibrary(enums, modelFactories, clients, clientOptions);
+            var library = new DpgOutputLibrary(enums, modelFactories, clients, clientOptions, isCadlInput);
 
-            CreateEnums(enums, library.TypeFactory);
             if (isCadlInput)
             {
+                CreateEnums(enums, library.TypeFactory);
                 CreateModels(modelFactories, library.TypeFactory);
             }
             CreateClients(clients, topLevelClientInfos, library.TypeFactory, clientOptions, isCadlInput);

--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelClient.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelClient.cs
@@ -144,7 +144,7 @@ namespace AutoRest.CSharp.Output.Models
             }
 
             var optionalParametersArguments = optionalParameters
-                .Select(p => p.Initializer ?? Parameter.GetParameterInitializer(p.Type, p.DefaultValue!.Value)!)
+                .Select(p => p.Initializer ?? p.Type.GetParameterInitializer(p.DefaultValue!.Value)!)
                 .ToArray();
 
             if (Fields.CredentialFields.Count == 0)

--- a/test/TestProjects/CadlFirstTest/Generated/HelloWorldClient.cs
+++ b/test/TestProjects/CadlFirstTest/Generated/HelloWorldClient.cs
@@ -61,18 +61,20 @@ namespace CadlFirstTest
         /// <param name="action"> The String to use. </param>
         /// <param name="exEnum"> The ExtensibleEnum to use. </param>
         /// <param name="enum"> The SimpleEnum to use. </param>
+        /// <param name="exEnumWithDefault"> The ExtensibleEnum to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="action"/> is null. </exception>
-        public virtual async Task<Response<Thing>> TopActionValueAsync(string action, ExtensibleEnum exEnum, SimpleEnum? @enum = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<Thing>> TopActionValueAsync(string action, ExtensibleEnum exEnum, SimpleEnum? @enum = null, ExtensibleEnum? exEnumWithDefault = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(action, nameof(action));
+            exEnumWithDefault ??= ExtensibleEnum.Two;
 
             using var scope = ClientDiagnostics.CreateScope("HelloWorldClient.TopActionValue");
             scope.Start();
             try
             {
                 RequestContext context = FromCancellationToken(cancellationToken);
-                Response response = await TopActionAsync(action, exEnum.ToString(), @enum?.ToSerialString(), context).ConfigureAwait(false);
+                Response response = await TopActionAsync(action, exEnum.ToString(), @enum?.ToSerialString(), exEnumWithDefault?.ToString(), context).ConfigureAwait(false);
                 return Response.FromValue(Thing.FromResponse(response), response);
             }
             catch (Exception e)
@@ -85,18 +87,20 @@ namespace CadlFirstTest
         /// <param name="action"> The String to use. </param>
         /// <param name="exEnum"> The ExtensibleEnum to use. </param>
         /// <param name="enum"> The SimpleEnum to use. </param>
+        /// <param name="exEnumWithDefault"> The ExtensibleEnum to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="action"/> is null. </exception>
-        public virtual Response<Thing> TopActionValue(string action, ExtensibleEnum exEnum, SimpleEnum? @enum = null, CancellationToken cancellationToken = default)
+        public virtual Response<Thing> TopActionValue(string action, ExtensibleEnum exEnum, SimpleEnum? @enum = null, ExtensibleEnum? exEnumWithDefault = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(action, nameof(action));
+            exEnumWithDefault ??= ExtensibleEnum.Two;
 
             using var scope = ClientDiagnostics.CreateScope("HelloWorldClient.TopActionValue");
             scope.Start();
             try
             {
                 RequestContext context = FromCancellationToken(cancellationToken);
-                Response response = TopAction(action, exEnum.ToString(), @enum?.ToSerialString(), context);
+                Response response = TopAction(action, exEnum.ToString(), @enum?.ToSerialString(), exEnumWithDefault?.ToString(), context);
                 return Response.FromValue(Thing.FromResponse(response), response);
             }
             catch (Exception e)
@@ -109,6 +113,7 @@ namespace CadlFirstTest
         /// <param name="action"> The String to use. </param>
         /// <param name="exEnum"> The ExtensibleEnum to use. Allowed values: &quot;1&quot; | &quot;2&quot; | &quot;4&quot;. </param>
         /// <param name="enum"> The SimpleEnum to use. Allowed values: &quot;1&quot; | &quot;2&quot; | &quot;4&quot;. </param>
+        /// <param name="exEnumWithDefault"> The ExtensibleEnum to use. Allowed values: &quot;1&quot; | &quot;2&quot; | &quot;4&quot;. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="action"/> or <paramref name="exEnum"/> is null. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
@@ -129,7 +134,7 @@ namespace CadlFirstTest
         /// var endpoint = new Uri("<https://my-service.azure.com>");
         /// var client = new HelloWorldClient(endpoint, "<apiVersion>");
         /// 
-        /// Response response = await client.TopActionAsync("<action>", "<exEnum>", "<enum>");
+        /// Response response = await client.TopActionAsync("<action>", "<exEnum>", "<enum>", "<exEnumWithDefault>");
         /// 
         /// JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
         /// Console.WriteLine(result.GetProperty("name").ToString());
@@ -147,16 +152,17 @@ namespace CadlFirstTest
         /// </code>
         /// 
         /// </remarks>
-        public virtual async Task<Response> TopActionAsync(string action, string exEnum, string @enum = null, RequestContext context = null)
+        public virtual async Task<Response> TopActionAsync(string action, string exEnum, string @enum = null, string exEnumWithDefault = null, RequestContext context = null)
         {
             Argument.AssertNotNull(action, nameof(action));
             Argument.AssertNotNull(exEnum, nameof(exEnum));
+            exEnumWithDefault ??= ExtensibleEnum.Two.ToString();
 
             using var scope = ClientDiagnostics.CreateScope("HelloWorldClient.TopAction");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateTopActionRequest(action, exEnum, @enum, context);
+                using HttpMessage message = CreateTopActionRequest(action, exEnum, @enum, exEnumWithDefault, context);
                 return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -169,6 +175,7 @@ namespace CadlFirstTest
         /// <param name="action"> The String to use. </param>
         /// <param name="exEnum"> The ExtensibleEnum to use. Allowed values: &quot;1&quot; | &quot;2&quot; | &quot;4&quot;. </param>
         /// <param name="enum"> The SimpleEnum to use. Allowed values: &quot;1&quot; | &quot;2&quot; | &quot;4&quot;. </param>
+        /// <param name="exEnumWithDefault"> The ExtensibleEnum to use. Allowed values: &quot;1&quot; | &quot;2&quot; | &quot;4&quot;. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="action"/> or <paramref name="exEnum"/> is null. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
@@ -189,7 +196,7 @@ namespace CadlFirstTest
         /// var endpoint = new Uri("<https://my-service.azure.com>");
         /// var client = new HelloWorldClient(endpoint, "<apiVersion>");
         /// 
-        /// Response response = client.TopAction("<action>", "<exEnum>", "<enum>");
+        /// Response response = client.TopAction("<action>", "<exEnum>", "<enum>", "<exEnumWithDefault>");
         /// 
         /// JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
         /// Console.WriteLine(result.GetProperty("name").ToString());
@@ -207,16 +214,17 @@ namespace CadlFirstTest
         /// </code>
         /// 
         /// </remarks>
-        public virtual Response TopAction(string action, string exEnum, string @enum = null, RequestContext context = null)
+        public virtual Response TopAction(string action, string exEnum, string @enum = null, string exEnumWithDefault = null, RequestContext context = null)
         {
             Argument.AssertNotNull(action, nameof(action));
             Argument.AssertNotNull(exEnum, nameof(exEnum));
+            exEnumWithDefault ??= ExtensibleEnum.Two.ToString();
 
             using var scope = ClientDiagnostics.CreateScope("HelloWorldClient.TopAction");
             scope.Start();
             try
             {
-                using HttpMessage message = CreateTopActionRequest(action, exEnum, @enum, context);
+                using HttpMessage message = CreateTopActionRequest(action, exEnum, @enum, exEnumWithDefault, context);
                 return _pipeline.ProcessMessage(message, context);
             }
             catch (Exception e)
@@ -348,7 +356,7 @@ namespace CadlFirstTest
             }
         }
 
-        internal HttpMessage CreateTopActionRequest(string action, string exEnum, string @enum, RequestContext context)
+        internal HttpMessage CreateTopActionRequest(string action, string exEnum, string @enum, string exEnumWithDefault, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier200);
             var request = message.Request;
@@ -364,6 +372,10 @@ namespace CadlFirstTest
             if (@enum != null)
             {
                 uri.AppendQuery("enum", @enum, true);
+            }
+            if (exEnumWithDefault != null)
+            {
+                uri.AppendQuery("exEnum", exEnumWithDefault, true);
             }
             request.Uri = uri;
             return message;

--- a/test/TestProjects/CadlFirstTest/Generated/cadl.json
+++ b/test/TestProjects/CadlFirstTest/Generated/cadl.json
@@ -143,6 +143,16 @@
               "Kind": "Method"
             },
             {
+              "Name": "exEnumWithDefault",
+              "NameInRequest": "exEnum",
+              "Description": "",
+              "Type": {"$ref" :"5"},
+              "Location": "Query",
+              "IsRequired": false,
+              "DefaultValue": {"Value":"2", "Type": {"$ref" :"5"}},
+              "Kind": "Method"
+            },
+            {
               "$id": "3",
               "Name": "apiVersion",
               "NameInRequest": "apiVersion",


### PR DESCRIPTION
- In `CanBeInitializedInline`, `type` may be initialized inline (e.g. `string`), but `defaultValue`, though convertible to `type`, may not be used for inline initialization (e.g. extensible enum). So, if `type` is different than the type of `defaultValue`, we need to check if `defaultValue` can be assigned to its own type, then check for the provided type
- `GetParameterInitializer` should add conversion extension method if required