### PR TITLE
fix(dataplane): infinite recursion in protocol methods ininitialization

### DIFF
--- a/src/AutoRest.CSharp/DataPlane/Output/DataPlaneRestClient.cs
+++ b/src/AutoRest.CSharp/DataPlane/Output/DataPlaneRestClient.cs
@@ -14,8 +14,10 @@ namespace AutoRest.CSharp.Output.Models
     internal class DataPlaneRestClient : RestClient
     {
         private readonly BuildContext<DataPlaneOutputLibrary> _context;
+        // postpone the calculation, since it depends on the initialization of context
+        private readonly Lazy<IReadOnlyList<LowLevelClientMethod>> _protocolMethods;
 
-        public IReadOnlyList<LowLevelClientMethod> ProtocolMethods { get; }
+        public IReadOnlyList<LowLevelClientMethod> ProtocolMethods => _protocolMethods.Value;
         public RestClientBuilder ClientBuilder { get; }
         public ClientFields Fields { get; }
 
@@ -25,7 +27,7 @@ namespace AutoRest.CSharp.Output.Models
             _context = context;
             ClientBuilder = clientBuilder;
             Fields = ClientFields.CreateForRestClient(Parameters);
-            ProtocolMethods = GetProtocolMethods(inputClient, context).ToList();
+            _protocolMethods = new Lazy<IReadOnlyList<LowLevelClientMethod>>(() => GetProtocolMethods(inputClient, context).ToList());
         }
 
         protected override Dictionary<InputOperation, RestClientMethod> EnsureNormalMethods()

--- a/test/TestProjects/ProtocolMethodsInRestClient/Generated/CodeModel.yaml
+++ b/test/TestProjects/ProtocolMethodsInRestClient/Generated/CodeModel.yaml
@@ -220,6 +220,17 @@ operationGroups:
             protocol: !Protocols 
               http: !HttpParameter 
                 in: path
+          - !Parameter &ref_11
+            schema: *ref_9
+            implementation: Method
+            language: !Languages 
+              default:
+                name: ifMatch
+                description: The ETag of the transformation.
+                serializedName: If-Match
+            protocol: !Protocols 
+              http: !HttpParameter 
+                in: header
         requests:
           - !Request 
             language: !Languages 
@@ -233,6 +244,7 @@ operationGroups:
                 uri: '{$host}'
         signatureParameters:
           - *ref_10
+          - *ref_11
         responses:
           - !Response 
             language: !Languages 
@@ -255,7 +267,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_11
+          - !Parameter &ref_12
             schema: *ref_9
             implementation: Method
             required: true
@@ -294,7 +306,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_11
+          - *ref_12
         responses:
           - !SchemaResponse 
             schema: *ref_5
@@ -330,7 +342,7 @@ operationGroups:
         parameters:
           - *ref_3
         requestMediaTypes:
-          application/json: !Request &ref_13
+          application/json: !Request &ref_14
             parameters:
               - !Parameter 
                 schema: *ref_4
@@ -345,7 +357,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_12
+              - !Parameter &ref_13
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -371,7 +383,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_12
+              - *ref_13
             language: !Languages 
               default:
                 name: ''
@@ -385,7 +397,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_13
+          - *ref_14
         signatureParameters: []
         responses:
           - !SchemaResponse 
@@ -413,7 +425,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_14
+          - !Parameter &ref_15
             schema: *ref_9
             implementation: Method
             required: true
@@ -437,7 +449,7 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_14
+          - *ref_15
         responses:
           - !Response 
             language: !Languages 
@@ -460,7 +472,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_15
+          - !Parameter &ref_16
             schema: *ref_9
             implementation: Method
             required: true
@@ -499,7 +511,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_15
+          - *ref_16
         responses:
           - !SchemaResponse 
             schema: *ref_5
@@ -535,7 +547,7 @@ operationGroups:
         parameters:
           - *ref_3
         requestMediaTypes:
-          application/json: !Request &ref_17
+          application/json: !Request &ref_18
             parameters:
               - !Parameter 
                 schema: *ref_4
@@ -550,7 +562,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_16
+              - !Parameter &ref_17
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -576,7 +588,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_16
+              - *ref_17
             language: !Languages 
               default:
                 name: ''
@@ -590,7 +602,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_17
+          - *ref_18
         signatureParameters: []
         responses:
           - !SchemaResponse 
@@ -618,7 +630,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_18
+          - !Parameter &ref_19
             schema: *ref_9
             implementation: Method
             required: true
@@ -642,7 +654,7 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_18
+          - *ref_19
         responses:
           - !Response 
             language: !Languages 
@@ -665,7 +677,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_19
+          - !Parameter &ref_20
             schema: *ref_9
             implementation: Method
             required: true
@@ -704,7 +716,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_19
+          - *ref_20
         responses:
           - !SchemaResponse 
             schema: *ref_5
@@ -739,7 +751,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_20
+          - !Parameter &ref_21
             schema: *ref_9
             implementation: Method
             required: true
@@ -763,7 +775,7 @@ operationGroups:
                 method: delete
                 uri: '{$host}'
         signatureParameters:
-          - *ref_20
+          - *ref_21
         responses:
           - !Response 
             language: !Languages 
@@ -786,7 +798,7 @@ operationGroups:
             version: 1.0.0
         parameters:
           - *ref_3
-          - !Parameter &ref_21
+          - !Parameter &ref_22
             schema: *ref_9
             implementation: Method
             required: true
@@ -825,7 +837,7 @@ operationGroups:
                 method: get
                 uri: '{$host}'
         signatureParameters:
-          - *ref_21
+          - *ref_22
         responses:
           - !SchemaResponse 
             schema: *ref_5
@@ -853,7 +865,7 @@ operationGroups:
         parameters:
           - *ref_3
         requestMediaTypes:
-          application/json: !Request &ref_23
+          application/json: !Request &ref_24
             parameters:
               - !Parameter 
                 schema: *ref_4
@@ -868,7 +880,7 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_22
+              - !Parameter &ref_23
                 schema: *ref_5
                 implementation: Method
                 required: false
@@ -894,7 +906,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_22
+              - *ref_23
             language: !Languages 
               default:
                 name: ''
@@ -908,7 +920,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_23
+          - *ref_24
         signatureParameters: []
         responses:
           - !SchemaResponse 

--- a/test/TestProjects/ProtocolMethodsInRestClient/Generated/TestServiceClient.cs
+++ b/test/TestProjects/ProtocolMethodsInRestClient/Generated/TestServiceClient.cs
@@ -95,14 +95,15 @@ namespace ProtocolMethodsInRestClient
 
         /// <summary> Delete resource. </summary>
         /// <param name="resourceId"> The id of the resource. </param>
+        /// <param name="ifMatch"> The ETag of the transformation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> DeleteAsync(string resourceId, CancellationToken cancellationToken = default)
+        public virtual async Task<Response> DeleteAsync(string resourceId, string ifMatch = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("TestServiceClient.Delete");
             scope.Start();
             try
             {
-                return await RestClient.DeleteAsync(resourceId, cancellationToken).ConfigureAwait(false);
+                return await RestClient.DeleteAsync(resourceId, ifMatch, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -113,14 +114,15 @@ namespace ProtocolMethodsInRestClient
 
         /// <summary> Delete resource. </summary>
         /// <param name="resourceId"> The id of the resource. </param>
+        /// <param name="ifMatch"> The ETag of the transformation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response Delete(string resourceId, CancellationToken cancellationToken = default)
+        public virtual Response Delete(string resourceId, string ifMatch = null, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("TestServiceClient.Delete");
             scope.Start();
             try
             {
-                return RestClient.Delete(resourceId, cancellationToken);
+                return RestClient.Delete(resourceId, ifMatch, cancellationToken);
             }
             catch (Exception e)
             {

--- a/test/TestProjects/ProtocolMethodsInRestClient/Generated/TestServiceRestClient.cs
+++ b/test/TestProjects/ProtocolMethodsInRestClient/Generated/TestServiceRestClient.cs
@@ -155,7 +155,7 @@ namespace ProtocolMethodsInRestClient
             }
         }
 
-        internal HttpMessage CreateDeleteRequest(string resourceId)
+        internal HttpMessage CreateDeleteRequest(string resourceId, string ifMatch)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -165,21 +165,26 @@ namespace ProtocolMethodsInRestClient
             uri.AppendPath("/template/resources/", false);
             uri.AppendPath(resourceId, true);
             request.Uri = uri;
+            if (ifMatch != null)
+            {
+                request.Headers.Add("If-Match", ifMatch);
+            }
             return message;
         }
 
         /// <summary> Delete resource. </summary>
         /// <param name="resourceId"> The id of the resource. </param>
+        /// <param name="ifMatch"> The ETag of the transformation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceId"/> is null. </exception>
-        public async Task<Response> DeleteAsync(string resourceId, CancellationToken cancellationToken = default)
+        public async Task<Response> DeleteAsync(string resourceId, string ifMatch = null, CancellationToken cancellationToken = default)
         {
             if (resourceId == null)
             {
                 throw new ArgumentNullException(nameof(resourceId));
             }
 
-            using var message = CreateDeleteRequest(resourceId);
+            using var message = CreateDeleteRequest(resourceId, ifMatch);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -192,16 +197,17 @@ namespace ProtocolMethodsInRestClient
 
         /// <summary> Delete resource. </summary>
         /// <param name="resourceId"> The id of the resource. </param>
+        /// <param name="ifMatch"> The ETag of the transformation. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceId"/> is null. </exception>
-        public Response Delete(string resourceId, CancellationToken cancellationToken = default)
+        public Response Delete(string resourceId, string ifMatch = null, CancellationToken cancellationToken = default)
         {
             if (resourceId == null)
             {
                 throw new ArgumentNullException(nameof(resourceId));
             }
 
-            using var message = CreateDeleteRequest(resourceId);
+            using var message = CreateDeleteRequest(resourceId, ifMatch);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -212,7 +218,7 @@ namespace ProtocolMethodsInRestClient
             }
         }
 
-        internal HttpMessage CreateDeleteRequest(string resourceId, RequestContext context)
+        internal HttpMessage CreateDeleteRequest(string resourceId, ETag? ifMatch, RequestContext context)
         {
             var message = _pipeline.CreateMessage(context, ResponseClassifier204);
             var request = message.Request;
@@ -222,17 +228,22 @@ namespace ProtocolMethodsInRestClient
             uri.AppendPath("/template/resources/", false);
             uri.AppendPath(resourceId, true);
             request.Uri = uri;
+            if (ifMatch != null)
+            {
+                request.Headers.Add("If-Match", ifMatch.Value);
+            }
             return message;
         }
 
         /// <summary> Delete resource. </summary>
         /// <param name="resourceId"> The id of the resource. </param>
+        /// <param name="ifMatch"> The ETag of the transformation. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="resourceId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        public virtual async Task<Response> DeleteAsync(string resourceId, RequestContext context = null)
+        public virtual async Task<Response> DeleteAsync(string resourceId, ETag? ifMatch = null, RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(resourceId, nameof(resourceId));
 
@@ -240,7 +251,7 @@ namespace ProtocolMethodsInRestClient
             scope.Start();
             try
             {
-                using HttpMessage message = CreateDeleteRequest(resourceId, context);
+                using HttpMessage message = CreateDeleteRequest(resourceId, ifMatch, context);
                 return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -252,12 +263,13 @@ namespace ProtocolMethodsInRestClient
 
         /// <summary> Delete resource. </summary>
         /// <param name="resourceId"> The id of the resource. </param>
+        /// <param name="ifMatch"> The ETag of the transformation. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceId"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="resourceId"/> is an empty string, and was expected to be non-empty. </exception>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        public virtual Response Delete(string resourceId, RequestContext context = null)
+        public virtual Response Delete(string resourceId, ETag? ifMatch = null, RequestContext context = null)
         {
             Argument.AssertNotNullOrEmpty(resourceId, nameof(resourceId));
 
@@ -265,7 +277,7 @@ namespace ProtocolMethodsInRestClient
             scope.Start();
             try
             {
-                using HttpMessage message = CreateDeleteRequest(resourceId, context);
+                using HttpMessage message = CreateDeleteRequest(resourceId, ifMatch, context);
                 return _pipeline.ProcessMessage(message, context);
             }
             catch (Exception e)

--- a/test/TestProjects/ProtocolMethodsInRestClient/ProtocolMethodsInRestClient.json
+++ b/test/TestProjects/ProtocolMethodsInRestClient/ProtocolMethodsInRestClient.json
@@ -51,6 +51,13 @@
             "required": true,
             "type": "string",
             "description": "The id of the resource."
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "The ETag of the transformation."
           }
         ],
         "responses": {


### PR DESCRIPTION
There is an infinite recursion between `DataPlaneOutputLibaray.EnsureRestClients()` and `DataPlaneRestClient.GetProtocolMethods()`. Since `DataPlaneRestClient.ProtocolMethods` can be evaluated later after `DataPlaneRestClient` is created, the fix is to postpone its evaluation when the getter is invoked.

fix #2620

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first