### PR TITLE
fix(cadl): emitter cannot run in .net framework > 3.1

### DIFF
--- a/eng/Generation.psm1
+++ b/eng/Generation.psm1
@@ -72,7 +72,7 @@ function Invoke-Cadl($baseOutput, $projectName, $mainFile, $arguments="", $share
         $repoRootPath = Join-Path $PSScriptRoot ".."
         $repoRootPath = Resolve-Path -Path $repoRootPath
         Push-Location $repoRootPath
-        $autorestCsharpBinPath = Join-Path $repoRootPath "artifacts/bin/AutoRest.CSharp/Debug/netcoreapp3.1/autorest.csharp.dll"
+        $autorestCsharpBinPath = Join-Path $repoRootPath "artifacts/bin/AutoRest.CSharp/Debug/netcoreapp3.1/AutoRest.CSharp.dll"
         Try
         {
             $cadlFileName = $mainFile ? $mainFile : "$baseOutput/$projectName.cadl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@autorest/csharp": {
-      "version": "3.0.0-beta.20221124.1",
-      "resolved": "https://registry.npmjs.org/@autorest/csharp/-/csharp-3.0.0-beta.20221124.1.tgz",
-      "integrity": "sha512-HDGu24Zqyr9iRlEvgv3h8rCEOvCYhAimDoPvyzvfgpYbpBhFcVC4iHcAxZLO15TNrlvtl9XLV/HqbGuFlP4cFw==",
+      "version": "3.0.0-beta.20221125.1",
+      "resolved": "https://registry.npmjs.org/@autorest/csharp/-/csharp-3.0.0-beta.20221125.1.tgz",
+      "integrity": "sha512-ub60digj3qg3jIoY5uPBB2W+GFMwU0qwvAupBrRgKzKGgfW2uDJWUVJM6lymPTQuXQ6uW5LdgWj7MAwJN4K4yw==",
       "dev": true
     },
     "node_modules/@azure-tools/cadl-autorest": {
@@ -12055,11 +12055,11 @@
     },
     "src/CADL.Extension/Emitter.Csharp": {
       "name": "@azure-tools/cadl-csharp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@autorest/csharp": "3.0.0-beta.20221124.1",
+        "@autorest/csharp": "3.0.0-beta.20221125.1",
         "@azure-tools/cadl-autorest": "0.22.0",
         "@azure-tools/cadl-azure-core": "0.9.0",
         "@azure-tools/cadl-dpg": "0.3.0",
@@ -12100,9 +12100,9 @@
       }
     },
     "@autorest/csharp": {
-      "version": "3.0.0-beta.20221124.1",
-      "resolved": "https://registry.npmjs.org/@autorest/csharp/-/csharp-3.0.0-beta.20221124.1.tgz",
-      "integrity": "sha512-HDGu24Zqyr9iRlEvgv3h8rCEOvCYhAimDoPvyzvfgpYbpBhFcVC4iHcAxZLO15TNrlvtl9XLV/HqbGuFlP4cFw==",
+      "version": "3.0.0-beta.20221125.1",
+      "resolved": "https://registry.npmjs.org/@autorest/csharp/-/csharp-3.0.0-beta.20221125.1.tgz",
+      "integrity": "sha512-ub60digj3qg3jIoY5uPBB2W+GFMwU0qwvAupBrRgKzKGgfW2uDJWUVJM6lymPTQuXQ6uW5LdgWj7MAwJN4K4yw==",
       "dev": true
     },
     "@azure-tools/cadl-autorest": {
@@ -12124,7 +12124,7 @@
     "@azure-tools/cadl-csharp": {
       "version": "file:src/CADL.Extension/Emitter.Csharp",
       "requires": {
-        "@autorest/csharp": "3.0.0-beta.20221124.1",
+        "@autorest/csharp": "3.0.0-beta.20221125.1",
         "@azure-tools/cadl-autorest": "0.22.0",
         "@azure-tools/cadl-azure-core": "0.9.0",
         "@azure-tools/cadl-dpg": "0.3.0",

--- a/src/CADL.Extension/Emitter.Csharp/package.json
+++ b/src/CADL.Extension/Emitter.Csharp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure-tools/cadl-csharp",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "author": "Microsoft Corporation",
     "description": "Cadl library for emitting csharp model from the Cadl REST protocol binding",
     "homepage": "https://github.com/Microsoft/cadl",
@@ -47,7 +47,7 @@
         "typescript": "~4.7.2"
     },
     "dependencies": {
-        "@autorest/csharp": "3.0.0-beta.20221124.1",
+        "@autorest/csharp": "3.0.0-beta.20221125.1",
         "@azure-tools/cadl-autorest": "0.22.0",
         "@azure-tools/cadl-azure-core": "0.9.0",
         "@azure-tools/cadl-dpg": "0.3.0",

--- a/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/CADL.Extension/Emitter.Csharp/src/emitter.ts
@@ -238,7 +238,7 @@ export async function $onEmit(
                 const newProjectOption = options["new-project"]
                     ? "--new-project"
                     : "";
-                const command = `dotnet ${resolvePath(
+                const command = `dotnet --roll-forward Major ${resolvePath(
                     options.csharpGeneratorPath
                 )} --project-path ${outputFolder} ${newProjectOption}`;
                 console.info(command);
@@ -249,6 +249,8 @@ export async function $onEmit(
                     if (error.message) console.log(error.message);
                     if (error.stderr) console.error(error.stderr);
                     if (error.stdout) console.log(error.stdout);
+
+                    throw error;
                 }
             }
 


### PR DESCRIPTION
- add `--roll-forward Major` when invoke `autorest.csharp`, so that the dll can be run under forward compatible .net framework
- throw error when invoke `autorest.csharp` fails, so that the error can be caught up by the cadl compiler
- fix case issue of `AutoRest.CSharp.dll` under linux environment

fix #2892

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first