### PR TITLE
Update XMsFormat and add EB.Never for LRO operation Id

### DIFF
--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageAccountRestoreBlobRangesOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageAccountRestoreBlobRangesOperation.cs
@@ -42,6 +42,7 @@ namespace Azure.Management.Storage
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperation.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperation.cs
@@ -39,6 +39,7 @@ namespace Azure.Management.Storage
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperationOfT.cs
+++ b/samples/Azure.Management.Storage/Generated/LongRunningOperation/StorageArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace Azure.Management.Storage
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperation.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperation.cs
@@ -39,6 +39,7 @@ namespace Azure.ResourceManager.Sample
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperationOfT.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/LongRunningOperation/SampleArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace Azure.ResourceManager.Sample
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineCaptureResult.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineCaptureResult.cs
@@ -97,6 +97,33 @@ namespace Azure.ResourceManager.Sample.Models
         /// <summary>
         /// a list of resource items of the captured virtual machine
         /// Serialized Name: VirtualMachineCaptureResult.resources
+        /// <para>
+        /// To assign an object to the element of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
         /// </summary>
         public IReadOnlyList<BinaryData> Resources { get; }
     }

--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -248,6 +248,9 @@ namespace AutoRest.CSharp.Generation.Types
         {
             XMsFormat.ArmId => typeof(ResourceIdentifier),
             XMsFormat.AzureLocation => typeof(AzureLocation),
+            XMsFormat.DateTime => typeof(DateTimeOffset),
+            XMsFormat.DateTimeRFC1123 => typeof(DateTimeOffset),
+            XMsFormat.DateTimeUnix => typeof(DateTimeOffset),
             XMsFormat.DurationConstant => typeof(TimeSpan),
             XMsFormat.ETag => typeof(ETag),
             XMsFormat.ResourceType => typeof(ResourceType),

--- a/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
@@ -329,6 +329,9 @@ namespace AutoRest.CSharp.Common.Input
             NumberSchema { Type: AllSchemaTypes.Integer, Precision: 64 } => InputPrimitiveType.Int64,
             NumberSchema { Type: AllSchemaTypes.Integer }                => InputPrimitiveType.Int32,
 
+            { Type: AllSchemaTypes.String } when format == XMsFormat.DateTime => InputPrimitiveType.DateTimeISO8601,
+            { Type: AllSchemaTypes.String } when format == XMsFormat.DateTimeRFC1123 => InputPrimitiveType.DateTimeRFC1123,
+            { Type: AllSchemaTypes.String } when format == XMsFormat.DateTimeUnix => InputPrimitiveType.DateTimeUnix,
             { Type: AllSchemaTypes.String } when format == XMsFormat.DurationConstant => InputPrimitiveType.DurationConstant,
             { Type: AllSchemaTypes.String } when format == XMsFormat.ArmId            => InputPrimitiveType.ResourceIdentifier,
             { Type: AllSchemaTypes.String } when format == XMsFormat.AzureLocation    => InputPrimitiveType.AzureLocation,

--- a/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using AutoRest.CSharp.Output.Models.Responses;
 using AutoRest.CSharp.Utilities;
 using Azure.Core;
 using YamlDotNet.Serialization;
@@ -179,6 +180,9 @@ namespace AutoRest.CSharp.Input
     {
         public const string ArmId = "arm-id";
         public const string AzureLocation = "azure-location";
+        public const string DateTime = "date-time";
+        public const string DateTimeRFC1123 = "date-time-rfc1123";
+        public const string DateTimeUnix = "date-time-unix";
         public const string DurationConstant = "duration-constant";
         public const string ETag = "etag";
         public const string ResourceType = "resource-type";

--- a/src/AutoRest.CSharp/Common/Output/Builders/BuilderHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/BuilderHelpers.cs
@@ -85,6 +85,9 @@ namespace AutoRest.CSharp.Output.Builders
 
             _ => schema.Extensions?.Format switch
                 {
+                    XMsFormat.DateTime => SerializationFormat.DateTime_ISO8601,
+                    XMsFormat.DateTimeRFC1123 => SerializationFormat.DateTime_RFC1123,
+                    XMsFormat.DateTimeUnix => SerializationFormat.DateTime_Unix,
                     XMsFormat.DurationConstant => SerializationFormat.Duration_Constant,
                     _ => SerializationFormat.Default
                 }

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtLongRunningInterimOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtLongRunningInterimOperationWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -67,6 +68,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                     _writer.WriteXmlDocumentationInheritDoc();
                     _writer
                         .LineRaw("#pragma warning disable CA1822")
+                        .LineRaw($"[{typeof(EditorBrowsableAttribute)}({typeof(EditorBrowsableState)}.{nameof(EditorBrowsableState.Never)})]")
                         .LineRaw("public override string Id => throw new NotImplementedException();")
                         .LineRaw("#pragma warning restore CA1822")
                         .Line();

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtLongRunningOperationWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtLongRunningOperationWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -83,6 +84,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                     _writer.WriteXmlDocumentationInheritDoc();
                     _writer
                         .LineRaw("#pragma warning disable CA1822")
+                        .LineRaw($"[{typeof(EditorBrowsableAttribute)}({typeof(EditorBrowsableState)}.{nameof(EditorBrowsableState.Never)})]")
                         .LineRaw("public override string Id => throw new NotImplementedException();")
                         .LineRaw("#pragma warning restore CA1822")
                         .Line();

--- a/test/TestProjects/ExactMatchFlattenInheritance/Generated/LongRunningOperation/ExactMatchFlattenInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/ExactMatchFlattenInheritance/Generated/LongRunningOperation/ExactMatchFlattenInheritanceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace ExactMatchFlattenInheritance
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/ExactMatchInheritance/Generated/LongRunningOperation/ExactMatchInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/ExactMatchInheritance/Generated/LongRunningOperation/ExactMatchInheritanceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace ExactMatchInheritance
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperation.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtDiscriminator
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperationOfT.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/LongRunningOperation/MgmtDiscriminatorArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtDiscriminator
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperation.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtExpandResourceTypes
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperationOfT.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/LongRunningOperation/MgmtExpandResourceTypesArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtExpandResourceTypes
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/LongRunningOperation/MgmtExtensionCommonRestOperationArmOperationOfT.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/LongRunningOperation/MgmtExtensionCommonRestOperationArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtExtensionCommonRestOperation
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperation.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtExtensionResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/LongRunningOperation/MgmtExtensionResourceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtExtensionResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtExtensionResource/Generated/Models/ParameterDefinitionsValue.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/Models/ParameterDefinitionsValue.cs
@@ -35,7 +35,36 @@ namespace MgmtExtensionResource.Models
 
         /// <summary> The data type of the parameter. </summary>
         public ParameterType? ParameterType { get; set; }
-        /// <summary> The allowed values for the parameter. </summary>
+        /// <summary>
+        /// The allowed values for the parameter.
+        /// <para>
+        /// To assign an object to the element of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </summary>
         public IList<BinaryData> AllowedValues { get; }
         /// <summary>
         /// The default value for the parameter if no value is provided.

--- a/test/TestProjects/MgmtExtensionResource/Generated/Models/ParameterDefinitionsValueMetadata.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/Models/ParameterDefinitionsValueMetadata.cs
@@ -43,7 +43,36 @@ namespace MgmtExtensionResource.Models
         public string StrongType { get; set; }
         /// <summary> Set to true to have Azure portal create role assignments on the resource ID or resource scope value of this parameter during policy assignment. This property is useful in case you wish to assign permissions outside the assignment scope. </summary>
         public bool? AssignPermissions { get; set; }
-        /// <summary> Additional Properties. </summary>
+        /// <summary>
+        /// Additional Properties
+        /// <para>
+        /// To assign an object to the value of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </summary>
         public IDictionary<string, BinaryData> AdditionalProperties { get; }
     }
 }

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperation.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtLRO
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperationOfT.cs
+++ b/test/TestProjects/MgmtLRO/Generated/LongRunningOperation/MgmtLROArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtLRO
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/MgmtListMethodsArmOperationOfT.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/LongRunningOperation/MgmtListMethodsArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtListMethods
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/LongRunningOperation/MgmtMockAndSampleArmOperation.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/LongRunningOperation/MgmtMockAndSampleArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtMockAndSample
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/LongRunningOperation/MgmtMockAndSampleArmOperationOfT.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/LongRunningOperation/MgmtMockAndSampleArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtMockAndSample
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperation.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtMultipleParentResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/LongRunningOperation/MgmtMultipleParentResourceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtMultipleParentResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperation.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtNonStringPathVariable
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperationOfT.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/LongRunningOperation/MgmtNonStringPathVariableArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtNonStringPathVariable
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperation.cs
+++ b/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtOperations
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperationOfT.cs
+++ b/test/TestProjects/MgmtOperations/Generated/LongRunningOperation/MgmtOperationsArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtOperations
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtOptionalConstant/Generated/LongRunningOperation/MgmtOptionalConstantArmOperation.cs
+++ b/test/TestProjects/MgmtOptionalConstant/Generated/LongRunningOperation/MgmtOptionalConstantArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtOptionalConstant
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtOptionalConstant/Generated/LongRunningOperation/MgmtOptionalConstantArmOperationOfT.cs
+++ b/test/TestProjects/MgmtOptionalConstant/Generated/LongRunningOperation/MgmtOptionalConstantArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtOptionalConstant
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperation.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtParamOrdering
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperationOfT.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/LongRunningOperation/MgmtParamOrderingArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtParamOrdering
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperation.cs
+++ b/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtParent
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperationOfT.cs
+++ b/test/TestProjects/MgmtParent/Generated/LongRunningOperation/MgmtParentArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtParent
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperation.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtPropertyChooser
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperationOfT.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/LongRunningOperation/MgmtPropertyChooserArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtPropertyChooser
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperation.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtRenameRules
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperationOfT.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/LongRunningOperation/MgmtRenameRulesArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtRenameRules
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineCaptureResult.cs
+++ b/test/TestProjects/MgmtRenameRules/Generated/Models/VirtualMachineCaptureResult.cs
@@ -97,6 +97,33 @@ namespace MgmtRenameRules.Models
         /// <summary>
         /// a list of resource items of the captured virtual machine
         /// Serialized Name: VirtualMachineCaptureResult.resources
+        /// <para>
+        /// To assign an object to the element of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
         /// </summary>
         public IReadOnlyList<BinaryData> Resources { get; }
     }

--- a/test/TestProjects/MgmtResourceName/Generated/LongRunningOperation/MgmtResourceNameArmOperationOfT.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/LongRunningOperation/MgmtResourceNameArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtResourceName
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtSafeFlatten/Generated/LongRunningOperation/MgmtSafeFlattenArmOperationOfT.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/LongRunningOperation/MgmtSafeFlattenArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtSafeFlatten
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperation.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtScopeResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperationOfT.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/LongRunningOperation/MgmtScopeResourceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtScopeResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperation.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperation.cs
@@ -39,6 +39,7 @@ namespace MgmtSubscriptionNameParameter
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperationOfT.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/LongRunningOperation/MgmtSubscriptionNameParameterArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace MgmtSubscriptionNameParameter
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/NoTypeReplacement/Generated/LongRunningOperation/NoTypeReplacementArmOperationOfT.cs
+++ b/test/TestProjects/NoTypeReplacement/Generated/LongRunningOperation/NoTypeReplacementArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace NoTypeReplacement
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/OmitOperationGroups/Generated/LongRunningOperation/OmitOperationGroupsArmOperationOfT.cs
+++ b/test/TestProjects/OmitOperationGroups/Generated/LongRunningOperation/OmitOperationGroupsArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace OmitOperationGroups
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/Pagination/Generated/LongRunningOperation/PaginationArmOperationOfT.cs
+++ b/test/TestProjects/Pagination/Generated/LongRunningOperation/PaginationArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace Pagination
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperation.cs
+++ b/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperation.cs
@@ -39,6 +39,7 @@ namespace ResourceRename
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperationOfT.cs
+++ b/test/TestProjects/ResourceRename/Generated/LongRunningOperation/ResourceRenameArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace ResourceRename
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/ResourceRename/Generated/Models/AnyObjectTests.cs
+++ b/test/TestProjects/ResourceRename/Generated/Models/AnyObjectTests.cs
@@ -84,11 +84,98 @@ namespace ResourceRename.Models
         /// </para>
         /// </summary>
         public BinaryData AnyObjectProperty { get; }
-        /// <summary> This is an array of Any type. </summary>
+        /// <summary>
+        /// This is an array of Any type
+        /// <para>
+        /// To assign an object to the element of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </summary>
         public IReadOnlyList<BinaryData> AnyList { get; }
-        /// <summary> This is an array of AnyObject type. </summary>
+        /// <summary>
+        /// This is an array of AnyObject type
+        /// <para>
+        /// To assign an object to the element of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </summary>
         public IReadOnlyList<BinaryData> AnyObjectList { get; }
-        /// <summary> This is a dictionary of Any type. </summary>
+        /// <summary>
+        /// This is a dictionary of Any type
+        /// <para>
+        /// To assign an object to the value of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
+        /// </para>
+        /// <para>
+        /// To assign an already formated json string to this property use <see cref="BinaryData.FromString(string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson("foo")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("\"foo\"")</term>
+        /// <description>Creates a payload of "foo".</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// <item>
+        /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
+        /// <description>Creates a payload of { "key": "value" }.</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </summary>
         public IReadOnlyDictionary<string, BinaryData> AnyDictionary { get; }
         /// <summary>
         /// This is a dictionary of AnyObject type

--- a/test/TestProjects/SingletonResource/Generated/LongRunningOperation/SingletonResourceArmOperationOfT.cs
+++ b/test/TestProjects/SingletonResource/Generated/LongRunningOperation/SingletonResourceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace SingletonResource
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/SubscriptionExtensionsArmOperationOfT.cs
+++ b/test/TestProjects/SubscriptionExtensions/Generated/LongRunningOperation/SubscriptionExtensionsArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace SubscriptionExtensions
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/SupersetFlattenInheritance/Generated/LongRunningOperation/SupersetFlattenInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/SupersetFlattenInheritance/Generated/LongRunningOperation/SupersetFlattenInheritanceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace SupersetFlattenInheritance
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/SupersetInheritance/Generated/LongRunningOperation/SupersetInheritanceArmOperationOfT.cs
+++ b/test/TestProjects/SupersetInheritance/Generated/LongRunningOperation/SupersetInheritanceArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace SupersetInheritance
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/TenantOnly/Generated/LongRunningOperation/TenantOnlyArmOperationOfT.cs
+++ b/test/TestProjects/TenantOnly/Generated/LongRunningOperation/TenantOnlyArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace TenantOnly
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperation.cs
+++ b/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperation.cs
@@ -39,6 +39,7 @@ namespace XmlDeserialization
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 

--- a/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperationOfT.cs
+++ b/test/TestProjects/XmlDeserialization/Generated/LongRunningOperation/XmlDeserializationArmOperationOfT.cs
@@ -39,6 +39,7 @@ namespace XmlDeserialization
 
         /// <inheritdoc />
 #pragma warning disable CA1822
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override string Id => throw new NotImplementedException();
 #pragma warning restore CA1822
 


### PR DESCRIPTION
This PR include three changes:

- Support `date-time`, `date-time--rfc1123` and `date-time-unix` in XMsFormat to ensure that we can have correct serialization with these three types.
- Add the `EB.Never` attribute for LRO operation Id
- Improve the implementation for BinaryData description so that the specific description could be added in the property when the type of property is `IList<BinaryData>` or `IDictionary<string, BinaryData>`.

Regen: https://github.com/Azure/azure-sdk-for-net/pull/31374

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first