### PR TITLE
Revert fix for #2726: DPG LROs for PATCH method do not return final response from original URI

### DIFF
--- a/src/assets/Generator.Shared/NextLinkOperationImplementation.cs
+++ b/src/assets/Generator.Shared/NextLinkOperationImplementation.cs
@@ -233,7 +233,7 @@ namespace Azure.Core
             // 1.Original request is a put method;
             // 2.Original request is a management plane patch method. For data plane patch method, the final uri will be determinned by the original response header and "_finalStateVia";
             // 3.Original response header contains "Location" and FinalStateVia is configured to OriginalUri.
-            if (_requestMethod == RequestMethod.Put || _requestMethod == RequestMethod.Patch || _originalResponseHasLocation && _finalStateVia == OperationFinalStateVia.OriginalUri)
+            if (_requestMethod == RequestMethod.Put || _requestMethod == RequestMethod.Patch && _startRequestUri.Scheme == "https" && _startRequestUri.Host == "management.azure.com" || _originalResponseHasLocation && _finalStateVia == OperationFinalStateVia.OriginalUri)
             {
                 return _startRequestUri.AbsoluteUri;
             }

--- a/test/AutoRest.TestServer.Tests/lro.cs
+++ b/test/AutoRest.TestServer.Tests/lro.cs
@@ -120,7 +120,7 @@ namespace AutoRest.TestServer.Tests
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartPatch201RetryWithAsyncHeaderAsync();
             var resp = await operation.WaitForCompletionAsync().ConfigureAwait(false);
-            Assert.AreEqual("/lro/patch/201/retry/onlyAsyncHeader", resp.Value.Id);
+            Assert.AreEqual("/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", resp.Value.Id);
         });
 
         [Test]
@@ -128,7 +128,7 @@ namespace AutoRest.TestServer.Tests
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartPatch201RetryWithAsyncHeader();
             var resp = WaitForCompletionWithValue(operation);
-            Assert.AreEqual("/lro/patch/201/retry/onlyAsyncHeader", resp.Value.Id);
+            Assert.AreEqual("/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", resp.Value.Id);
         });
 
         [Test]
@@ -136,7 +136,7 @@ namespace AutoRest.TestServer.Tests
         {
             var operation = await new LROsClient(ClientDiagnostics, pipeline, host).StartPatch202RetryWithAsyncAndLocationHeaderAsync();
             var resp = await operation.WaitForCompletionAsync().ConfigureAwait(false);
-            Assert.AreEqual("/lro/patch/202/retry/asyncAndLocationHeader", resp.Value.Id);
+            Assert.AreEqual("/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202", resp.Value.Id);
         });
 
         [Test]
@@ -144,7 +144,7 @@ namespace AutoRest.TestServer.Tests
         {
             var operation = new LROsClient(ClientDiagnostics, pipeline, host).StartPatch202RetryWithAsyncAndLocationHeader();
             var resp = WaitForCompletionWithValue(operation);
-            Assert.AreEqual("/lro/patch/202/retry/asyncAndLocationHeader", resp.Value.Id);
+            Assert.AreEqual("/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202", resp.Value.Id);
         });
 
         [Test]


### PR DESCRIPTION
Reverting due to failure in Azure.Communication.PhoneNumbers.Tests (see comment from @Yao725: https://github.com/Azure/autorest.csharp/pull/2752#discussion_r990727037)