### PR TITLE
fix(dpg): enum value type is not correctly fetched

### DIFF
--- a/src/CADL.Extension/Emitter.Csharp/src/lib/model.ts
+++ b/src/CADL.Extension/Emitter.Csharp/src/lib/model.ts
@@ -338,7 +338,7 @@ export function getInputType(
             }
             const allowValues: InputEnumTypeValue[] = [];
             const enumValueType = enumMemberType(
-                e.members.entries().next().value
+                e.members.entries().next().value[1]
             );
 
             for (const key of e.members.keys()) {


### PR DESCRIPTION
# Description
`Map<K,V>.entries().next().value` returns entry type (e.g. `[K, V]`), not map entry value (e.g. `V`)

This problem is not exposed, because by far all enum types are of string values. If there was an integer type enum, the problematic line of code will return different value from https://github.com/Azure/autorest.csharp/blob/c157c68ff50ed5ffaa3b3e38c37bbc878b669ea4/src/CADL.Extension/Emitter.Csharp/src/lib/model.ts#L349

Thus, it will result in error `The enum member value type is not consistent.`.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first