### PR TITLE
fix(common): remove duplicated security schemes

### DIFF
--- a/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
@@ -42,7 +42,7 @@ namespace AutoRest.CSharp.Common.Input
                 Models: models,
                 Enums: enums,
                 ApiVersions: GetApiVersions(codeModel),
-                Auth: new CodeModelSecurity(Schemes: codeModel.Security.Schemes.OfType<SecurityScheme>().ToList()));
+                Auth: new CodeModelSecurity(Schemes: codeModel.Security.Schemes.OfType<SecurityScheme>().Distinct().ToList()));
         }
 
         public IReadOnlyList<InputClient> CreateClients(IEnumerable<OperationGroup> operationGroups)

--- a/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
@@ -730,5 +730,91 @@ namespace AutoRest.CSharp.Input
         public string CSharpName() =>
             (this.Language.Default.Name == null || this.Language.Default.Name == "null") ? "NullProperty" : this.Language.Default.Name.ToCleanName();
     }
+
+
+    internal partial class SecurityScheme
+    {
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is SecurityScheme scheme))
+            {
+                return false;
+            }
+            return (Type == scheme.Type);
+        }
+
+        public override int GetHashCode()
+        {
+            return Type.GetHashCode();
+        }
+    }
+
+    internal partial class OAuth2SecurityScheme : SecurityScheme
+    {
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is OAuth2SecurityScheme scheme))
+            {
+                return false;
+            }
+            return base.Equals(obj) && Scopes.SequenceEqual(scheme.Scopes);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode() ^ Scopes.GetHashCode();
+        }
+    }
+
+    internal partial class KeySecurityScheme : SecurityScheme
+    {
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is KeySecurityScheme scheme))
+            {
+                return false;
+            }
+            return base.Equals(obj) & (In == scheme.In) && (Name == scheme.Name);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode() ^ In.GetHashCode() ^ Name.GetHashCode();
+        }
+    }
+
+    internal partial class AADTokenSecurityScheme : SecurityScheme
+    {
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is AADTokenSecurityScheme scheme))
+            {
+                return false;
+            }
+            return base.Equals(obj) && Scopes.SequenceEqual(scheme.Scopes);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode() ^ Scopes.GetHashCode();
+        }
+    }
+
+    internal partial class AzureKeySecurityScheme : SecurityScheme
+    {
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is AzureKeySecurityScheme scheme))
+            {
+                return false;
+            }
+            return base.Equals(obj) & (HeaderName == scheme.HeaderName);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode() ^ HeaderName.GetHashCode();
+        }
+    }
 }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.


### PR DESCRIPTION
it's possible that in some cases the M4 will pass in duplicated security schemes. That will cause duplicated security auth fields being generated.

this commit fixes the issue:
- override `Equals()` and `GetHashCode` for each security scheme type
- when convert M4 model, call `Distinct` to remove duplicated security schemes

part of https://github.com/Azure/azure-sdk-for-net/issues/29223

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first