### PR TITLE
don't generate convenience method when no convenience api decorator

### DIFF
--- a/src/CADL.Extension/Emitter.Csharp/package-lock.json
+++ b/src/CADL.Extension/Emitter.Csharp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure-tools/cadl-csharp",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure-tools/cadl-csharp",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "license": "MIT",
             "dependencies": {
                 "js-yaml": "^4.1.0",

--- a/src/CADL.Extension/Emitter.Csharp/package.json
+++ b/src/CADL.Extension/Emitter.Csharp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure-tools/cadl-csharp",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "author": "Microsoft Corporation",
     "description": "Cadl library for emitting csharp model from the Cadl REST protocol binding",
     "homepage": "https://github.com/Microsoft/cadl",

--- a/src/CADL.Extension/Emitter.Csharp/samples/CadlFirstTest/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/samples/CadlFirstTest/Generated/cadl.json
@@ -240,7 +240,7 @@
      "Uri": "",
      "Path": "/top/{action}",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "32",
@@ -268,7 +268,7 @@
      "Uri": "",
      "Path": "/top2",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "34",
@@ -313,7 +313,7 @@
      "Uri": "",
      "Path": "/anonymousBody",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
@@ -351,7 +351,7 @@
      "Uri": "",
      "Path": "/hello",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
@@ -405,7 +405,7 @@
      "Uri": "",
      "Path": "/againHi",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "46",
@@ -433,7 +433,7 @@
      "Uri": "",
      "Path": "/demoHi",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/samples/petStore/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/samples/petStore/Generated/cadl.json
@@ -213,7 +213,7 @@
      "Uri": "{petStoreUrl}",
      "Path": "/pets/{petId}",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "27",
@@ -275,7 +275,7 @@
      "Uri": "{petStoreUrl}",
      "Path": "/pets/{petId}",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "32",
@@ -322,7 +322,7 @@
      "Uri": "{petStoreUrl}",
      "Path": "/pets",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
@@ -401,7 +401,7 @@
      "Uri": "{petStoreUrl}",
      "Path": "/pets/{petId}/toys",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
@@ -212,10 +212,6 @@ function createModel(program: Program): any {
             }
         }
 
-        const hasNoConvenienceApiDecorators = routes.every(
-            (u) => !getExtensions(program, u.operation).has(convenienceApiKey)
-        );
-
         for (const operation of routes) {
             console.log(JSON.stringify(operation.path));
             if (!isSupportedOperation(operation)) continue;
@@ -242,8 +238,7 @@ function createModel(program: Program): any {
                 url,
                 endPointParam,
                 modelMap,
-                enumMap,
-                hasNoConvenienceApiDecorators
+                enumMap
             );
             if (
                 contentTypeParameter &&
@@ -420,8 +415,7 @@ function loadOperation(
     uri: string,
     endpoint: InputParameter | undefined = undefined,
     models: Map<string, InputModelType>,
-    enums: Map<string, InputEnumType>,
-    hasNoConvenienceApiDecorators: boolean
+    enums: Map<string, InputEnumType>
 ): InputOperation {
     const {
         path: fullPath,
@@ -470,10 +464,10 @@ function loadOperation(
         mediaTypes.push(contentTypeParameter.DefaultValue?.Value);
     }
     const requestMethod = parseHttpRequestMethod(verb);
-    const generateConvenienceMethod =
-        requestMethod !== RequestMethod.PATCH &&
-        (hasNoConvenienceApiDecorators ||
-            getExtensions(program, op).get(convenienceApiKey));
+    const convenienceApiDecorator: boolean =
+        getExtensions(program, op).get(convenienceApiKey) ?? false;
+    const generateConvenienceMethod: boolean =
+        requestMethod !== RequestMethod.PATCH && convenienceApiDecorator;
 
     return {
         Name: op.name,

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/array/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/array/Generated/cadl.json
@@ -173,7 +173,7 @@
      "Uri": "{host}",
      "Path": "/pets",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpoint/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpoint/Generated/cadl.json
@@ -102,7 +102,7 @@
      "Uri": "{endpointServiceUrl}",
      "Path": "/endpoint/{action}",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/enum/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/enum/Generated/cadl.json
@@ -265,7 +265,7 @@
      "Uri": "{host}",
      "Path": "/models",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/head/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/head/Generated/cadl.json
@@ -206,7 +206,7 @@
       "image/jpeg"
      ],
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "24",
@@ -283,7 +283,7 @@
       "text/plain"
      ],
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/interface/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/interface/Generated/cadl.json
@@ -193,7 +193,8 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/dogs/models",
-     "BufferResponse": false
+     "BufferResponse": false,
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
@@ -232,7 +233,8 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/cats",
-     "BufferResponse": false
+     "BufferResponse": false,
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "26",
@@ -279,7 +281,8 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/cats",
-     "BufferResponse": false
+     "BufferResponse": false,
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/security/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/security/Generated/cadl.json
@@ -95,7 +95,7 @@
      "Uri": "{host}",
      "Path": "/security",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/string-format/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/string-format/Generated/cadl.json
@@ -82,7 +82,7 @@
      "Uri": "",
      "Path": "/zonedDateTime/{time}",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "11",
@@ -127,7 +127,7 @@
      "Uri": "",
      "Path": "/uri/{uri}",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/visibility/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/visibility/Generated/cadl.json
@@ -165,7 +165,7 @@
      "Uri": "{host}",
      "Path": "/visibility",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/test/TestProjects/Customizations-Cadl/Generated/CustomizationsInCadlClient.cs
+++ b/test/TestProjects/Customizations-Cadl/Generated/CustomizationsInCadlClient.cs
@@ -6,12 +6,10 @@
 #nullable disable
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using CustomizationsInCadl;
 
 namespace GeneratedModels
 {
@@ -42,32 +40,6 @@ namespace GeneratedModels
             ClientDiagnostics = new ClientDiagnostics(options, true);
             _pipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), Array.Empty<HttpPipelinePolicy>(), new ResponseClassifier());
             _apiVersion = options.Version;
-        }
-
-        /// <summary> RoundTrip operation to make RootModel round-trip. </summary>
-        /// <param name="input"> The RootModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual async Task<Response<RootModel>> RoundTripAsync(RootModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = await RoundTripAsync(input.ToRequestContent(), context).ConfigureAwait(false);
-            return Response.FromValue(RootModel.FromResponse(response), response);
-        }
-
-        /// <summary> RoundTrip operation to make RootModel round-trip. </summary>
-        /// <param name="input"> The RootModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual Response<RootModel> RoundTrip(RootModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = RoundTrip(input.ToRequestContent(), context);
-            return Response.FromValue(RootModel.FromResponse(response), response);
         }
 
         /// <summary> RoundTrip operation to make RootModel round-trip. </summary>
@@ -374,17 +346,6 @@ namespace GeneratedModels
             request.Uri = uri;
             request.Content = content;
             return message;
-        }
-
-        private static RequestContext DefaultRequestContext = new RequestContext();
-        internal static RequestContext FromCancellationToken(CancellationToken cancellationToken = default)
-        {
-            if (!cancellationToken.CanBeCanceled)
-            {
-                return DefaultRequestContext;
-            }
-
-            return new RequestContext() { CancellationToken = cancellationToken };
         }
 
         private static ResponseClassifier _responseClassifier200;

--- a/test/TestProjects/Customizations-Cadl/Generated/cadl.json
+++ b/test/TestProjects/Customizations-Cadl/Generated/cadl.json
@@ -458,7 +458,7 @@
      "Uri": "",
      "Path": "/inputToRoundTrip",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {

--- a/test/TestProjects/FirstTest-Cadl/Generated/cadl.json
+++ b/test/TestProjects/FirstTest-Cadl/Generated/cadl.json
@@ -345,7 +345,8 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/top2",
-     "BufferResponse": false
+     "BufferResponse": false,
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "42",
@@ -586,7 +587,8 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/hello",
-     "BufferResponse": false
+     "BufferResponse": false,
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
@@ -812,7 +814,8 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false
+     "BufferResponse": false,
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "80",

--- a/test/TestProjects/Models-Cadl/Generated/ModelsInCadlClient.cs
+++ b/test/TestProjects/Models-Cadl/Generated/ModelsInCadlClient.cs
@@ -6,12 +6,10 @@
 #nullable disable
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
-using ModelsInCadl;
 
 namespace GeneratedModels
 {
@@ -42,32 +40,6 @@ namespace GeneratedModels
             ClientDiagnostics = new ClientDiagnostics(options, true);
             _pipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), Array.Empty<HttpPipelinePolicy>(), new ResponseClassifier());
             _apiVersion = options.Version;
-        }
-
-        /// <summary> Input to RoundTrip. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual async Task<Response<RoundTripModel>> InputToRoundTripAsync(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = await InputToRoundTripAsync(input.ToRequestContent(), context).ConfigureAwait(false);
-            return Response.FromValue(RoundTripModel.FromResponse(response), response);
-        }
-
-        /// <summary> Input to RoundTrip. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual Response<RoundTripModel> InputToRoundTrip(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = InputToRoundTrip(input.ToRequestContent(), context);
-            return Response.FromValue(RoundTripModel.FromResponse(response), response);
         }
 
         /// <summary> Input to RoundTrip. </summary>
@@ -291,32 +263,6 @@ namespace GeneratedModels
         }
 
         /// <summary> Input to RoundTripPrimitive. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual async Task<Response<RoundTripPrimitiveModel>> InputToRoundTripPrimitiveAsync(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = await InputToRoundTripPrimitiveAsync(input.ToRequestContent(), context).ConfigureAwait(false);
-            return Response.FromValue(RoundTripPrimitiveModel.FromResponse(response), response);
-        }
-
-        /// <summary> Input to RoundTripPrimitive. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual Response<RoundTripPrimitiveModel> InputToRoundTripPrimitive(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = InputToRoundTripPrimitive(input.ToRequestContent(), context);
-            return Response.FromValue(RoundTripPrimitiveModel.FromResponse(response), response);
-        }
-
-        /// <summary> Input to RoundTripPrimitive. </summary>
         /// <param name="content"> The content to send as the body of the request. Details of the request body schema are in the Remarks section below. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
@@ -530,32 +476,6 @@ namespace GeneratedModels
                 scope.Failed(e);
                 throw;
             }
-        }
-
-        /// <summary> Input to RoundTripOptional. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual async Task<Response<RoundTripOptionalModel>> InputToRoundTripOptionalAsync(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = await InputToRoundTripOptionalAsync(input.ToRequestContent(), context).ConfigureAwait(false);
-            return Response.FromValue(RoundTripOptionalModel.FromResponse(response), response);
-        }
-
-        /// <summary> Input to RoundTripOptional. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual Response<RoundTripOptionalModel> InputToRoundTripOptional(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = InputToRoundTripOptional(input.ToRequestContent(), context);
-            return Response.FromValue(RoundTripOptionalModel.FromResponse(response), response);
         }
 
         /// <summary> Input to RoundTripOptional. </summary>
@@ -778,32 +698,6 @@ namespace GeneratedModels
                 scope.Failed(e);
                 throw;
             }
-        }
-
-        /// <summary> Input to RoundTripReadOnly. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual async Task<Response<RoundTripReadOnlyModel>> InputToRoundTripReadOnlyAsync(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = await InputToRoundTripReadOnlyAsync(input.ToRequestContent(), context).ConfigureAwait(false);
-            return Response.FromValue(RoundTripReadOnlyModel.FromResponse(response), response);
-        }
-
-        /// <summary> Input to RoundTripReadOnly. </summary>
-        /// <param name="input"> The InputModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual Response<RoundTripReadOnlyModel> InputToRoundTripReadOnly(InputModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = InputToRoundTripReadOnly(input.ToRequestContent(), context);
-            return Response.FromValue(RoundTripReadOnlyModel.FromResponse(response), response);
         }
 
         /// <summary> Input to RoundTripReadOnly. </summary>
@@ -1067,32 +961,6 @@ namespace GeneratedModels
         }
 
         /// <summary> RoundTrip to Output. </summary>
-        /// <param name="input"> The RoundTripModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual async Task<Response<OutputModel>> RoundTripToOutputAsync(RoundTripModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = await RoundTripToOutputAsync(input.ToRequestContent(), context).ConfigureAwait(false);
-            return Response.FromValue(OutputModel.FromResponse(response), response);
-        }
-
-        /// <summary> RoundTrip to Output. </summary>
-        /// <param name="input"> The RoundTripModel to use. </param>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
-        public virtual Response<OutputModel> RoundTripToOutput(RoundTripModel input, CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(input, nameof(input));
-
-            RequestContext context = FromCancellationToken(cancellationToken);
-            Response response = RoundTripToOutput(input.ToRequestContent(), context);
-            return Response.FromValue(OutputModel.FromResponse(response), response);
-        }
-
-        /// <summary> RoundTrip to Output. </summary>
         /// <param name="content"> The content to send as the body of the request. Details of the request body schema are in the Remarks section below. </param>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
@@ -1317,44 +1185,6 @@ namespace GeneratedModels
         }
 
         /// <summary> Returns model that has property of its own type. </summary>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response<ErrorModel>> SelfReferenceValueAsync(CancellationToken cancellationToken = default)
-        {
-            using var scope = ClientDiagnostics.CreateScope("ModelsInCadlClient.SelfReferenceValue");
-            scope.Start();
-            try
-            {
-                RequestContext context = FromCancellationToken(cancellationToken);
-                Response response = await SelfReferenceAsync(context).ConfigureAwait(false);
-                return Response.FromValue(ErrorModel.FromResponse(response), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        /// <summary> Returns model that has property of its own type. </summary>
-        /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response<ErrorModel> SelfReferenceValue(CancellationToken cancellationToken = default)
-        {
-            using var scope = ClientDiagnostics.CreateScope("ModelsInCadlClient.SelfReferenceValue");
-            scope.Start();
-            try
-            {
-                RequestContext context = FromCancellationToken(cancellationToken);
-                Response response = SelfReference(context);
-                return Response.FromValue(ErrorModel.FromResponse(response), response);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
-        }
-
-        /// <summary> Returns model that has property of its own type. </summary>
         /// <param name="context"> The request context, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="RequestFailedException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. Details of the response body schema are in the Remarks section below. </returns>
@@ -1519,17 +1349,6 @@ namespace GeneratedModels
             uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             return message;
-        }
-
-        private static RequestContext DefaultRequestContext = new RequestContext();
-        internal static RequestContext FromCancellationToken(CancellationToken cancellationToken = default)
-        {
-            if (!cancellationToken.CanBeCanceled)
-            {
-                return DefaultRequestContext;
-            }
-
-            return new RequestContext() { CancellationToken = cancellationToken };
         }
 
         private static ResponseClassifier _responseClassifier200;

--- a/test/TestProjects/Models-Cadl/Generated/cadl.json
+++ b/test/TestProjects/Models-Cadl/Generated/cadl.json
@@ -1533,7 +1533,7 @@
      "Uri": "",
      "Path": "/inputToRoundTrip",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "196",
@@ -1578,7 +1578,7 @@
      "Uri": "",
      "Path": "/inputToRoundTripPrimitive",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "199",
@@ -1623,7 +1623,7 @@
      "Uri": "",
      "Path": "/inputToRoundTripOptional",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "202",
@@ -1668,7 +1668,7 @@
      "Uri": "",
      "Path": "/inputToRoundTripReadOnly",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "205",
@@ -1713,7 +1713,7 @@
      "Uri": "",
      "Path": "/roundTripToOutput",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     },
     {
      "$id": "208",
@@ -1741,7 +1741,7 @@
      "Uri": "",
      "Path": "/selfReference",
      "BufferResponse": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {


### PR DESCRIPTION
# Description

- When there is no convenience api decorator, no convenience method will be generated.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first