### PR TITLE
fix(dpg): duplicated names in `CodeWriterScopeDecalarations`

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterScopeDeclarations.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterScopeDeclarations.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace AutoRest.CSharp.Generation.Writers
@@ -12,13 +14,34 @@ namespace AutoRest.CSharp.Generation.Writers
         public CodeWriterScopeDeclarations(IEnumerable<CodeWriterDeclaration> declarations)
         {
             var names = new List<string>();
+            var existingNames = new HashSet<string>();
             foreach (var declaration in declarations)
             {
-                declaration.SetActualName(declaration.RequestedName);
+                declaration.SetActualName(GetUniqueName(declaration.RequestedName, existingNames));
                 names.Add(declaration.ActualName);
+                existingNames.Add(declaration.ActualName);
             }
 
             Names = names;
+        }
+
+        // for the declarations in the same level of scope, we should ensure the names are unique
+        private static string GetUniqueName(string requestedName, IReadOnlyCollection<string> existingNames)
+        {
+            if (!existingNames.Contains(requestedName))
+            {
+                return requestedName;
+            }
+
+            for (int i = 0; i < 100; i++)
+            {
+                var name = requestedName + i;
+                if (!existingNames.Contains(name))
+                {
+                    return name;
+                }
+            }
+            throw new InvalidOperationException("Can't find suitable variable name.");
         }
     }
 }

--- a/test/AutoRest.TestServer.Tests/Common/Generation/Writers/CodeWriterScopeDeclarationsTests.cs
+++ b/test/AutoRest.TestServer.Tests/Common/Generation/Writers/CodeWriterScopeDeclarationsTests.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+
+namespace AutoRest.CSharp.Generation.Writers.Tests
+{
+    public class CodeWriterScopeDeclarationsTests
+    {
+        [Test]
+        public void UniqueRequestedNames()
+        {
+            var declarations = new CodeWriterScopeDeclarations(new CodeWriterDeclaration[]
+            {
+                new CodeWriterDeclaration("foo"),
+                new CodeWriterDeclaration("bar")
+            });
+
+            Assert.AreEqual(declarations.Names, new string[] { "foo", "bar" });
+        }
+
+        [Test]
+        public void DuplicatedRequestedNames()
+        {
+            var declarations = new CodeWriterScopeDeclarations(new CodeWriterDeclaration[]
+            {
+                new CodeWriterDeclaration("foo"),
+                new CodeWriterDeclaration("foo"),
+                new CodeWriterDeclaration("foo")
+            });
+
+            Assert.AreEqual(declarations.Names, new string[] { "foo", "foo0", "foo1" });
+        }
+    }
+}


### PR DESCRIPTION
right now we don't try to resolve duplication in the names inside a `CodeWriterScopeDeclarations` which will generate fields with duplicated names, like the case in https://github.com/Azure/azure-sdk-for-net/issues/29223#issuecomment-1167917629

this commit will fix the issue:
- try to assign a new name if the currently requested name is occupied
- add unit test

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first