### PR TITLE
Introduce PolicyAssignmentResource and PolicyDefinitionResource as built-in parent resource in the generator

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtFacts.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtFacts.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using AutoRest.CSharp.Input;
+using AutoRest.CSharp.Mgmt.Models;
+using Azure.ResourceManager.ManagementGroups;
+using Azure.ResourceManager.Resources;
+
+namespace AutoRest.CSharp.Mgmt.AutoRest
+{
+    internal static class MgmtFacts
+    {
+        public static List<ExtensibleResourceDetail> KnownExtensibleResources { get; }
+
+        public static List<ExtensibleResourceDetail> StandaloneExtensibleResources { get; }
+
+        static MgmtFacts()
+        {
+            KnownExtensibleResources = new()
+            {
+                new(typeof(ManagementGroupResource), RequestPath.ManagementGroup),
+                new(typeof(ResourceGroupResource), RequestPath.ResourceGroup),
+                new(typeof(SubscriptionResource), RequestPath.Subscription),
+                new(typeof(TenantResource), RequestPath.Tenant),
+            };
+            // the list of the extensible resources that are in an extension class. Those are not included will be generated as instance methods
+            StandaloneExtensibleResources = Configuration.MgmtConfiguration.IsArmCore ?
+                new()
+                {
+                    new(typeof(TenantResource), RequestPath.Tenant),
+                    new(typeof(ManagementGroupResource), RequestPath.ManagementGroup),
+                } :
+                new()
+                {
+                    new(typeof(TenantResource), RequestPath.Tenant),
+                    new(typeof(SubscriptionResource), RequestPath.Subscription),
+                    new(typeof(ResourceGroupResource), RequestPath.ResourceGroup),
+                    new(typeof(ManagementGroupResource), RequestPath.ManagementGroup),
+                };
+        }
+
+        public record ExtensibleResourceDetail(Type Type, RequestPath RequestPath);
+    }
+}

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtFacts.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtFacts.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoRest.CSharp.Input;
+using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Mgmt.Models;
 using Azure.ResourceManager.ManagementGroups;
 using Azure.ResourceManager.Resources;
@@ -15,13 +16,17 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
     {
         public static List<ExtensibleResourceDetail> KnownExtensibleResources { get; }
 
-        public static List<ExtensibleResourceDetail> StandaloneExtensibleResources { get; }
+        public static List<ResourceTypeSegment> StandaloneExtensibleResourceTypes { get; }
         public static IEnumerable<RequestPath> KnownParentResourcePaths { get; }
 
         static MgmtFacts()
         {
             KnownExtensibleResources = new()
             {
+                new(typeof(PolicyAssignmentResource), RequestPath.PolicyAssignment),
+                new(typeof(SubscriptionPolicyDefinitionResource), RequestPath.SubscriptionPolicyDefinition),
+                new(typeof(ManagementGroupPolicyDefinitionResource), RequestPath.ManagementGroupPolicyDefinition),
+                new(typeof(SubscriptionPolicySetDefinitionResource), RequestPath.SubscriptionPolicySetDefinition),
                 new(typeof(ManagementGroupResource), RequestPath.ManagementGroup),
                 new(typeof(ResourceGroupResource), RequestPath.ResourceGroup),
                 new(typeof(SubscriptionResource), RequestPath.Subscription),
@@ -30,18 +35,24 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
             // the known parent resource paths will exclude tenant because tenant is so general that every resource path could take the tenant as a parent (usually not direct parent though)
             KnownParentResourcePaths = KnownExtensibleResources.Select(info => info.RequestPath).Where(path => !path.Equals(RequestPath.Tenant));
             // the list of the extensible resources that are in an extension class. Those are not included will be generated as instance methods
-            StandaloneExtensibleResources = Configuration.MgmtConfiguration.IsArmCore ?
+            StandaloneExtensibleResourceTypes = Configuration.MgmtConfiguration.IsArmCore ?
                 new()
                 {
-                    new(typeof(TenantResource), RequestPath.Tenant),
-                    new(typeof(ManagementGroupResource), RequestPath.ManagementGroup),
+                    ResourceTypeSegment.Tenant,
+                    ResourceTypeSegment.ManagementGroup,
+                    ResourceTypeSegment.PolicyAssignment,
+                    ResourceTypeSegment.PolicyDefinition,
+                    ResourceTypeSegment.PolicySetDefinition,
                 } :
                 new()
                 {
-                    new(typeof(TenantResource), RequestPath.Tenant),
-                    new(typeof(SubscriptionResource), RequestPath.Subscription),
-                    new(typeof(ResourceGroupResource), RequestPath.ResourceGroup),
-                    new(typeof(ManagementGroupResource), RequestPath.ManagementGroup),
+                    ResourceTypeSegment.Tenant,
+                    ResourceTypeSegment.Subscription,
+                    ResourceTypeSegment.ResourceGroup,
+                    ResourceTypeSegment.ManagementGroup,
+                    ResourceTypeSegment.PolicyAssignment,
+                    ResourceTypeSegment.PolicyDefinition,
+                    ResourceTypeSegment.PolicySetDefinition,
                 };
         }
 

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtFacts.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtFacts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.Models;
 using Azure.ResourceManager.ManagementGroups;
@@ -15,6 +16,7 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
         public static List<ExtensibleResourceDetail> KnownExtensibleResources { get; }
 
         public static List<ExtensibleResourceDetail> StandaloneExtensibleResources { get; }
+        public static IEnumerable<RequestPath> KnownParentResourcePaths { get; }
 
         static MgmtFacts()
         {
@@ -25,6 +27,8 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
                 new(typeof(SubscriptionResource), RequestPath.Subscription),
                 new(typeof(TenantResource), RequestPath.Tenant),
             };
+            // the known parent resource paths will exclude tenant because tenant is so general that every resource path could take the tenant as a parent (usually not direct parent though)
+            KnownParentResourcePaths = KnownExtensibleResources.Select(info => info.RequestPath).Where(path => !path.Equals(RequestPath.Tenant));
             // the list of the extensible resources that are in an extension class. Those are not included will be generated as instance methods
             StandaloneExtensibleResources = Configuration.MgmtConfiguration.IsArmCore ?
                 new()

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -105,14 +105,17 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 AddGeneratedFile(project, $"{resource.Type.Name}.cs", codeWriter.ToString());
             }
 
-            // write extension class
+            // write the public extension class
             if (!isArmCore && !MgmtContext.Library.ExtensionWrapper.IsEmpty)
                 WriteExtensionPiece(project, new MgmtExtensionWrapperWriter(MgmtContext.Library.ExtensionWrapper));
 
-            WriteExtensionClient(project, MgmtContext.Library.ResourceGroupExtensions.ExtensionClient);
-            WriteExtensionClient(project, MgmtContext.Library.SubscriptionExtensions.ExtensionClient);
-            WriteExtensionClient(project, MgmtContext.Library.ManagementGroupExtensions.ExtensionClient);
-            WriteExtensionClient(project, MgmtContext.Library.TenantExtensions.ExtensionClient);
+            // write know extensions
+            foreach (var extension in MgmtContext.Library.OtherExtensions)
+            {
+                WriteExtensionClient(project, extension.ExtensionClient);
+            }
+
+            // write unknown extensions
             WriteExtensionClient(project, MgmtContext.Library.ArmResourceExtensions.ExtensionClient);
 
             if (isArmCore && !MgmtContext.Library.ArmClientExtensions.IsEmpty)

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -118,9 +118,9 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             // write unknown extensions
             WriteExtensionClient(project, MgmtContext.Library.ArmResourceExtensions.ExtensionClient);
 
-            if (isArmCore && !MgmtContext.Library.ArmClientExtensions.IsEmpty)
+            if (isArmCore && !MgmtContext.Library.ArmClientExtension.IsEmpty)
             {
-                WriteExtensionPiece(project, new ArmClientExtensionsWriter(MgmtContext.Library.ArmClientExtensions));
+                WriteExtensionPiece(project, new ArmClientExtensionWriter(MgmtContext.Library.ArmClientExtension));
             }
 
             var lroWriter = new MgmtLongRunningOperationWriter(true);

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
@@ -167,7 +167,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             // We will never want this
             var scope = requestPath.GetScopePath();
             var candidates = MgmtContext.Library.ResourceOperationSets.Select(operationSet => operationSet.GetRequestPath())
-                .Concat(RequestPath.KnownParentResourcePaths)
+                .Concat(MgmtFacts.KnownParentResourcePaths)
                 .Where(r => r.IsAncestorOf(requestPath)).OrderByDescending(r => r.Count);
             if (candidates.Any())
             {

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
@@ -55,6 +55,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             {
                 return parent.AsIEnumerable();
             }
+            // TODO -- need to add some new entries or refactor
             // if we cannot find a resource as its parent, its parent must be one of the Extensions
             if (parentRequestPath.Equals(RequestPath.ManagementGroup))
                 return MgmtContext.Library.ManagementGroupExtensions.AsIEnumerable();
@@ -175,7 +176,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             // We will never want this
             var scope = requestPath.GetScopePath();
             var candidates = MgmtContext.Library.ResourceOperationSets.Select(operationSet => operationSet.GetRequestPath())
-                .Concat(new List<RequestPath> { RequestPath.ResourceGroup, RequestPath.Subscription, RequestPath.ManagementGroup }) // When generating management group in management.json, the path is /providers/Microsoft.Management/managementGroups/{groupId} while RequestPath.ManagementGroup is /providers/Microsoft.Management/managementGroups/{managementGroupId}. We pick the first one.
+                .Concat(RequestPath.KnownParentResourcePaths)
                 .Where(r => r.IsAncestorOf(requestPath)).OrderByDescending(r => r.Count);
             if (candidates.Any())
             {

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ParentDetection.cs
@@ -57,8 +57,8 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             }
             // TODO -- need to add some new entries or refactor
             // if we cannot find a resource as its parent, its parent must be one of the Extensions
-            if (!parentRequestPath.Equals(RequestPath.Tenant) && MgmtContext.Library.TryGetExtension(parentRequestPath.GetResourceType(), out var extension))
-                return extension.AsIEnumerable();
+            if (!parentRequestPath.Equals(RequestPath.Tenant) && MgmtContext.Library.TryGetExtension(parentRequestPath.GetResourceType(), out var extensions))
+                return extensions;
 
             // the only option left is the tenant. But we have our last chance that its parent could be the scope of this
             var scope = parentRequestPath.GetScopePath();
@@ -70,7 +70,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                 return FindScopeParents(types).Distinct();
             }
             // otherwise we use the tenant as a fallback
-            return MgmtContext.Library.GetExtension(RequestPath.Tenant.GetResourceType()).AsIEnumerable();
+            return MgmtContext.Library.GetExtension(RequestPath.Tenant.GetResourceType());
         }
 
         // TODO -- enhence this to support the new arm-id format
@@ -84,8 +84,11 @@ namespace AutoRest.CSharp.Mgmt.Decorator
 
             foreach (var type in parameterizedScopeTypes)
             {
-                if (MgmtContext.Library.TryGetExtension(type, out var extension))
-                    yield return extension;
+                if (MgmtContext.Library.TryGetExtension(type, out var extensions))
+                {
+                    foreach (var extension in extensions)
+                        yield return extension;
+                }
                 else
                     yield return MgmtContext.Library.ArmResourceExtensions; // we return anything unrecognized scope parent resource type as ArmResourceExtensions
             }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ResourceTypeBuilder.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ResourceTypeBuilder.cs
@@ -21,6 +21,10 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             _requestPathToResourceTypeCache.TryAdd(RequestPath.ResourceGroup, ResourceTypeSegment.ResourceGroup);
             _requestPathToResourceTypeCache.TryAdd(RequestPath.Tenant, ResourceTypeSegment.Tenant);
             _requestPathToResourceTypeCache.TryAdd(RequestPath.ManagementGroup, ResourceTypeSegment.ManagementGroup);
+            _requestPathToResourceTypeCache.TryAdd(RequestPath.PolicyAssignment, ResourceTypeSegment.PolicyAssignment);
+            _requestPathToResourceTypeCache.TryAdd(RequestPath.SubscriptionPolicyDefinition, ResourceTypeSegment.PolicyDefinition);
+            _requestPathToResourceTypeCache.TryAdd(RequestPath.ManagementGroupPolicyDefinition, ResourceTypeSegment.PolicyDefinition);
+            _requestPathToResourceTypeCache.TryAdd(RequestPath.SubscriptionPolicySetDefinition, ResourceTypeSegment.PolicySetDefinition);
         }
 
         public static ResourceTypeSegment GetResourceType(this RequestPath requestPath)

--- a/src/AutoRest.CSharp/Mgmt/Decorator/ResourceTypeBuilder.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/ResourceTypeBuilder.cs
@@ -16,6 +16,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
 
         static ResourceTypeBuilder()
         {
+            // TODO -- centralize this
             _requestPathToResourceTypeCache.TryAdd(RequestPath.Subscription, ResourceTypeSegment.Subscription);
             _requestPathToResourceTypeCache.TryAdd(RequestPath.ResourceGroup, ResourceTypeSegment.ResourceGroup);
             _requestPathToResourceTypeCache.TryAdd(RequestPath.Tenant, ResourceTypeSegment.Tenant);

--- a/src/AutoRest.CSharp/Mgmt/Generation/ArmClientExtensionWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ArmClientExtensionWriter.cs
@@ -13,15 +13,15 @@ using Azure.Core;
 
 namespace AutoRest.CSharp.Mgmt.Generation
 {
-    internal class ArmClientExtensionsWriter : MgmtExtensionWriter
+    internal class ArmClientExtensionWriter : MgmtExtensionWriter
     {
-        private MgmtExtensions This { get; }
+        private MgmtExtension This { get; }
 
-        public ArmClientExtensionsWriter(ArmClientExtensions extensions) : this(new CodeWriter(), extensions)
+        public ArmClientExtensionWriter(ArmClientExtension extensions) : this(new CodeWriter(), extensions)
         {
         }
 
-        public ArmClientExtensionsWriter(CodeWriter writer, ArmClientExtensions extensions) : base(writer, extensions)
+        public ArmClientExtensionWriter(CodeWriter writer, ArmClientExtension extensions) : base(writer, extensions)
         {
             This = extensions;
         }

--- a/src/AutoRest.CSharp/Mgmt/Generation/ArmResourceExtensionWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ArmResourceExtensionWriter.cs
@@ -16,14 +16,14 @@ using static AutoRest.CSharp.Output.Models.MethodSignatureModifiers;
 
 namespace AutoRest.CSharp.Mgmt.Generation
 {
-    internal class ArmResourceExtensionsWriter : MgmtExtensionWriter
+    internal class ArmResourceExtensionWriter : MgmtExtensionWriter
     {
-        private MgmtExtensions This { get; }
+        private MgmtExtension This { get; }
 
         private readonly Parameter _armClientParameter;
         private readonly Parameter _scopeParameter;
 
-        public ArmResourceExtensionsWriter(CodeWriter writer, MgmtExtensions extension)
+        public ArmResourceExtensionWriter(CodeWriter writer, MgmtExtension extension)
             : base(writer, extension)
         {
             This = extension;

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -850,7 +850,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
             _writer.Append($"(");
             if (operation.IsFakeLongRunningOperation)
             {
-                if (operation.MgmtReturnType is not null && MgmtContext.Library.CsharpTypeToResource.ContainsKey(operation.MgmtReturnType))
+                if (operation.MgmtReturnType is not null && MgmtContext.Library.CSharpTypeToResource.ContainsKey(operation.MgmtReturnType))
                 {
                     _writer.Append($"{typeof(Response)}.FromValue(new {operation.MgmtReturnType}({ArmClientReference}, response), response.GetRawResponse())");
                 }
@@ -864,7 +864,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                 if (operation.OperationSource is not null)
                 {
                     _writer.Append($"new {operation.OperationSource.TypeName}(");
-                    if (MgmtContext.Library.CsharpTypeToResource.ContainsKey(operation.MgmtReturnType!))
+                    if (MgmtContext.Library.CSharpTypeToResource.ContainsKey(operation.MgmtReturnType!))
                         _writer.Append($"{ArmClientReference}");
                     _writer.Append($"), ");
                 }

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtExtensionWrapperWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtExtensionWrapperWriter.cs
@@ -12,8 +12,8 @@ namespace AutoRest.CSharp.Mgmt.Generation
 {
     internal class MgmtExtensionWrapperWriter : MgmtClientBaseWriter
     {
-        private MgmtExtensionsWrapper _wrapper;
-        public MgmtExtensionWrapperWriter(MgmtExtensionsWrapper extensionsWrapper) : base(new CodeWriter(), extensionsWrapper)
+        private MgmtExtensionWrapper _wrapper;
+        public MgmtExtensionWrapperWriter(MgmtExtensionWrapper extensionsWrapper) : base(new CodeWriter(), extensionsWrapper)
         {
             _wrapper = extensionsWrapper;
         }
@@ -26,8 +26,8 @@ namespace AutoRest.CSharp.Mgmt.Generation
                     continue;
                 var extensionWriter = extension switch
                 {
-                    ArmClientExtensions armClientExtensions => new ArmClientExtensionsWriter(_writer, armClientExtensions),
-                    _ when extension.ArmCoreType == typeof(ArmResource) => new ArmResourceExtensionsWriter(_writer, extension),
+                    ArmClientExtension armClientExtensions => new ArmClientExtensionWriter(_writer, armClientExtensions),
+                    _ when extension.ArmCoreType == typeof(ArmResource) => new ArmResourceExtensionWriter(_writer, extension),
                     _ => new MgmtExtensionWriter(_writer, extension)
                 };
                 extensionWriter.WriteImplementations();

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtExtensionWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtExtensionWriter.cs
@@ -16,16 +16,16 @@ namespace AutoRest.CSharp.Mgmt.Generation
 {
     internal class MgmtExtensionWriter : MgmtClientBaseWriter
     {
-        private MgmtExtensions This { get; }
+        private MgmtExtension This { get; }
         protected delegate void WriteResourceGetBody(MethodSignature signature, bool isAsync, bool isPaging);
 
-        public MgmtExtensionWriter(MgmtExtensions extensions)
+        public MgmtExtensionWriter(MgmtExtension extensions)
             : this(new CodeWriter(), extensions)
         {
             This = extensions;
         }
 
-        public MgmtExtensionWriter(CodeWriter writer, MgmtExtensions extensions) : base(writer, extensions)
+        public MgmtExtensionWriter(CodeWriter writer, MgmtExtension extensions) : base(writer, extensions)
         {
             This = extensions;
         }

--- a/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
@@ -28,7 +28,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
         {
             _writer = new CodeWriter();
             _opSource = opSource;
-            _isReturningResource = MgmtContext.Library.CsharpTypeToResource.ContainsKey(_opSource.ReturnType);
+            _isReturningResource = MgmtContext.Library.CSharpTypeToResource.ContainsKey(_opSource.ReturnType);
             if (_opSource.Resource is not null && Configuration.MgmtConfiguration.OperationIdMappings.TryGetValue(_opSource.Resource.ResourceName, out var mappings))
                 _operationIdMappings = mappings;
         }

--- a/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
@@ -163,7 +163,7 @@ namespace AutoRest.CSharp.Mgmt.Models
 
             if (!MgmtContext.Library.CSharpTypeToOperationSource.TryGetValue(MgmtReturnType, out var operationSource))
             {
-                MgmtContext.Library.CsharpTypeToResource.TryGetValue(MgmtReturnType, out var resourceBeingReturned);
+                MgmtContext.Library.CSharpTypeToResource.TryGetValue(MgmtReturnType, out var resourceBeingReturned);
                 operationSource = new OperationSource(MgmtReturnType, resourceBeingReturned, FinalResponseSchema!);
                 MgmtContext.Library.CSharpTypeToOperationSource.Add(MgmtReturnType, operationSource);
             }

--- a/src/AutoRest.CSharp/Mgmt/Models/RequestPath.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/RequestPath.cs
@@ -30,15 +30,6 @@ namespace AutoRest.CSharp.Mgmt.Models
         internal const string SubscriptionScopePrefix = "/subscriptions";
         internal const string TenantScopePrefix = "/tenants";
 
-        public static readonly IReadOnlyList<RequestPath> KnownParentResourcePaths;
-
-        static RequestPath()
-        {
-            KnownParentResourcePaths = new[] {
-                ResourceGroup, Subscription, ManagementGroup
-            };
-        }
-
         /// <summary>
         /// This is a placeholder of request path for "any" resources in other RPs
         /// </summary>

--- a/src/AutoRest.CSharp/Mgmt/Models/RequestPath.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/RequestPath.cs
@@ -25,17 +25,19 @@ namespace AutoRest.CSharp.Mgmt.Models
         private const string _providerPath = "/subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}";
         private const string _featurePath = "/subscriptions/{subscriptionId}/providers/Microsoft.Features/providers/{resourceProviderNamespace}/features";
 
-        private const string ManagementGroupScopePrefix = "/providers/Microsoft.Management/managementGroups";
-        private const string ResourceGroupScopePrefix = "/subscriptions/{subscriptionId}/resourceGroups";
-        private const string SubscriptionScopePrefix = "/subscriptions";
-        private const string TenantScopePrefix = "/tenants";
+        internal const string ManagementGroupScopePrefix = "/providers/Microsoft.Management/managementGroups";
+        internal const string ResourceGroupScopePrefix = "/subscriptions/{subscriptionId}/resourceGroups";
+        internal const string SubscriptionScopePrefix = "/subscriptions";
+        internal const string TenantScopePrefix = "/tenants";
 
-        public static readonly IReadOnlyList<RequestPath> KnownParentResourcePaths = new[]
+        public static readonly IReadOnlyList<RequestPath> KnownParentResourcePaths;
+
+        static RequestPath()
         {
-            ResourceGroup,
-            Subscription,
-            ManagementGroup
-        };
+            KnownParentResourcePaths = new[] {
+                ResourceGroup, Subscription, ManagementGroup
+            };
+        }
 
         /// <summary>
         /// This is a placeholder of request path for "any" resources in other RPs
@@ -211,28 +213,28 @@ namespace AutoRest.CSharp.Mgmt.Models
             if (_scopePathCache.TryGetValue(this, out var result))
                 return result;
 
-            result = CalculateScopePath(this);
+            result = CalculateScopePath();
             _scopePathCache.TryAdd(this, result);
             return result;
         }
 
-        private static RequestPath CalculateScopePath(RequestPath requestPath)
+        private RequestPath CalculateScopePath()
         {
-            var indexOfProvider = requestPath.ToList().LastIndexOf(Segment.Providers);
+            var indexOfProvider = _segments.ToList().LastIndexOf(Segment.Providers);
             // if there is no providers segment, myself should be a scope request path. Just return myself
             if (indexOfProvider >= 0)
             {
-                if (indexOfProvider == 0 && requestPath.SerializedPath.StartsWith(RequestPath.ManagementGroupScopePrefix, StringComparison.InvariantCultureIgnoreCase))
+                if (indexOfProvider == 0 && SerializedPath.StartsWith(RequestPath.ManagementGroupScopePrefix, StringComparison.InvariantCultureIgnoreCase))
                     return RequestPath.ManagementGroup;
-                return new RequestPath(requestPath.Take(indexOfProvider));
+                return new RequestPath(_segments.Take(indexOfProvider));
             }
-            if (requestPath.SerializedPath.StartsWith(RequestPath.ResourceGroupScopePrefix, StringComparison.InvariantCultureIgnoreCase))
+            if (SerializedPath.StartsWith(RequestPath.ResourceGroupScopePrefix, StringComparison.InvariantCultureIgnoreCase))
                 return RequestPath.ResourceGroup;
-            if (requestPath.SerializedPath.StartsWith(RequestPath.SubscriptionScopePrefix, StringComparison.InvariantCultureIgnoreCase))
+            if (SerializedPath.StartsWith(RequestPath.SubscriptionScopePrefix, StringComparison.InvariantCultureIgnoreCase))
                 return RequestPath.Subscription;
-            if (requestPath.SerializedPath.Equals(RequestPath.TenantScopePrefix))
+            if (SerializedPath.Equals(RequestPath.TenantScopePrefix))
                 return RequestPath.Tenant;
-            return requestPath;
+            return this;
         }
 
         /// <summary>

--- a/src/AutoRest.CSharp/Mgmt/Models/RequestPath.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/RequestPath.cs
@@ -69,6 +69,47 @@ namespace AutoRest.CSharp.Mgmt.Models
             new Segment(new Reference("managementGroupId", typeof(string)), true, false)
         });
 
+        public static readonly RequestPath PolicyAssignment = new(new[]
+        {
+            new Segment(new Reference("scope", typeof(string)), false, true),
+            new Segment("providers"),
+            new Segment("Microsoft.Authorization"),
+            new Segment("policyAssignments"),
+            new Segment(new Reference("policyAssignmentName", typeof(string)), true, false)
+        });
+
+        public static readonly RequestPath SubscriptionPolicyDefinition = new(new[]
+        {
+            new Segment("subscriptions"),
+            new Segment(new Reference("subscriptionId", typeof(string)), true, true),
+            new Segment("providers"),
+            new Segment("Microsoft.Authorization"),
+            new Segment("policyDefinitions"),
+            new Segment(new Reference("policyDefinitionName", typeof(string)), true, false)
+        });
+
+        public static readonly RequestPath ManagementGroupPolicyDefinition = new(new[]
+        {
+            new Segment("providers"),
+            new Segment("Microsoft.Management"),
+            new Segment("managementGroups"),
+            new Segment(new Reference("managementGroupId", typeof(string)), true, false),
+            new Segment("providers"),
+            new Segment("Microsoft.Authorization"),
+            new Segment("policyDefinitions"),
+            new Segment(new Reference("policyDefinitionName", typeof(string)), true, false)
+        });
+
+        public static readonly RequestPath SubscriptionPolicySetDefinition = new(new[]
+        {
+            new Segment("subscriptions"),
+            new Segment(new Reference("subscriptionId", typeof(string)), true, true),
+            new Segment("providers"),
+            new Segment("Microsoft.Authorization"),
+            new Segment("policySetDefinitions"),
+            new Segment(new Reference("policySetDefinitionName", typeof(string)), true, false)
+        });
+
         private readonly IReadOnlyList<Segment> _segments;
 
         public static RequestPath FromOperation(Operation operation, OperationGroup operationGroup)

--- a/src/AutoRest.CSharp/Mgmt/Models/ResourceTypeSegment.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/ResourceTypeSegment.cs
@@ -54,6 +54,29 @@ namespace AutoRest.CSharp.Mgmt.Models
             new Segment("managementGroups")
         });
 
+        /// <summary>
+        /// The <see cref="ResourceTypeSegment"/> of the policy assignment resource
+        /// </summary>
+        public static readonly ResourceTypeSegment PolicyAssignment = new(new[] {
+            new Segment("Microsoft.Authorization"),
+            new Segment("policyAssignments")
+        });
+
+        /// <summary>
+        /// The <see cref="ResourceTypeSegment"/> of the policy definition resource
+        /// </summary>
+        public static readonly ResourceTypeSegment PolicyDefinition = new(new[] {
+            new Segment("Microsoft.Authorization"),
+            new Segment("policyDefinitions")
+        });
+        /// <summary>
+        /// The <see cref="ResourceTypeSegment"/> of the policy set definition resource
+        /// </summary>
+        public static readonly ResourceTypeSegment PolicySetDefinition = new(new[] {
+            new Segment("Microsoft.Authorization"),
+            new Segment("policySetDefinitions")
+        });
+
         private IReadOnlyList<Segment> _segments;
 
         public static ResourceTypeSegment ParseRequestPath(RequestPath path)

--- a/src/AutoRest.CSharp/Mgmt/Output/ArmClientExtension.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ArmClientExtension.cs
@@ -11,9 +11,9 @@ using Azure.ResourceManager;
 
 namespace AutoRest.CSharp.Mgmt.Output
 {
-    internal class ArmClientExtensions : MgmtExtensions
+    internal class ArmClientExtension : MgmtExtension
     {
-        public ArmClientExtensions(IEnumerable<Operation> allOperations)
+        public ArmClientExtension(IEnumerable<Operation> allOperations)
             : base(allOperations, typeof(ArmClient), RequestPath.Tenant)
         {
         }

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtExtension.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtExtension.cs
@@ -15,11 +15,11 @@ using AutoRest.CSharp.Utilities;
 
 namespace AutoRest.CSharp.Mgmt.Output
 {
-    internal class MgmtExtensions : MgmtTypeProvider
+    internal class MgmtExtension : MgmtTypeProvider
     {
         public IEnumerable<Operation> AllRawOperations { get; }
 
-        public MgmtExtensions(IEnumerable<Operation> allRawOperations, Type armCoreType, RequestPath contextualPath)
+        public MgmtExtension(IEnumerable<Operation> allRawOperations, Type armCoreType, RequestPath contextualPath)
             : base(armCoreType.Name)
         {
             AllRawOperations = allRawOperations;
@@ -67,6 +67,8 @@ namespace AutoRest.CSharp.Mgmt.Output
         protected override string DefaultNamespace { get; }
 
         public virtual RequestPath ContextualPath { get; }
+
+        public ResourceTypeSegment ResourceType => ContextualPath.GetResourceType();
 
         public override IEnumerable<Resource> ChildResources { get; }
 

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtExtensionClient.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtExtensionClient.cs
@@ -19,7 +19,7 @@ namespace AutoRest.CSharp.Mgmt.Output
     internal class MgmtExtensionClient : MgmtTypeProvider
     {
         private string _defaultName;
-        public MgmtExtensionClient(MgmtExtensions publicExtension)
+        public MgmtExtensionClient(MgmtExtension publicExtension)
             : base(publicExtension.ResourceName)
         {
             Extension = publicExtension;
@@ -64,7 +64,7 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         protected override string DefaultName => _defaultName;
 
-        public MgmtExtensions Extension { get; }
+        public MgmtExtension Extension { get; }
 
         public bool IsEmpty => Extension.IsEmpty;
 

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtExtensionWrapper.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtExtensionWrapper.cs
@@ -14,16 +14,16 @@ using AutoRest.CSharp.Output.Models.Types;
 namespace AutoRest.CSharp.Mgmt.Output
 {
     /// <summary>
-    /// MgmtExtensionsWrapper is a wrapper of all the <see cref="MgmtExtensions"/>, despite the <see cref="MgmtExtensions"/> is inheriting from <see cref="MgmtTypeProvider"/>, currently it will not produce a class in the generated code.
+    /// MgmtExtensionsWrapper is a wrapper of all the <see cref="MgmtExtension"/>, despite the <see cref="MgmtExtension"/> is inheriting from <see cref="MgmtTypeProvider"/>, currently it will not produce a class in the generated code.
     /// Instead, this class will take all the things that are used to be produces into the individual extension classes, producing a big extension class
     /// </summary>
-    internal class MgmtExtensionsWrapper : MgmtTypeProvider
+    internal class MgmtExtensionWrapper : MgmtTypeProvider
     {
-        public IEnumerable<MgmtExtensions> Extensions { get; }
+        public IEnumerable<MgmtExtension> Extensions { get; }
 
         public bool IsEmpty => Extensions.All(extension => extension.IsEmpty);
 
-        public MgmtExtensionsWrapper(IEnumerable<MgmtExtensions> extensions) : base(MgmtContext.Context.DefaultNamespace.Split('.').Last())
+        public MgmtExtensionWrapper(IEnumerable<MgmtExtension> extensions) : base(MgmtContext.Context.DefaultNamespace.Split('.').Last())
         {
             DefaultName = $"{ResourceName}Extensions";
             Description = Configuration.MgmtConfiguration.IsArmCore ? (FormattableString)$"" : $"A class to add extension methods to {MgmtContext.Context.DefaultNamespace}.";

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
@@ -22,8 +22,7 @@ namespace AutoRest.CSharp.Mgmt.Output
 {
     /// <summary>
     /// MgmtTypeProvider represents the information that corresponds to the generated class in the SDK that contains operations in it.
-    /// This includes <see cref="Resource"/>, <see cref="ResourceCollection"/>, <see cref="ArmClientExtensions"/>, <see cref="TenantExtensions"/>,
-    /// <see cref="SubscriptionExtensions"/>, <see cref="ResourceGroupExtensions"/> and <see cref="ManagementGroupExtensions"/>
+    /// This includes <see cref="Resource"/>, <see cref="ResourceCollection"/>, <see cref="MgmtExtension"/>, <see cref="ArmClientExtension"/>
     /// </summary>
     internal abstract class MgmtTypeProvider : TypeProvider
     {
@@ -33,7 +32,7 @@ namespace AutoRest.CSharp.Mgmt.Output
         {
             ResourceName = resourceName;
             IsArmCore = Configuration.MgmtConfiguration.IsArmCore;
-            IsStatic = !IsArmCore && BaseType is null && (this is MgmtExtensions extension || this is MgmtExtensionsWrapper);
+            IsStatic = !IsArmCore && BaseType is null && (this is MgmtExtension extension || this is MgmtExtensionWrapper);
         }
 
         protected virtual string IdParamDescription => $"The identifier of the resource that is the target of operations.";

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -419,7 +419,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             var an = clientPrefix.StartsWithVowel() ? "an" : "a";
             List<FormattableString> lines = new List<FormattableString>();
             var parents = this.Parent();
-            var parentTypes = parents.Select(parent => parent is MgmtExtensions extensions ? extensions.ArmCoreType : parent.Type).ToList();
+            var parentTypes = parents.Select(parent => parent is MgmtExtension extensions ? extensions.ArmCoreType : parent.Type).ToList();
             var parentDescription = CreateParentDescription(parentTypes);
 
             lines.Add($"A Class representing {an} {ResourceName} along with the instance operations that can be performed on it.");

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
@@ -214,7 +214,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             var an = clientPrefix.StartsWithVowel() ? "an" : "a";
             List<FormattableString> lines = new List<FormattableString>();
             var parents = Resource.Parent();
-            var parentTypes = parents.Select(parent => parent is MgmtExtensions extensions ? extensions.ArmCoreType : parent.Type).ToList();
+            var parentTypes = parents.Select(parent => parent is MgmtExtension extensions ? extensions.ArmCoreType : parent.Type).ToList();
             var parentDescription = CreateParentDescription(parentTypes);
 
             lines.Add($"A class representing a collection of <see cref=\"{Resource.Type}\" /> and their operations.");

--- a/src/AutoRest.CSharp/MgmtTest/AutoRest/MgmtTestOutputLibrary.cs
+++ b/src/AutoRest.CSharp/MgmtTest/AutoRest/MgmtTestOutputLibrary.cs
@@ -63,7 +63,7 @@ namespace AutoRest.CSharp.MgmtTest.AutoRest
                     {
                         // the operations on ArmClientExtensions are the same as the tenant extension, therefore we skip it here
                         // the source code generator will never write them if it is not in arm core
-                        if (providerForExample.Carrier is ArmClientExtensions)
+                        if (providerForExample.Carrier is ArmClientExtension)
                             continue;
                         var mockTestCase = new MockTestCase(operationId, providerForExample.Carrier, providerForExample.Operation, example);
                         result.AddInList(mockTestCase.Owner, mockTestCase);
@@ -110,11 +110,11 @@ namespace AutoRest.CSharp.MgmtTest.AutoRest
             return _operationIdToProviders;
         }
 
-        private MgmtMockTestProvider<MgmtExtensionsWrapper>? _extensionWrapperMockTest;
-        public MgmtMockTestProvider<MgmtExtensionsWrapper> ExtensionWrapperMockTest => _extensionWrapperMockTest ??= new MgmtMockTestProvider<MgmtExtensionsWrapper>(MgmtContext.Library.ExtensionWrapper, Enumerable.Empty<MockTestCase>());
+        private MgmtMockTestProvider<MgmtExtensionWrapper>? _extensionWrapperMockTest;
+        public MgmtMockTestProvider<MgmtExtensionWrapper> ExtensionWrapperMockTest => _extensionWrapperMockTest ??= new MgmtMockTestProvider<MgmtExtensionWrapper>(MgmtContext.Library.ExtensionWrapper, Enumerable.Empty<MockTestCase>());
 
-        private IEnumerable<MgmtMockTestProvider<MgmtExtensions>>? _extensionMockTests;
-        public IEnumerable<MgmtMockTestProvider<MgmtExtensions>> ExtensionMockTests => _extensionMockTests ??= EnsureMockTestProviders<MgmtExtensions>();
+        private IEnumerable<MgmtMockTestProvider<MgmtExtension>>? _extensionMockTests;
+        public IEnumerable<MgmtMockTestProvider<MgmtExtension>> ExtensionMockTests => _extensionMockTests ??= EnsureMockTestProviders<MgmtExtension>();
 
         private IEnumerable<MgmtMockTestProvider<ResourceCollection>>? _resourceCollectionMockTests;
         public IEnumerable<MgmtMockTestProvider<ResourceCollection>> ResourceCollectionMockTests => _resourceCollectionMockTests ??= EnsureMockTestProviders<ResourceCollection>();

--- a/src/AutoRest.CSharp/MgmtTest/Generation/MgmtTestWriterBase.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Generation/MgmtTestWriterBase.cs
@@ -85,7 +85,7 @@ namespace AutoRest.CSharp.MgmtTest.Generation
             {
                 ResourceCollection => throw new InvalidOperationException($"ResourceCollection is not supported here"),
                 Resource parentResource => WriteGetFromResource(parentResource, example, client),
-                MgmtExtensions parentExtension => WriteGetExtension(parentExtension, example, client),
+                MgmtExtension parentExtension => WriteGetExtension(parentExtension, example, client),
                 _ => throw new InvalidOperationException($"Unknown parent {carrierResource.GetType()}"),
             };
 
@@ -99,21 +99,21 @@ namespace AutoRest.CSharp.MgmtTest.Generation
             return resourceVar;
         }
 
-        protected CodeWriterDeclaration WriteGetExtension(MgmtExtensions parentExtension, OperationExample example, FormattableString client) => parentExtension.ArmCoreType switch
+        protected CodeWriterDeclaration WriteGetExtension(MgmtExtension parentExtension, OperationExample example, FormattableString client) => parentExtension.ArmCoreType switch
         {
             _ when parentExtension.ArmCoreType == typeof(TenantResource) => WriteGetTenantResource(parentExtension, example, client),
             _ when parentExtension.ArmCoreType == typeof(ArmResource) => throw new InvalidOperationException("The method that extends ArmResource might not exist, we should always use the client.GetXXXs(scope) to get the collection, this does not have to be invoked on a resource"),
             _ => WriteGetOtherExtension(parentExtension, example, client)
         };
 
-        private CodeWriterDeclaration WriteGetTenantResource(MgmtExtensions parentExtension, OperationExample example, FormattableString client)
+        private CodeWriterDeclaration WriteGetTenantResource(MgmtExtension parentExtension, OperationExample example, FormattableString client)
         {
             var resourceVar = new CodeWriterDeclaration(parentExtension.ResourceName.ToVariableName());
             _writer.Line($"var {resourceVar:D} = {client}.GetTenants().GetAllAsync().GetAsyncEnumerator().Current;");
             return resourceVar;
         }
 
-        private CodeWriterDeclaration WriteGetOtherExtension(MgmtExtensions parentExtension, OperationExample example, FormattableString client)
+        private CodeWriterDeclaration WriteGetOtherExtension(MgmtExtension parentExtension, OperationExample example, FormattableString client)
         {
             var resourceVar = new CodeWriterDeclaration(parentExtension.ResourceName.ToVariableName());
             var idVar = new CodeWriterDeclaration($"{parentExtension.ArmCoreType.Name}Id".ToVariableName());

--- a/src/AutoRest.CSharp/MgmtTest/Generation/Mock/ExtensionMockTestWriter.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Generation/Mock/ExtensionMockTestWriter.cs
@@ -11,9 +11,9 @@ using AutoRest.CSharp.MgmtTest.Output.Mock;
 
 namespace AutoRest.CSharp.MgmtTest.Generation.Mock
 {
-    internal class ExtensionMockTestWriter : MgmtMockTestBaseWriter<MgmtExtensions>
+    internal class ExtensionMockTestWriter : MgmtMockTestBaseWriter<MgmtExtension>
     {
-        public ExtensionMockTestWriter(CodeWriter writer, MgmtMockTestProvider<MgmtExtensions> extensionTest) : base(writer, extensionTest)
+        public ExtensionMockTestWriter(CodeWriter writer, MgmtMockTestProvider<MgmtExtension> extensionTest) : base(writer, extensionTest)
         {
         }
 

--- a/src/AutoRest.CSharp/MgmtTest/Generation/Mock/ExtensionWrapMockTestWriter.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Generation/Mock/ExtensionWrapMockTestWriter.cs
@@ -10,10 +10,10 @@ using AutoRest.CSharp.MgmtTest.Output.Mock;
 
 namespace AutoRest.CSharp.MgmtTest.Generation.Mock
 {
-    internal class ExtensionWrapMockTestWriter : MgmtMockTestBaseWriter<MgmtExtensionsWrapper>
+    internal class ExtensionWrapMockTestWriter : MgmtMockTestBaseWriter<MgmtExtensionWrapper>
     {
-        private IEnumerable<MgmtMockTestProvider<MgmtExtensions>> _extensionTests;
-        public ExtensionWrapMockTestWriter(MgmtMockTestProvider<MgmtExtensionsWrapper> testWrapper, IEnumerable<MgmtMockTestProvider<MgmtExtensions>> extensionTests) : base(testWrapper)
+        private IEnumerable<MgmtMockTestProvider<MgmtExtension>> _extensionTests;
+        public ExtensionWrapMockTestWriter(MgmtMockTestProvider<MgmtExtensionWrapper> testWrapper, IEnumerable<MgmtMockTestProvider<MgmtExtension>> extensionTests) : base(testWrapper)
         {
             _extensionTests = extensionTests;
         }

--- a/src/AutoRest.CSharp/MgmtTest/Generation/Mock/ResourceCollectionMockTestWriter.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Generation/Mock/ResourceCollectionMockTestWriter.cs
@@ -31,7 +31,7 @@ namespace AutoRest.CSharp.MgmtTest.Generation.Mock
 
         private CodeWriterDeclaration? WriteGetParentResource(MgmtTypeProvider parent, MockTestCase testCase)
         {
-            if (parent is MgmtExtensions extension && extension.ArmCoreType == typeof(ArmResource))
+            if (parent is MgmtExtension extension && extension.ArmCoreType == typeof(ArmResource))
                 return null;
 
             return WriteGetResource(parent, testCase, GetArmClientExpression);

--- a/src/AutoRest.CSharp/MgmtTest/Generation/Samples/MgmtSampleWriter.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Generation/Samples/MgmtSampleWriter.cs
@@ -76,7 +76,7 @@ namespace AutoRest.CSharp.MgmtTest.Generation.Samples
             {
                 ResourceCollection collection => WriteSampleOperationForResourceCollection(clientStepResult, collection, sample),
                 Resource resource => WriteSampleOperationForResource(clientStepResult, resource, sample),
-                MgmtExtensions extension => WriteSampleOperationForExtension(clientStepResult, extension, sample),
+                MgmtExtension extension => WriteSampleOperationForExtension(clientStepResult, extension, sample),
                 _ => throw new InvalidOperationException("Should never happen"),
             };
 
@@ -152,7 +152,7 @@ namespace AutoRest.CSharp.MgmtTest.Generation.Samples
         private string GetResourceName(MgmtTypeProvider provider) => provider switch
         {
             Resource resource => resource.Type.Name,
-            MgmtExtensions extension => extension.ArmCoreType.Name,
+            MgmtExtension extension => extension.ArmCoreType.Name,
             _ => throw new InvalidOperationException("Should never happen")
         };
 
@@ -179,7 +179,7 @@ namespace AutoRest.CSharp.MgmtTest.Generation.Samples
             return result;
         }
 
-        private CodeWriterVariableDeclaration? WriteSampleOperationForExtension(CodeWriterVariableDeclaration clientVar, MgmtExtensions extension, Sample sample)
+        private CodeWriterVariableDeclaration? WriteSampleOperationForExtension(CodeWriterVariableDeclaration clientVar, MgmtExtension extension, Sample sample)
         {
             _writer.Line();
 
@@ -194,7 +194,7 @@ namespace AutoRest.CSharp.MgmtTest.Generation.Samples
 
         private CodeWriterDeclaration? WriteGetParentResource(MgmtTypeProvider parent, MockTestCase testCase, FormattableString clientExpression)
         {
-            if (parent is MgmtExtensions extension && extension.ArmCoreType == typeof(ArmResource))
+            if (parent is MgmtExtension extension && extension.ArmCoreType == typeof(ArmResource))
                 return null;
 
             return WriteGetResource(parent, testCase, clientExpression);


### PR DESCRIPTION
# Description

1. Move the logic around `GetScopePath()` back to `RequestPath` instead of an extension method.
2. Introduce some new arrays and dictionaries to represent the extensions we will generate in a centralized place
3. Refactor the initialization of the extensions in `MgmtOutputLibrary` by iterate over the arrays and dictionaries introduced in 2
4. Add some new built-in resources in resourcemanager for extensions to be generated from

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first