### PR TITLE
Multiple url parameters

### DIFF
--- a/src/CADL.Extension/Emitter.Csharp/samples/CadlFirstTest/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/samples/CadlFirstTest/Generated/cadl.json
@@ -266,7 +266,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "",
      "Path": "/top/{action}",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
@@ -321,7 +321,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "",
      "Path": "/top2",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
@@ -423,7 +423,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
@@ -488,7 +488,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "",
      "Path": "/hello",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
@@ -599,7 +599,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
@@ -654,7 +654,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "",
      "Path": "/demoHi",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/samples/petStore/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/samples/petStore/Generated/cadl.json
@@ -62,19 +62,71 @@
   },
   {
    "$id": "9",
-   "Name": "Toy",
+   "Name": "ToyListResults",
    "Namespace": "PetStore",
    "IsNullable": false,
    "Properties": [
     {
      "$id": "10",
-     "Name": "id",
-     "SerializedName": "id",
+     "Name": "items",
+     "SerializedName": "items",
      "Description": "",
      "Type": {
       "$id": "11",
-      "Name": "Int64",
-      "Kind": "Int64",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "12",
+       "Name": "Toy",
+       "Namespace": "PetStore",
+       "IsNullable": false,
+       "Properties": [
+        {
+         "$id": "13",
+         "Name": "id",
+         "SerializedName": "id",
+         "Description": "",
+         "Type": {
+          "$id": "14",
+          "Name": "Int64",
+          "Kind": "Int64",
+          "IsNullable": false
+         },
+         "IsRequired": true,
+         "IsReadOnly": false,
+         "IsDiscriminator": false
+        },
+        {
+         "$id": "15",
+         "Name": "petId",
+         "SerializedName": "petId",
+         "Description": "",
+         "Type": {
+          "$id": "16",
+          "Name": "Int64",
+          "Kind": "Int64",
+          "IsNullable": false
+         },
+         "IsRequired": true,
+         "IsReadOnly": false,
+         "IsDiscriminator": false
+        },
+        {
+         "$id": "17",
+         "Name": "name",
+         "SerializedName": "name",
+         "Description": "",
+         "Type": {
+          "$id": "18",
+          "Name": "string",
+          "Kind": "String",
+          "IsNullable": false
+         },
+         "IsRequired": true,
+         "IsReadOnly": false,
+         "IsDiscriminator": false
+        }
+       ]
+      },
       "IsNullable": false
      },
      "IsRequired": true,
@@ -82,56 +134,44 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "12",
-     "Name": "petId",
-     "SerializedName": "petId",
+     "$id": "19",
+     "Name": "nextLink",
+     "SerializedName": "nextLink",
      "Description": "",
      "Type": {
-      "$id": "13",
-      "Name": "Int64",
-      "Kind": "Int64",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false,
-     "IsDiscriminator": false
-    },
-    {
-     "$id": "14",
-     "Name": "name",
-     "SerializedName": "name",
-     "Description": "",
-     "Type": {
-      "$id": "15",
+      "$id": "20",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
      },
-     "IsRequired": true,
+     "IsRequired": false,
      "IsReadOnly": false,
      "IsDiscriminator": false
     }
    ]
+  },
+  {
+   "$ref": "12"
   }
  ],
  "Clients": [
   {
-   "$id": "16",
+   "$id": "21",
    "Name": "Pets",
    "Description": "Manage your pets. You can delete or get the Pet from pet store.",
    "Operations": [
     {
-     "$id": "17",
+     "$id": "22",
      "Name": "delete",
      "Summary": "delete.",
      "Description": "Delete a pet.",
      "Parameters": [
       {
-       "$id": "18",
+       "$id": "23",
        "Name": "petStoreUrl",
        "NameInRequest": "petStoreUrl",
        "Type": {
-        "$id": "19",
+        "$id": "24",
         "Name": "Uri",
         "Kind": "Uri",
         "IsNullable": false
@@ -147,12 +187,12 @@
        "Kind": "Client"
       },
       {
-       "$id": "20",
+       "$id": "25",
        "Name": "petId",
        "NameInRequest": "petId",
        "Description": "The id of pet.",
        "Type": {
-        "$id": "21",
+        "$id": "26",
         "Name": "Int32",
         "Kind": "Int32",
         "IsNullable": false
@@ -168,11 +208,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "22",
+       "$id": "27",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "23",
+        "$id": "28",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -187,20 +227,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "24",
+        "$id": "29",
         "Type": {
-         "$ref": "23"
+         "$ref": "28"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "25",
+       "$id": "30",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "26",
+        "$id": "31",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -215,9 +255,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "27",
+        "$id": "32",
         "Type": {
-         "$id": "28",
+         "$id": "33",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -228,7 +268,7 @@
      ],
      "Responses": [
       {
-       "$id": "29",
+       "$id": "34",
        "StatusCodes": [
         200
        ],
@@ -239,24 +279,24 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{petStoreUrl}",
      "Path": "/pets/{petId}",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
-     "$id": "30",
+     "$id": "35",
      "Name": "read",
      "Description": "Returns a pet. Supports eTags.",
      "Parameters": [
       {
-       "$ref": "18"
+       "$ref": "23"
       },
       {
-       "$id": "31",
+       "$id": "36",
        "Name": "petId",
        "NameInRequest": "petId",
        "Description": "The id of pet.",
        "Type": {
-        "$id": "32",
+        "$id": "37",
         "Name": "Int32",
         "Kind": "Int32",
         "IsNullable": false
@@ -272,11 +312,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "33",
+       "$id": "38",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "34",
+        "$id": "39",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -291,20 +331,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "35",
+        "$id": "40",
         "Type": {
-         "$ref": "34"
+         "$ref": "39"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "25"
+       "$ref": "30"
       }
      ],
      "Responses": [
       {
-       "$id": "36",
+       "$id": "41",
        "StatusCodes": [
         200
        ],
@@ -314,7 +354,7 @@
        "BodyMediaType": "Json"
       },
       {
-       "$id": "37",
+       "$id": "42",
        "StatusCodes": [
         304
        ],
@@ -328,18 +368,18 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{petStoreUrl}",
      "Path": "/pets/{petId}",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
-     "$id": "38",
+     "$id": "43",
      "Name": "create",
      "Parameters": [
       {
-       "$ref": "18"
+       "$ref": "23"
       },
       {
-       "$id": "39",
+       "$id": "44",
        "Name": "pet",
        "NameInRequest": "pet",
        "Type": {
@@ -356,11 +396,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "40",
+       "$id": "45",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "41",
+        "$id": "46",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -375,19 +415,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "42",
+        "$id": "47",
         "Type": {
-         "$ref": "41"
+         "$ref": "46"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "43",
+       "$id": "48",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "44",
+        "$id": "49",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -402,20 +442,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "45",
+        "$id": "50",
         "Type": {
-         "$ref": "44"
+         "$ref": "49"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "25"
+       "$ref": "30"
       }
      ],
      "Responses": [
       {
-       "$id": "46",
+       "$id": "51",
        "StatusCodes": [
         200
        ],
@@ -432,31 +472,31 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
-    "$id": "47"
+    "$id": "52"
    }
   },
   {
-   "$id": "48",
+   "$id": "53",
    "Name": "ListPetToysResponse",
    "Operations": [
     {
-     "$id": "49",
+     "$id": "54",
      "Name": "list",
      "Parameters": [
       {
-       "$ref": "18"
+       "$ref": "23"
       },
       {
-       "$id": "50",
+       "$id": "55",
        "Name": "petId",
        "NameInRequest": "petId",
        "Type": {
-        "$id": "51",
+        "$id": "56",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -472,11 +512,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "52",
+       "$id": "57",
        "Name": "nameFilter",
        "NameInRequest": "nameFilter",
        "Type": {
-        "$id": "53",
+        "$id": "58",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -492,11 +532,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "54",
+       "$id": "59",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "55",
+        "$id": "60",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -511,20 +551,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "56",
+        "$id": "61",
         "Type": {
-         "$ref": "55"
+         "$ref": "60"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "25"
+       "$ref": "30"
       }
      ],
      "Responses": [
       {
-       "$id": "57",
+       "$id": "62",
        "StatusCodes": [
         200
        ],
@@ -538,12 +578,12 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{petStoreUrl}",
      "Path": "/pets/{petId}/toys",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
-    "$id": "58"
+    "$id": "63"
    }
   }
  ]

--- a/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
@@ -184,14 +184,14 @@ function createModel(program: Program): any {
         console.log("routes:" + routes.length);
         const clients: InputClient[] = [];
         //create endpoint parameter from servers
-        let endPointParam = undefined;
+        let endPointParam : InputParameter[] | undefined = undefined;
         let url: string = "";
         if (servers !== undefined) {
             const cadlServers = resolveServers(program, servers);
             if (cadlServers.length > 0) {
                 /* choose the first server as endpoint. */
                 url = cadlServers[0].url;
-                endPointParam = cadlServers[0].parameters[0];
+                endPointParam = cadlServers[0].parameters;
             }
         }
 
@@ -396,7 +396,7 @@ function loadOperation(
     program: Program,
     operation: OperationDetails,
     uri: string,
-    endpoint: InputParameter | undefined = undefined,
+    endpoint: InputParameter[] | undefined = undefined,
     models: Map<string, InputModelType>,
     enums: Map<string, InputEnumType>
 ): InputOperation {
@@ -413,7 +413,11 @@ function loadOperation(
     const externalDocs = getExternalDocs(program, op);
 
     const parameters: InputParameter[] = [];
-    if (endpoint) parameters.push(endpoint);
+    if (endpoint) {
+        for(const para of endpoint) {
+            parameters.push(para);
+        }
+    }
     for (const p of cadlParameters.parameters) {
         parameters.push(loadOperationParameter(program, p));
     }

--- a/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
@@ -184,14 +184,14 @@ function createModel(program: Program): any {
         console.log("routes:" + routes.length);
         const clients: InputClient[] = [];
         //create endpoint parameter from servers
-        let endPointParam : InputParameter[] | undefined = undefined;
+        let urlParameters : InputParameter[] | undefined = undefined;
         let url: string = "";
         if (servers !== undefined) {
             const cadlServers = resolveServers(program, servers);
             if (cadlServers.length > 0) {
                 /* choose the first server as endpoint. */
                 url = cadlServers[0].url;
-                endPointParam = cadlServers[0].parameters;
+                urlParameters = cadlServers[0].parameters;
             }
         }
 
@@ -219,7 +219,7 @@ function createModel(program: Program): any {
                 program,
                 operation,
                 url,
-                endPointParam,
+                urlParameters,
                 modelMap,
                 enumMap
             );
@@ -396,7 +396,7 @@ function loadOperation(
     program: Program,
     operation: OperationDetails,
     uri: string,
-    endpoint: InputParameter[] | undefined = undefined,
+    urlParameters: InputParameter[] | undefined = undefined,
     models: Map<string, InputModelType>,
     enums: Map<string, InputEnumType>
 ): InputOperation {
@@ -413,9 +413,9 @@ function loadOperation(
     const externalDocs = getExternalDocs(program, op);
 
     const parameters: InputParameter[] = [];
-    if (endpoint) {
-        for(const para of endpoint) {
-            parameters.push(para);
+    if (urlParameters) {
+        for(const param of urlParameters) {
+            parameters.push(param);
         }
     }
     for (const p of cadlParameters.parameters) {

--- a/src/CADL.Extension/Emitter.Csharp/src/lib/cadlServer.ts
+++ b/src/CADL.Extension/Emitter.Csharp/src/lib/cadlServer.ts
@@ -38,18 +38,19 @@ export function resolveServers(
     return servers.map((server) => {
         const parameters: InputParameter[] = [];
         let url: string = server.url;
+        let endpoint: string = url.replace("http://", "").replace("https://", "").split("/")[0];
         for (const [name, prop] of server.parameters) {
             // if (!validateValidServerVariable(program, prop)) {
             //   continue;
             // }
-
+            const isEndpoint: boolean = endpoint === (`{${name}}`);
             let defaultValue = undefined;
             const value = prop.default ? getDefaultValue(prop.default) : "";
             if (value) {
                 defaultValue = {
                     Type: {
-                        Name: "Uri",
-                        Kind: InputTypeKind.Uri,
+                        Name: isEndpoint ? "Uri": "String",
+                        Kind: isEndpoint ? InputTypeKind.Uri : InputTypeKind.String,
                         IsNullable: false
                     } as InputPrimitiveType,
                     Value: value
@@ -60,8 +61,8 @@ export function resolveServers(
                 NameInRequest: name,
                 Description: getDoc(program, prop),
                 Type: {
-                    Name: "Uri",
-                    Kind: InputTypeKind.Uri,
+                    Name: isEndpoint ? "Uri": "String",
+                    Kind: isEndpoint ? InputTypeKind.Uri : InputTypeKind.String,
                     IsNullable: false
                 } as InputPrimitiveType,
                 Location: RequestLocation.Uri,
@@ -69,7 +70,7 @@ export function resolveServers(
                 IsResourceParameter: false,
                 IsContentType: false,
                 IsRequired: true,
-                IsEndpoint: true,
+                IsEndpoint: isEndpoint,
                 SkipUrlEncoding: false,
                 Explode: false,
                 Kind: InputOperationParameterKind.Client,

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/array/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/array/Generated/cadl.json
@@ -190,7 +190,12 @@
         200
        ],
        "BodyType": {
-        "$ref": "2"
+        "$id": "25",
+        "Name": "Array",
+        "ElementType": {
+         "$ref": "2"
+        },
+        "IsNullable": false
        },
        "BodyMediaType": "Json"
       }
@@ -199,12 +204,12 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/pets",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
-    "$id": "25"
+    "$id": "26"
    }
   }
  ]

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpoint/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpoint/Generated/cadl.json
@@ -128,7 +128,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{endpointServiceUrl}",
      "Path": "/endpoint/{action}",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpointWithMultiplePart/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpointWithMultiplePart/Generated/cadl.json
@@ -1,32 +1,29 @@
 {
  "$id": "1",
- "Name": "securityclient",
- "Description": "Illustrates clients generated from a Cadl with security.",
+ "Name": "endpoint",
  "ApiVersions": [
-  "1.0.0"
+  "2015-06-18"
  ],
  "Enums": [],
  "Models": [],
  "Clients": [
   {
    "$id": "2",
-   "Name": "SecurityClient",
-   "Description": "Illustrates clients generated from a Cadl with security.",
+   "Name": "endpoint",
    "Operations": [
     {
      "$id": "3",
-     "Name": "genSecurity",
-     "Description": "Get security info",
+     "Name": "genEndPoint",
+     "Description": "Path parameter is string with format",
      "Parameters": [
       {
        "$id": "4",
-       "Name": "host",
-       "NameInRequest": "host",
-       "Description": "TestServer endpoint",
+       "Name": "endpointServiceUrl",
+       "NameInRequest": "endpointServiceUrl",
        "Type": {
         "$id": "5",
-        "Name": "String",
-        "Kind": "String",
+        "Name": "Uri",
+        "Kind": "Uri",
         "IsNullable": false
        },
        "Location": "Uri",
@@ -37,24 +34,54 @@
        "IsEndpoint": true,
        "SkipUrlEncoding": false,
        "Explode": false,
-       "Kind": "Client",
-       "DefaultValue": {
-        "$id": "6",
-        "Type": {
-         "$id": "7",
-         "Name": "String",
-         "Kind": "String",
-         "IsNullable": false
-        },
-        "Value": "http://localhost:3000"
-       }
+       "Kind": "Client"
+      },
+      {
+       "$id": "6",
+       "Name": "id",
+       "NameInRequest": "id",
+       "Type": {
+        "$id": "7",
+        "Name": "String",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       "Location": "Uri",
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsRequired": true,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Client"
       },
       {
        "$id": "8",
+       "Name": "action",
+       "NameInRequest": "action",
+       "Type": {
+        "$id": "9",
+        "Name": "string",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       "Location": "Path",
+       "IsRequired": true,
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Method"
+      },
+      {
+       "$id": "10",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "9",
+        "$id": "11",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -69,20 +96,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "10",
+        "$id": "12",
         "Type": {
-         "$ref": "9"
+         "$ref": "11"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "11",
+       "$id": "13",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "12",
+        "$id": "14",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -97,50 +124,37 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "13",
+        "$id": "15",
         "Type": {
-         "$id": "14",
+         "$id": "16",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
         },
-        "Value": "1.0.0"
+        "Value": "2015-06-18"
        }
       }
      ],
      "Responses": [
       {
-       "$id": "15",
+       "$id": "17",
        "StatusCodes": [
-        200
+        204
        ],
        "BodyMediaType": "Json"
       }
      ],
      "HttpMethod": "GET",
      "RequestBodyMediaType": "Json",
-     "Uri": "{host}",
-     "Path": "/security",
+     "Uri": "{endpointServiceUrl}/id/{id}",
+     "Path": "/endpoint/{action}",
      "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
    "Protocol": {
-    "$id": "16"
+    "$id": "18"
    }
   }
- ],
- "Auth": {
-  "$id": "17",
-  "ApiKey": {
-   "$id": "18",
-   "Name": "x-ms-api-key"
-  },
-  "OAuth2": {
-   "$id": "19",
-   "Scopes": [
-    "https://api.example.com/.default"
-   ]
-  }
- }
+ ]
 }

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpointWithMultiplePart/endpointWithMultiplePart.cadl
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/endpointWithMultiplePart/endpointWithMultiplePart.cadl
@@ -1,0 +1,20 @@
+import "@cadl-lang/rest";
+
+@serviceTitle("endpoint")
+@serviceVersion("2015-06-18")
+@server(
+    "{endpointServiceUrl}/id/{id}",
+    "Endpoint Service",
+    {
+        endpointServiceUrl: string,
+        id:string
+    }
+)
+namespace endpoint;
+
+using Cadl.Http;
+
+@route("/endpoint")
+@doc("Path parameter is string with format")
+@get
+op genEndPoint(@path action: string): void;

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/enum/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/enum/Generated/cadl.json
@@ -321,7 +321,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/head/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/head/Generated/cadl.json
@@ -211,7 +211,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
@@ -312,7 +312,7 @@
      "RequestMediaTypes": [
       "text/plain"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/interface/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/interface/Generated/cadl.json
@@ -172,7 +172,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/dogs",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": true
     },
     {
@@ -277,7 +277,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],
@@ -344,7 +344,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "{host}",
      "Path": "/cats",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
@@ -449,7 +449,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/lro/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/lro/Generated/cadl.json
@@ -128,7 +128,7 @@
         },
         "Value": "application/merge-patch+json"
        },
-       "IsRequired": false,
+       "IsRequired": true,
        "IsApiVersion": false,
        "IsResourceParameter": false,
        "IsContentType": true,
@@ -242,7 +242,7 @@
      "RequestMediaTypes": [
       "application/merge-patch+json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/string-format/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/string-format/Generated/cadl.json
@@ -108,7 +108,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "",
      "Path": "/zonedDateTime/{time}",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     },
     {
@@ -180,7 +180,7 @@
      "RequestBodyMediaType": "Json",
      "Uri": "",
      "Path": "/uri/{uri}",
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],

--- a/src/CADL.Extension/Emitter.Csharp/test/TestProjects/visibility/Generated/cadl.json
+++ b/src/CADL.Extension/Emitter.Csharp/test/TestProjects/visibility/Generated/cadl.json
@@ -221,7 +221,7 @@
      "RequestMediaTypes": [
       "application/json"
      ],
-     "BufferResponse": false,
+     "BufferResponse": true,
      "GenerateConvenienceMethod": false
     }
    ],


### PR DESCRIPTION
# Description
Fix https://github.com/Azure/autorest.csharp/issues/2730

- support url which contains more than one url parameter
- 
we need to support following Url schemas:
1. http://{urlstr}
2. http://{urlstr}/parameter/{parameterName}
3. http://{namespace}.service.com
4. http://{namespace}.service.com/parameter/{parameterName}

For #1, #2, we still change `urlStr` to `endpoint` with Url type and isEndpoint=true. And `parameterName` is a normal client parameter with String type, isEndpoint=false
For #3, #4, both `namespace` and `parameterName` are normal client parameter with string type, and isEndpoint=false

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first