### PR TITLE
Bump Azure.Core to 1.26.0 + Update RawRequestUriBuilder

### DIFF
--- a/samples/AppConfiguration/AppConfiguration.csproj
+++ b/samples/AppConfiguration/AppConfiguration.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.AI.DocumentTranslation/Azure.AI.DocumentTranslation.csproj
+++ b/samples/Azure.AI.DocumentTranslation/Azure.AI.DocumentTranslation.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer.csproj
+++ b/samples/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.csproj
+++ b/samples/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.Management.Storage/Azure.Management.Storage.csproj
+++ b/samples/Azure.Management.Storage/Azure.Management.Storage.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.Network.Management.Interface/Azure.Network.Management.Interface.csproj
+++ b/samples/Azure.Network.Management.Interface/Azure.Network.Management.Interface.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.ResourceManager.Sample/Azure.ResourceManager.Sample.csproj
+++ b/samples/Azure.ResourceManager.Sample/Azure.ResourceManager.Sample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Azure.Storage.Tables/Azure.Storage.Tables.csproj
+++ b/samples/Azure.Storage.Tables/Azure.Storage.Tables.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/CognitiveSearch/CognitiveSearch.csproj
+++ b/samples/CognitiveSearch/CognitiveSearch.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics.csproj
+++ b/samples/CognitiveServices.TextAnalytics/CognitiveServices.TextAnalytics.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -18,7 +18,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Include="Azure.ResourceManager" Version="1.3.1" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpProj.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpProj.cs
@@ -33,7 +33,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
 ";
         private string _coreCsProjContent = @"
   <ItemGroup>
-    <PackageReference Include=""Azure.Core"" Version=""1.25.0"" />
+    <PackageReference Include=""Azure.Core"" Version=""1.26.0"" />
   </ItemGroup>";
 
         private string _armCsProjContent = @"

--- a/src/assets/Generator.Shared/RawRequestUriBuilder.cs
+++ b/src/assets/Generator.Shared/RawRequestUriBuilder.cs
@@ -45,11 +45,11 @@ namespace Azure.Core
         {
             if (_position == null)
             {
-                if (!string.IsNullOrEmpty(Query))
+                if (HasQuery)
                 {
                     _position = RawWritingPosition.Query;
                 }
-                else if (!string.IsNullOrEmpty(Path))
+                else if (HasPath)
                 {
                     _position = RawWritingPosition.Path;
                 }
@@ -87,7 +87,7 @@ namespace Azure.Core
                     int separator = value.IndexOfAny(HostOrPort);
                     if (separator == -1)
                     {
-                        if (string.IsNullOrEmpty(Path))
+                        if (!HasPath)
                         {
                             Host += value.ToString();
                             value = ReadOnlySpan<char>.Empty;
@@ -135,12 +135,12 @@ namespace Azure.Core
                     int separator = value.IndexOf(QueryBeginSeparator);
                     if (separator == -1)
                     {
-                        AppendPath(value.ToString(), escape);
+                        AppendPath(value, escape);
                         value = ReadOnlySpan<char>.Empty;
                     }
                     else
                     {
-                        AppendPath(value.Slice(0, separator).ToString(), escape);
+                        AppendPath(value.Slice(0, separator), escape);
                         value = value.Slice(separator + 1);
                         _position = RawWritingPosition.Query;
                     }
@@ -155,13 +155,13 @@ namespace Azure.Core
                     else if (separator == -1)
                     {
                         GetQueryParts(value, out var queryName, out var queryValue);
-                        AppendQuery(queryName.ToString(), queryValue.ToString(), escape);
+                        AppendQuery(queryName, queryValue, escape);
                         value = ReadOnlySpan<char>.Empty;
                     }
                     else
                     {
                         GetQueryParts(value.Slice(0, separator), out var queryName, out var queryValue);
-                        AppendQuery(queryName.ToString(), queryValue.ToString(), escape);
+                        AppendQuery(queryName, queryValue, escape);
                         value = value.Slice(separator + 1);
                     }
                 }

--- a/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
+++ b/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
 
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
+++ b/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Include="Azure.Identity" Version="1.0.0" />
     <PackageReference Include="Azure.ResourceManager" Version="1.3.1" />

--- a/test/AutoRest.TestServerLowLevel.Tests/AutoRest.TestServerLowLevel.Tests.csproj
+++ b/test/AutoRest.TestServerLowLevel.Tests/AutoRest.TestServerLowLevel.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Include="Azure.Identity" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />

--- a/test/CadlRanchProjects.Tests/CadlRanchProjects.Tests.csproj
+++ b/test/CadlRanchProjects.Tests/CadlRanchProjects.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
     <PackageReference Include="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Include="Azure.Identity" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />

--- a/test/CadlRanchProjects/api-key/ApiKey.csproj
+++ b/test/CadlRanchProjects/api-key/ApiKey.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/extensible-enums/ExtensibleEnum.csproj
+++ b/test/CadlRanchProjects/extensible-enums/ExtensibleEnum.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/oauth2/OAuth2.csproj
+++ b/test/CadlRanchProjects/oauth2/OAuth2.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/property-optional/PropertyOptional.csproj
+++ b/test/CadlRanchProjects/property-optional/PropertyOptional.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/property-types/PropertyTypes.csproj
+++ b/test/CadlRanchProjects/property-types/PropertyTypes.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Accessibility-LowLevel-NoAuth/Accessibility_LowLevel_NoAuth.csproj
+++ b/test/TestProjects/Accessibility-LowLevel-NoAuth/Accessibility_LowLevel_NoAuth.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Accessibility-LowLevel-TokenAuth/Accessibility_LowLevel_TokenAuth.csproj
+++ b/test/TestProjects/Accessibility-LowLevel-TokenAuth/Accessibility_LowLevel_TokenAuth.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Accessibility-LowLevel/Accessibility_LowLevel.csproj
+++ b/test/TestProjects/Accessibility-LowLevel/Accessibility_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Accessibility/Accessibility.csproj
+++ b/test/TestProjects/Accessibility/Accessibility.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/AdditionalPropertiesEx/AdditionalPropertiesEx.csproj
+++ b/test/TestProjects/AdditionalPropertiesEx/AdditionalPropertiesEx.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ApiVersion/ApiVersion.csproj
+++ b/test/TestProjects/ApiVersion/ApiVersion.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Authoring-Cadl/Authoring-Cadl.csproj
+++ b/test/TestProjects/Authoring-Cadl/Authoring-Cadl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/BodyAndPath-LowLevel/BodyAndPath_LowLevel.csproj
+++ b/test/TestProjects/BodyAndPath-LowLevel/BodyAndPath_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/CollapseRequestCondition-LowLevel/CollapseRequestCondition_LowLevel.csproj
+++ b/test/TestProjects/CollapseRequestCondition-LowLevel/CollapseRequestCondition_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Customizations-Cadl/Customizations.csproj
+++ b/test/TestProjects/Customizations-Cadl/Customizations.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ExactMatchFlattenInheritance/ExactMatchFlattenInheritance.csproj
+++ b/test/TestProjects/ExactMatchFlattenInheritance/ExactMatchFlattenInheritance.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ExactMatchInheritance/ExactMatchInheritance.csproj
+++ b/test/TestProjects/ExactMatchInheritance/ExactMatchInheritance.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ExtensionClientName/ExtensionClientName.csproj
+++ b/test/TestProjects/ExtensionClientName/ExtensionClientName.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/FirstTest-Cadl/FirstTest.csproj
+++ b/test/TestProjects/FirstTest-Cadl/FirstTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/FlattenedParameters/FlattenedParameters.csproj
+++ b/test/TestProjects/FlattenedParameters/FlattenedParameters.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/HeadAsBooleanTrue-LowLevel/HeadAsBooleanTrue_LowLevel.csproj
+++ b/test/TestProjects/HeadAsBooleanTrue-LowLevel/HeadAsBooleanTrue_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/HeadAsBooleanTrue/HeadAsBooleanTrue.csproj
+++ b/test/TestProjects/HeadAsBooleanTrue/HeadAsBooleanTrue.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/HeaderCollectionPrefix/HeaderCollectionPrefix.csproj
+++ b/test/TestProjects/HeaderCollectionPrefix/HeaderCollectionPrefix.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Inheritance/Inheritance.csproj
+++ b/test/TestProjects/Inheritance/Inheritance.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/JsonAsBinary/JsonAsBinary.csproj
+++ b/test/TestProjects/JsonAsBinary/JsonAsBinary.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Lro-Basic-Cadl/LroBasicCadl.csproj
+++ b/test/TestProjects/Lro-Basic-Cadl/LroBasicCadl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtCollectionParent/MgmtCollectionParent.csproj
+++ b/test/TestProjects/MgmtCollectionParent/MgmtCollectionParent.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtDiscriminator/MgmtDiscriminator.csproj
+++ b/test/TestProjects/MgmtDiscriminator/MgmtDiscriminator.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtExpandResourceTypes/MgmtExpandResourceTypes.csproj
+++ b/test/TestProjects/MgmtExpandResourceTypes/MgmtExpandResourceTypes.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/MgmtExtensionCommonRestOperation.csproj
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/MgmtExtensionCommonRestOperation.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtExtensionResource/MgmtExtensionResource.csproj
+++ b/test/TestProjects/MgmtExtensionResource/MgmtExtensionResource.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtHierarchicalNonResource/MgmtHierarchicalNonResource.csproj
+++ b/test/TestProjects/MgmtHierarchicalNonResource/MgmtHierarchicalNonResource.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtLRO/MgmtLRO.csproj
+++ b/test/TestProjects/MgmtLRO/MgmtLRO.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtListMethods/MgmtListMethods.csproj
+++ b/test/TestProjects/MgmtListMethods/MgmtListMethods.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtMockAndSample/src/MgmtMockAndSample.csproj
+++ b/test/TestProjects/MgmtMockAndSample/src/MgmtMockAndSample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtMockAndSample/tests/MgmtMockAndSample.Tests.csproj
+++ b/test/TestProjects/MgmtMockAndSample/tests/MgmtMockAndSample.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/MgmtMultipleParentResource/MgmtMultipleParentResource.csproj
+++ b/test/TestProjects/MgmtMultipleParentResource/MgmtMultipleParentResource.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtNonStringPathVariable/MgmtNonStringPathVariable.csproj
+++ b/test/TestProjects/MgmtNonStringPathVariable/MgmtNonStringPathVariable.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtOperations/MgmtOperations.csproj
+++ b/test/TestProjects/MgmtOperations/MgmtOperations.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtOptionalConstant/MgmtOptionalConstant.csproj
+++ b/test/TestProjects/MgmtOptionalConstant/MgmtOptionalConstant.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtParamOrdering/MgmtParamOrdering.csproj
+++ b/test/TestProjects/MgmtParamOrdering/MgmtParamOrdering.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtParent/MgmtParent.csproj
+++ b/test/TestProjects/MgmtParent/MgmtParent.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtPropertyChooser/MgmtPropertyChooser.csproj
+++ b/test/TestProjects/MgmtPropertyChooser/MgmtPropertyChooser.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtRenameRules/MgmtRenameRules.csproj
+++ b/test/TestProjects/MgmtRenameRules/MgmtRenameRules.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtResourceName/MgmtResourceName.csproj
+++ b/test/TestProjects/MgmtResourceName/MgmtResourceName.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtSafeFlatten/MgmtSafeFlatten.csproj
+++ b/test/TestProjects/MgmtSafeFlatten/MgmtSafeFlatten.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtScopeResource/MgmtScopeResource.csproj
+++ b/test/TestProjects/MgmtScopeResource/MgmtScopeResource.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MgmtSubscriptionNameParameter/MgmtSubscriptionNameParameter.csproj
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/MgmtSubscriptionNameParameter.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ModelNamespace/ModelNamespace.csproj
+++ b/test/TestProjects/ModelNamespace/ModelNamespace.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ModelShapes/ModelShapes.csproj
+++ b/test/TestProjects/ModelShapes/ModelShapes.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ModelWithConverterUsage/ModelWithConverterUsage.csproj
+++ b/test/TestProjects/ModelWithConverterUsage/ModelWithConverterUsage.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Models-Cadl/Models.csproj
+++ b/test/TestProjects/Models-Cadl/Models.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MultipleInputFiles/MultipleInputFiles.csproj
+++ b/test/TestProjects/MultipleInputFiles/MultipleInputFiles.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/NameConflicts/NameConflicts.csproj
+++ b/test/TestProjects/NameConflicts/NameConflicts.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/NoTypeReplacement/NoTypeReplacement.csproj
+++ b/test/TestProjects/NoTypeReplacement/NoTypeReplacement.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/OmitOperationGroups/OmitOperationGroups.csproj
+++ b/test/TestProjects/OmitOperationGroups/OmitOperationGroups.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Pagination-Cadl/Pagination.csproj
+++ b/test/TestProjects/Pagination-Cadl/Pagination.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Pagination/Pagination.csproj
+++ b/test/TestProjects/Pagination/Pagination.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/PaginationParams-LowLevel/PaginationParams_LowLevel.csproj
+++ b/test/TestProjects/PaginationParams-LowLevel/PaginationParams_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ParameterSequence-LowLevel/ParameterSequence_LowLevel.csproj
+++ b/test/TestProjects/ParameterSequence-LowLevel/ParameterSequence_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Parameters-Cadl/ParametersCadl.csproj
+++ b/test/TestProjects/Parameters-Cadl/ParametersCadl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Parameters-LowLevel/Parameters_LowLevel.csproj
+++ b/test/TestProjects/Parameters-LowLevel/Parameters_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/PetStore-Cadl/PetStore.csproj
+++ b/test/TestProjects/PetStore-Cadl/PetStore.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ProtocolMethodsInRestClient/ProtocolMethodsInRestClient.csproj
+++ b/test/TestProjects/ProtocolMethodsInRestClient/ProtocolMethodsInRestClient.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/PublicClientCtor/PublicClientCtor.csproj
+++ b/test/TestProjects/PublicClientCtor/PublicClientCtor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ReferenceTypes/ReferenceTypes.csproj
+++ b/test/TestProjects/ReferenceTypes/ReferenceTypes.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ResourceClients-LowLevel/ResourceClients_LowLevel.csproj
+++ b/test/TestProjects/ResourceClients-LowLevel/ResourceClients_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ResourceRename/ResourceRename.csproj
+++ b/test/TestProjects/ResourceRename/ResourceRename.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SecurityDefinition-LowLevel/SecurityDefinition_LowLevel.csproj
+++ b/test/TestProjects/SecurityDefinition-LowLevel/SecurityDefinition_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ServiceVersionOverride/ServiceVersionOverride.csproj
+++ b/test/TestProjects/ServiceVersionOverride/ServiceVersionOverride.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SingleTopLevelClientWithOperations-LowLevel/SingleTopLevelClientWithOperations_LowLevel.csproj
+++ b/test/TestProjects/SingleTopLevelClientWithOperations-LowLevel/SingleTopLevelClientWithOperations_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SingleTopLevelClientWithoutOperations-LowLevel/SingleTopLevelClientWithoutOperations_LowLevel.csproj
+++ b/test/TestProjects/SingleTopLevelClientWithoutOperations-LowLevel/SingleTopLevelClientWithoutOperations_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SingletonResource/SingletonResource.csproj
+++ b/test/TestProjects/SingletonResource/SingletonResource.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SubClients-LowLevel/SubClients_LowLevel.csproj
+++ b/test/TestProjects/SubClients-LowLevel/SubClients_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SubscriptionExtensions/SubscriptionExtensions.csproj
+++ b/test/TestProjects/SubscriptionExtensions/SubscriptionExtensions.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SupersetFlattenInheritance/SupersetFlattenInheritance.csproj
+++ b/test/TestProjects/SupersetFlattenInheritance/SupersetFlattenInheritance.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/SupersetInheritance/SupersetInheritance.csproj
+++ b/test/TestProjects/SupersetInheritance/SupersetInheritance.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/TenantOnly/TenantOnly.csproj
+++ b/test/TestProjects/TenantOnly/TenantOnly.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/TypeSchemaMapping/TypeSchemaMapping.csproj
+++ b/test/TestProjects/TypeSchemaMapping/TypeSchemaMapping.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.23.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/XmlDeserialization/XmlDeserialization.csproj
+++ b/test/TestProjects/XmlDeserialization/XmlDeserialization.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/additionalProperties/additionalProperties.csproj
+++ b/test/TestServerProjects/additionalProperties/additionalProperties.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/azure-parameter-grouping/azure_parameter_grouping.csproj
+++ b/test/TestServerProjects/azure-parameter-grouping/azure_parameter_grouping.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/azure-special-properties/azure_special_properties.csproj
+++ b/test/TestServerProjects/azure-special-properties/azure_special_properties.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-array/body_array.csproj
+++ b/test/TestServerProjects/body-array/body_array.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-boolean/body_boolean.csproj
+++ b/test/TestServerProjects/body-boolean/body_boolean.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-byte/body_byte.csproj
+++ b/test/TestServerProjects/body-byte/body_byte.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-complex/body_complex.csproj
+++ b/test/TestServerProjects/body-complex/body_complex.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-date/body_date.csproj
+++ b/test/TestServerProjects/body-date/body_date.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-datetime-rfc1123/body_datetime_rfc1123.csproj
+++ b/test/TestServerProjects/body-datetime-rfc1123/body_datetime_rfc1123.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-datetime/body_datetime.csproj
+++ b/test/TestServerProjects/body-datetime/body_datetime.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-dictionary/body_dictionary.csproj
+++ b/test/TestServerProjects/body-dictionary/body_dictionary.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-duration/body_duration.csproj
+++ b/test/TestServerProjects/body-duration/body_duration.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-file/body_file.csproj
+++ b/test/TestServerProjects/body-file/body_file.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-formdata-urlencoded/body_formdata_urlencoded.csproj
+++ b/test/TestServerProjects/body-formdata-urlencoded/body_formdata_urlencoded.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-formdata/body_formdata.csproj
+++ b/test/TestServerProjects/body-formdata/body_formdata.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-integer/body_integer.csproj
+++ b/test/TestServerProjects/body-integer/body_integer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-number/body_number.csproj
+++ b/test/TestServerProjects/body-number/body_number.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-string/body_string.csproj
+++ b/test/TestServerProjects/body-string/body_string.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/body-time/body_time.csproj
+++ b/test/TestServerProjects/body-time/body_time.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/constants/constants.csproj
+++ b/test/TestServerProjects/constants/constants.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/custom-baseUrl-more-options/custom_baseUrl_more_options.csproj
+++ b/test/TestServerProjects/custom-baseUrl-more-options/custom_baseUrl_more_options.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/custom-baseUrl-paging/custom_baseUrl_paging.csproj
+++ b/test/TestServerProjects/custom-baseUrl-paging/custom_baseUrl_paging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/custom-baseUrl/custom_baseUrl.csproj
+++ b/test/TestServerProjects/custom-baseUrl/custom_baseUrl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/extensible-enums-swagger/extensible_enums_swagger.csproj
+++ b/test/TestServerProjects/extensible-enums-swagger/extensible_enums_swagger.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/head/head.csproj
+++ b/test/TestServerProjects/head/head.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/header/header.csproj
+++ b/test/TestServerProjects/header/header.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/httpInfrastructure/httpInfrastructure.csproj
+++ b/test/TestServerProjects/httpInfrastructure/httpInfrastructure.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/lro-parameterized-endpoints/lro_parameterized_endpoints.csproj
+++ b/test/TestServerProjects/lro-parameterized-endpoints/lro_parameterized_endpoints.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/lro/lro.csproj
+++ b/test/TestServerProjects/lro/lro.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/media_types/media_types.csproj
+++ b/test/TestServerProjects/media_types/media_types.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/model-flattening/model_flattening.csproj
+++ b/test/TestServerProjects/model-flattening/model_flattening.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/multiple-inheritance/multiple_inheritance.csproj
+++ b/test/TestServerProjects/multiple-inheritance/multiple_inheritance.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/non-string-enum/non_string_enum.csproj
+++ b/test/TestServerProjects/non-string-enum/non_string_enum.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/object-type/object_type.csproj
+++ b/test/TestServerProjects/object-type/object_type.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/paging/paging.csproj
+++ b/test/TestServerProjects/paging/paging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/required-optional/required_optional.csproj
+++ b/test/TestServerProjects/required-optional/required_optional.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/subscriptionId-apiVersion/subscriptionId_apiVersion.csproj
+++ b/test/TestServerProjects/subscriptionId-apiVersion/subscriptionId_apiVersion.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/url-multi-collectionFormat/url_multi_collectionFormat.csproj
+++ b/test/TestServerProjects/url-multi-collectionFormat/url_multi_collectionFormat.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/url/url.csproj
+++ b/test/TestServerProjects/url/url.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/validation/validation.csproj
+++ b/test/TestServerProjects/validation/validation.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/xml-service/xml_service.csproj
+++ b/test/TestServerProjects/xml-service/xml_service.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjects/xms-error-responses/xms_error_responses.csproj
+++ b/test/TestServerProjects/xms-error-responses/xms_error_responses.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/body-array/body_array_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/body-array/body_array_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/body-complex/body_complex_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/body-complex/body_complex_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/body-file/body_file_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/body-file/body_file_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/body-string/body_string_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/body-string/body_string_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/custom-baseUrl-more-options/custom_baseUrl_more_options_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/custom-baseUrl-more-options/custom_baseUrl_more_options_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/custom-baseUrl-paging/custom_baseUrl_paging_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/custom-baseUrl-paging/custom_baseUrl_paging_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/custom-baseUrl/custom_baseUrl_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/custom-baseUrl/custom_baseUrl_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/dpg-customization/dpg_customization_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/dpg-customization/dpg_customization_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/dpg-initial/dpg_initial_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/dpg-initial/dpg_initial_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/dpg-update1/dpg_update1_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/dpg-update1/dpg_update1_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/head/head_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/head/head_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/header/header_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/header/header_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/httpInfrastructure/httpInfrastructure_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/httpInfrastructure/httpInfrastructure_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/lro/lro_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/lro/lro_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/media_types/media_types_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/media_types/media_types_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/paging/paging_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/paging/paging_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/security-aad/security_aad_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/security-aad/security_aad_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/security-key/security_key_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/security-key/security_key_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/url-multi-collectionFormat/url_multi_collectionFormat_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/url-multi-collectionFormat/url_multi_collectionFormat_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestServerProjectsLowLevel/url/url_LowLevel.csproj
+++ b/test/TestServerProjectsLowLevel/url/url_LowLevel.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
RawRequestUriBuilder is updated to use new properties and methods available in `RequestUriBuilder` in 1.26 to minimize string allocations.