### PR TITLE
Refactor the remover and fix the "unused field" issues

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -145,7 +145,6 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 throw new InvalidOperationException($"At least one file was overridden during the generation process. Filenames are: {string.Join(", ", overriddenFilenames)}");
 
             await project.PostProcess(PostProcess);
-
         }
 
         private static async Task<Project> PostProcess(Project project)

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -155,6 +155,8 @@ namespace AutoRest.CSharp.AutoRest.Plugins
 
             project = await Remover.RemoveUnusedAsync(project, modelsToKeep);
 
+            project = await Remover.RemoveUnusedFieldsAsync(project);
+
             return project;
         }
 

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/PostProcessCommon.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/PostProcess/PostProcessCommon.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.CSharp.AutoRest.Plugins;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AutoRest.CSharp.Mgmt.AutoRest.PostProcess
+{
+    internal static class PostProcessCommon
+    {
+        /// <summary>
+        /// Get all the models (including Clients) defined in this generated project.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <param name="publicOnly"></param>
+        /// <returns></returns>
+        public static async Task<ImmutableHashSet<BaseTypeDeclarationSyntax>> GetModels(Project project, bool publicOnly)
+        {
+            var classVisitor = new DefinitionVisitor(publicOnly);
+
+            foreach (var document in project.Documents)
+            {
+                if (!GeneratedCodeWorkspace.IsSharedDocument(document))
+                {
+                    var root = await document.GetSyntaxRootAsync();
+                    classVisitor.Visit(root);
+                }
+            }
+
+            return classVisitor.ModelDeclarations;
+        }
+
+        /// <summary>
+        /// Get the "root node" in this generated project.
+        /// A root node is defined as the type defined in a root document (file).
+        /// A root document (file) consists of three different types:
+        /// 1. the file is `IsMgmtRootDocument` - it is generated and under the root directory or `Extensions` of our generated output folder. This includes all the resource classes, collection classes, data classes and all the extension clients
+        /// 2. the file is declaring a `ReferenceType`, a special type with some specific attributes
+        /// 3. the file is customized code (not generated and not shared)
+        /// </summary>
+        /// <param name="project"></param>
+        /// <param name="publicOnly"></param>
+        /// <param name="modelsToKeep"></param>
+        /// <returns></returns>
+        public static async Task<ImmutableHashSet<BaseTypeDeclarationSyntax>> GetRootNodes(Project project, bool publicOnly, ImmutableHashSet<string>? modelsToKeep = null)
+        {
+            modelsToKeep ??= ImmutableHashSet<string>.Empty;
+            var classVisitor = new DefinitionVisitor(publicOnly);
+            foreach (var document in project.Documents)
+            {
+                var root = await document.GetSyntaxRootAsync();
+                // we add a declaration as root node when
+                // 1. the file is under `Generated` or `Generated/Extensions` which is handled by `IsMgmtRootDocument`
+                // 2. the declaration has a ReferenceType or similar attribute on it which is handled by `IsReferenceType`
+                // 3. the file is customized code (not generated and not shared) which is handled by `IsCustomDocument`
+                if (IsMgmtRootDocument(document) || IsReferenceType(root) || GeneratedCodeWorkspace.IsCustomDocument(document) || ShouldKeepModel(root, modelsToKeep))
+                {
+                    classVisitor.Visit(root);
+                }
+            }
+
+            return classVisitor.ModelDeclarations;
+        }
+
+        public static async Task<ImmutableHashSet<BaseTypeDeclarationSyntax>> GetClients(Project project)
+        {
+            var classVisitor = new DefinitionVisitor(false);
+            foreach (var document in project.Documents)
+            {
+                var root = await document.GetSyntaxRootAsync();
+                if (IsMgmtRootDocument(document) && GeneratedCodeWorkspace.IsGeneratedDocument(document))
+                {
+                    classVisitor.Visit(root);
+                }
+            }
+
+            return classVisitor.ModelDeclarations;
+        }
+
+        private static bool IsMgmtRootDocument(Document document) => GeneratedCodeWorkspace.IsGeneratedDocument(document) && Path.GetDirectoryName(document.Name) is "Extensions" or "";
+
+        private static HashSet<string> _referenceAttributes = new HashSet<string> { "ReferenceType", "PropertyReferenceType", "TypeReferenceType" };
+
+        private static bool IsReferenceType(SyntaxNode? root)
+        {
+            if (root is null)
+                return false;
+
+            var childNodes = root.DescendantNodes();
+            var typeNode = childNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
+            if (typeNode is null)
+            {
+                return false;
+            }
+
+            var attributeLists = GetAttributeLists(typeNode);
+            if (attributeLists is null || attributeLists.Value.Count == 0)
+                return false;
+
+            foreach (var attributeList in attributeLists.Value)
+            {
+                if (_referenceAttributes.Contains(attributeList.Attributes[0].Name.ToString()))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static SyntaxList<AttributeListSyntax>? GetAttributeLists(SyntaxNode node)
+        {
+            if (node is StructDeclarationSyntax structDeclaration)
+                return structDeclaration.AttributeLists;
+
+            if (node is ClassDeclarationSyntax classDeclaration)
+                return classDeclaration.AttributeLists;
+
+            return null;
+        }
+
+        private static bool ShouldKeepModel(SyntaxNode? root, ImmutableHashSet<string> modelsToKeep)
+        {
+            if (root is null)
+                return false;
+
+            // use `BaseTypeDeclarationSyntax` to also include enums because `EnumDeclarationSyntax` extends `BaseTypeDeclarationSyntax`
+            // `ClassDeclarationSyntax` and `StructDeclarationSyntax` both inherit `TypeDeclarationSyntax`
+            var typeNodes = root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>();
+            // there is possibility that we have multiple types defined in the same document (for instance, custom code)
+            return typeNodes.Any(t => modelsToKeep.Contains(t.Identifier.Text));
+        }
+    }
+}

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -210,11 +210,11 @@ namespace AutoRest.CSharp.Mgmt.Generation
             FormattableString ctorString = ConstructClientDiagnostic(_writer, $"{GetProviderNamespaceFromReturnType(resourceName)}", DiagnosticsProperty);
             string diagFieldName = GetDiagnosticFieldName(restClient, resource);
             _writer.Line($"{diagFieldName} = {ctorString};");
-            string apiVersionText = string.Empty;
+            FormattableString apiVersionText = $"";
             if (resource is not null)
             {
-                string apiVersionVariable = GetApiVersionVariableName(restClient, resource);
-                _writer.Line($"TryGetApiVersion({resourceName}.ResourceType, out string {apiVersionVariable});");
+                var apiVersionVariable = new CodeWriterDeclaration(GetApiVersionVariableName(restClient, resource));
+                _writer.Line($"TryGetApiVersion({resourceName}.ResourceType, out string {apiVersionVariable:D});");
                 apiVersionText = $", {apiVersionVariable}";
             }
             _writer.Line($"{GetRestFieldName(restClient, resource)} = {GetRestConstructorString(restClient, apiVersionText)};");
@@ -401,32 +401,32 @@ namespace AutoRest.CSharp.Mgmt.Generation
             return $"new {typeof(ClientDiagnostics)}(\"{This.Type.Namespace}\", {providerNamespace}, {diagnosticsOptionsVariable})";
         }
 
-        protected string GetRestConstructorString(MgmtRestClient restClient, string apiVersionVariable)
+        protected FormattableString GetRestConstructorString(MgmtRestClient restClient, FormattableString apiVersionVariable)
         {
             string subIdVariable = ", Id.SubscriptionId";
             if (!restClient.Parameters.Any(p => p.Name.Equals("subscriptionId")))
                 subIdVariable = string.Empty;
-            return $"new {restClient.Type.Name}({PipelineProperty}, {DiagnosticsProperty}.ApplicationId{subIdVariable}, {EndpointProperty}{apiVersionVariable})";
+            return (FormattableString)$"new {restClient.Type.Name}({PipelineProperty}, {DiagnosticsProperty}.ApplicationId{subIdVariable}, {EndpointProperty}{apiVersionVariable})";
         }
 
         protected string GetRestClientName(MgmtRestOperation operation) => GetRestClientName(operation.RestClient, operation.Resource);
         private string GetRestClientName(MgmtRestClient client, Resource? resource)
         {
             var names = This.GetRestDiagNames(new NameSetKey(client, resource));
-            return UseField ? names.RestField : names.RestProperty;
+            return UseField ? names.RestFieldDeclaration.Name : names.RestProperty;
         }
 
         protected string GetDiagnosticName(MgmtRestOperation operation) => GetDiagnosticName(operation.RestClient, operation.Resource);
         private string GetDiagnosticName(MgmtRestClient client, Resource? resource)
         {
             var names = This.GetRestDiagNames(new NameSetKey(client, resource));
-            return UseField ? names.DiagnosticField : names.DiagnosticProperty;
+            return UseField ? names.DiagnosticFieldDeclaration.Name : names.DiagnosticProperty;
         }
 
         protected string GetRestPropertyName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).RestProperty;
-        protected string GetRestFieldName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).RestField;
+        protected string GetRestFieldName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).RestFieldDeclaration.Name;
         protected string GetDiagnosticsPropertyName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).DiagnosticProperty;
-        protected string GetDiagnosticFieldName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).DiagnosticField;
+        protected string GetDiagnosticFieldName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).DiagnosticFieldDeclaration.Name;
         protected virtual string GetApiVersionVariableName(MgmtRestClient client, Resource? resource) => This.GetRestDiagNames(new NameSetKey(client, resource)).ApiVersionVariable;
 
         protected internal static string GetConfigureAwait(bool isAsync)

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceExtensionWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceExtensionWriter.cs
@@ -49,8 +49,8 @@ namespace AutoRest.CSharp.Mgmt.Generation
             string diagPropertyName = GetDiagnosticsPropertyName(client, resource);
             FormattableString diagOptionsCtor = ConstructClientDiagnostic(_writer, GetProviderNamespaceFromReturnType(resourceName), DiagnosticsProperty);
             _writer.Line($"private {typeof(ClientDiagnostics)} {diagPropertyName} => {GetDiagnosticFieldName(client, resource)} ??= {diagOptionsCtor};");
-            string apiVersionString = resourceName == null ? string.Empty : $", GetApiVersionOrNull({resourceName}.ResourceType)";
-            string restCtor = GetRestConstructorString(client, apiVersionString);
+            FormattableString apiVersionString = resourceName == null ? (FormattableString)$"" : $", GetApiVersionOrNull({resourceName}.ResourceType)";
+            FormattableString restCtor = GetRestConstructorString(client, apiVersionString);
             _writer.Line($"private {client.Type} {GetRestPropertyName(client, resource)} => {GetRestFieldName(client, resource)} ??= {restCtor};");
         }
     }

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
@@ -89,14 +89,8 @@ namespace AutoRest.CSharp.Mgmt.Output
             foreach (var set in UniqueSets)
             {
                 var nameSet = GetRestDiagNames(set);
-                yield return new FieldDeclaration(
-                    FieldModifiers,
-                    typeof(ClientDiagnostics),
-                    nameSet.DiagnosticField);
-                yield return new FieldDeclaration(
-                    FieldModifiers,
-                    set.RestClient.Type,
-                    nameSet.RestField);
+                yield return nameSet.DiagnosticFieldDeclaration;
+                yield return nameSet.RestFieldDeclaration;
             }
 
             var additionalFields = GetAdditionalFields();
@@ -147,7 +141,9 @@ namespace AutoRest.CSharp.Mgmt.Output
                 $"{uniqueName}ClientDiagnostics",
                 $"_{uniqueVariable}RestClient",
                 $"{uniqueName}RestClient",
-                $"{uniqueVariable}ApiVersion");
+                $"{uniqueVariable}ApiVersion",
+                FieldModifiers,
+                client.Type);
             _nameCache.Add(set, result);
 
             return result;

--- a/src/AutoRest.CSharp/Mgmt/Output/NameSet.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/NameSet.cs
@@ -1,19 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using AutoRest.CSharp.Generation.Types;
+using AutoRest.CSharp.Output.Models;
+using Azure.Core.Pipeline;
+using static Azure.Core.HttpHeader;
+
 internal readonly struct NameSet
 {
-    public string DiagnosticField { get; }
+    //public string DiagnosticField { get; }
+    public FieldDeclaration DiagnosticFieldDeclaration { get; }
     public string DiagnosticProperty { get; }
-    public string RestField { get; }
+    //public string RestField { get; }
+    public FieldDeclaration RestFieldDeclaration { get; }
     public string RestProperty { get; }
     public string ApiVersionVariable { get; }
 
-    public NameSet(string diagField, string diagProperty, string restField, string restProperty, string apiVariable)
+    public NameSet(string diagField, string diagProperty, string restField, string restProperty, string apiVariable, FieldModifiers fieldModifiers, CSharpType restClientType)
     {
-        DiagnosticField = diagField;
+        //DiagnosticField = diagField;
+        DiagnosticFieldDeclaration = new FieldDeclaration(fieldModifiers, typeof(ClientDiagnostics), diagField);
         DiagnosticProperty = diagProperty;
-        RestField = restField;
+        //RestField = restField;
+        RestFieldDeclaration = new FieldDeclaration(fieldModifiers, restClientType, restField);
         RestProperty = restProperty;
         ApiVersionVariable = apiVariable;
     }


### PR DESCRIPTION
# Description

Sometimes in some RPs, the operation groups are not properly named, therefore we might have one resource corresponding to multiple restOperation instances.
And when the generator writes them, it is not checking if this restOperation will actually be used in this client it is writing. Therefore it is possible that one of the rest operation instance in this resource client is completely not used, and the compiler will complain about this.

This PR updates the remover, to make it is able to remove those unused field if any,

Updated: the root cause of the above issue is that the generator defines those field in different names, but when use it, it always uses its original name. Therefore we will have one field that is not used.
![image](https://user-images.githubusercontent.com/10554446/188412610-60f297f1-37be-4b73-b969-57f16d932ff9.png)
while actually we should have 
![image](https://user-images.githubusercontent.com/10554446/188412677-1a1e73cb-7b1e-4a7b-b680-c1f8bcb222ee.png)


# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first