### PR TITLE
feat(dpg): follow-up changes on readonly property

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -21,7 +21,7 @@ namespace AutoRest.CSharp.Output.Models.Shared
         public static Parameter FromModelProperty(in InputModelProperty property, CSharpType propertyType)
         {
             var name = property.Name.ToVariableName();
-            var validation = propertyType.IsValueType ? ValidationType.None : ValidationType.AssertNotNull;
+            var validation = propertyType.IsValueType || property.IsReadOnly ? ValidationType.None : ValidationType.AssertNotNull;
             return new Parameter(name, property.Description, propertyType, null, validation, null);
         }
 

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelModelWriter.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelModelWriter.cs
@@ -51,7 +51,7 @@ namespace AutoRest.CSharp.Generation.Writers
                 // TODO: Add IReadOnlyDictionary
                 foreach (var field in model.Fields.Where(f => TypeFactory.IsReadOnlyList(f.Type)))
                 {
-                    writer.Line($"{field.Name:I} = new List<{field.Type.Arguments[0]}>(0);");
+                    writer.Line($"{field.Name:I} = new List<{field.Type.Arguments[0]}>(0).AsReadOnly();");
                 }
             }
         }

--- a/test/AutoRest.TestServerLowLevel.Tests/LowLevel/Generation/ReadonlyPropertyWritingTests.cs
+++ b/test/AutoRest.TestServerLowLevel.Tests/LowLevel/Generation/ReadonlyPropertyWritingTests.cs
@@ -48,9 +48,7 @@ namespace AutoRest.CSharp.Generation.Writers.Tests
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
-using Azure.Core;
 
 namespace Cadl.TestServer.ReadonlyProperties.Models
 {
@@ -59,10 +57,10 @@ public partial class RoundTripModel
 /// <summary> Initializes a new instance of RoundTripModel. </summary>
 public RoundTripModel()
 {
-RequiredReadonlyStringList = new List<string>(0);
-RequiredReadonlyIntList = new List<int>(0);
-OptionalReadonlyStringList = new List<string>(0);
-OptionalReadonlyIntList = new List<int>(0);
+RequiredReadonlyStringList = new List<string>(0).AsReadOnly();
+RequiredReadonlyIntList = new List<int>(0).AsReadOnly();
+OptionalReadonlyStringList = new List<string>(0).AsReadOnly();
+OptionalReadonlyIntList = new List<int>(0).AsReadOnly();
 }
 /// <summary> Initializes a new instance of RoundTripModel. </summary>
 /// <param name=""requiredReadonlyString""> Required string, illustrating a readonly reference type property. </param>
@@ -73,16 +71,8 @@ OptionalReadonlyIntList = new List<int>(0);
 /// <param name=""requiredReadonlyIntList""> Required readonly int collection. </param>
 /// <param name=""optionalReadonlyStringList""> Optional readonly string collection. </param>
 /// <param name=""optionalReadonlyIntList""> Optional readonly int collection. </param>
-/// <exception cref=""global::System.ArgumentNullException""> <paramref name=""requiredReadonlyString""/>, <paramref name=""optionalReadonlyString""/>, <paramref name=""requiredReadonlyStringList""/>, <paramref name=""requiredReadonlyIntList""/>, <paramref name=""optionalReadonlyStringList""/> or <paramref name=""optionalReadonlyIntList""/> is null. </exception>
 internal RoundTripModel(string requiredReadonlyString,int requiredReadonlyInt,string optionalReadonlyString,int optionalReadonlyInt,global::System.Collections.Generic.IReadOnlyList<string> requiredReadonlyStringList,global::System.Collections.Generic.IReadOnlyList<int> requiredReadonlyIntList,global::System.Collections.Generic.IReadOnlyList<string> optionalReadonlyStringList,global::System.Collections.Generic.IReadOnlyList<int> optionalReadonlyIntList)
 {
-global::Azure.Core.Argument.AssertNotNull(requiredReadonlyString, nameof(requiredReadonlyString));
-global::Azure.Core.Argument.AssertNotNull(optionalReadonlyString, nameof(optionalReadonlyString));
-global::Azure.Core.Argument.AssertNotNull(requiredReadonlyStringList, nameof(requiredReadonlyStringList));
-global::Azure.Core.Argument.AssertNotNull(requiredReadonlyIntList, nameof(requiredReadonlyIntList));
-global::Azure.Core.Argument.AssertNotNull(optionalReadonlyStringList, nameof(optionalReadonlyStringList));
-global::Azure.Core.Argument.AssertNotNull(optionalReadonlyIntList, nameof(optionalReadonlyIntList));
-
 RequiredReadonlyString = requiredReadonlyString;
 RequiredReadonlyInt = requiredReadonlyInt;
 OptionalReadonlyString = optionalReadonlyString;


### PR DESCRIPTION
- add `AsReadOnly()` when initialize a read-only list
- do not valid readonly values in serialization constructor

part of #2341 

# Conflicts:
#	test/TestProjects/PetStore-Cadl/Generated/Pet.cs

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first