### PR TITLE
Fix #2880: When Client parameter Type is enum or model, codegen throw exception

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Shared/Parameter.cs
@@ -25,6 +25,9 @@ namespace AutoRest.CSharp.Output.Models.Shared
             return new Parameter(name, property.Description, propertyType, null, validation, null);
         }
 
+        public static Parameter FromInputParameter(in InputParameter inputParameter, TypeFactory typeFactory)
+            => FromInputParameter(inputParameter, typeFactory.CreateType(inputParameter.Type), typeFactory);
+
         public static Parameter FromInputParameter(in InputParameter operationParameter, CSharpType type, TypeFactory typeFactory)
         {
             var name = operationParameter.Name.ToVariableName();


### PR DESCRIPTION
The root cause of the problem was that `OperationMethodChainBuilder.BuildParameters` has been consolidating multiple types of parameters and then try to resolve them, resolving cases that are either impossible or not supported, e.g.:
- `ContentType` parameters can only be method parameters and only when there is more than one supported content type
- Parameter type for request conditions is always known upfront
- Constant parameter should always have a `DefaultValue` specified
- Generation of protocol or convenience method parameters for client fields is not needed

And so on. Handling of all these cases is now split, and for some conditions exceptions are thrown to avoid generation of incorrect code.

Fix doesn't contain the test because `cadl compile` for the example from https://github.com/Azure/autorest.csharp/issues/2880 shows the following error:
```
C:/GitHub/autorest.csharp/test/TestProjects/Parameters-Cadl/Parameters-Cadl.cadl:10:2 - error unknown-identifier: Unknown identifier versioned
> 10 | @versioned(Versions)
     |  ^^^^^^^^^
C:/GitHub/autorest.csharp/test/TestProjects/Parameters-Cadl/Parameters-Cadl.cadl:10:1 - error unknown-decorator: Unknown decorator
> 10 | @versioned(Versions)
     | ^^^^^^^^^^^^^^^^^^^^
```

No changes in existing generated code