### PR TITLE
dpg: temporarily disable enum description check

### DIFF
--- a/src/AutoRest.CSharp/Common/Input/CadlInputEnumTypeConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/CadlInputEnumTypeConverter.cs
@@ -50,7 +50,13 @@ namespace AutoRest.CSharp.Common.Input
             }
 
             name = name ?? throw new JsonException("Enum must have name");
-            description = description ?? throw new JsonException("Enum must have a description");
+            // TODO: roll back to throw JSON error when there is linter on the upstream to check enum without @doc
+            //description = description ?? throw new JsonException("Enum must have a description");
+            if (description == null)
+            {
+                description = "";
+                System.Console.Error.WriteLine($"[Warn]: Enum '{name}' must have a description");
+            }
 
             if (allowedValues == null || allowedValues.Count == 0)
             {


### PR DESCRIPTION
There are too many enums without description on the upstream (e.g. `@Azure.Core` etc). Let's disable the check and convert it into warning for now. We can resume the error when we're sure the issues are fixed on the upstream.

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first