### PR TITLE
Update RawRequestUriBuilder + bump azure core version in test projects

### DIFF
--- a/src/assets/Generator.Shared/RawRequestUriBuilder.cs
+++ b/src/assets/Generator.Shared/RawRequestUriBuilder.cs
@@ -45,11 +45,11 @@ namespace Azure.Core
         {
             if (_position == null)
             {
-                if (!string.IsNullOrEmpty(Query))
+                if (HasQuery)
                 {
                     _position = RawWritingPosition.Query;
                 }
-                else if (!string.IsNullOrEmpty(Path))
+                else if (HasPath)
                 {
                     _position = RawWritingPosition.Path;
                 }
@@ -87,7 +87,7 @@ namespace Azure.Core
                     int separator = value.IndexOfAny(HostOrPort);
                     if (separator == -1)
                     {
-                        if (string.IsNullOrEmpty(Path))
+                        if (!HasPath)
                         {
                             Host += value.ToString();
                             value = ReadOnlySpan<char>.Empty;
@@ -135,12 +135,12 @@ namespace Azure.Core
                     int separator = value.IndexOf(QueryBeginSeparator);
                     if (separator == -1)
                     {
-                        AppendPath(value.ToString(), escape);
+                        AppendPath(value, escape);
                         value = ReadOnlySpan<char>.Empty;
                     }
                     else
                     {
-                        AppendPath(value.Slice(0, separator).ToString(), escape);
+                        AppendPath(value.Slice(0, separator), escape);
                         value = value.Slice(separator + 1);
                         _position = RawWritingPosition.Query;
                     }
@@ -155,13 +155,13 @@ namespace Azure.Core
                     else if (separator == -1)
                     {
                         GetQueryParts(value, out var queryName, out var queryValue);
-                        AppendQuery(queryName.ToString(), queryValue.ToString(), escape);
+                        AppendQuery(queryName, queryValue, escape);
                         value = ReadOnlySpan<char>.Empty;
                     }
                     else
                     {
                         GetQueryParts(value.Slice(0, separator), out var queryName, out var queryValue);
-                        AppendQuery(queryName.ToString(), queryValue.ToString(), escape);
+                        AppendQuery(queryName, queryValue, escape);
                         value = value.Slice(separator + 1);
                     }
                 }

--- a/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
+++ b/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
 
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/test/CadlRanchProjects/api-key/ApiKey.csproj
+++ b/test/CadlRanchProjects/api-key/ApiKey.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/extensible-enums/ExtensibleEnum.csproj
+++ b/test/CadlRanchProjects/extensible-enums/ExtensibleEnum.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/inheritance/Inheritance.csproj
+++ b/test/CadlRanchProjects/inheritance/Inheritance.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/oauth2/OAuth2.csproj
+++ b/test/CadlRanchProjects/oauth2/OAuth2.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/property-optional/PropertyOptional.csproj
+++ b/test/CadlRanchProjects/property-optional/PropertyOptional.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/CadlRanchProjects/property-types/PropertyTypes.csproj
+++ b/test/CadlRanchProjects/property-types/PropertyTypes.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ApiVersion-Cadl/ApiVersion.csproj
+++ b/test/TestProjects/ApiVersion-Cadl/ApiVersion.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Authoring-Cadl/Authoring-Cadl.csproj
+++ b/test/TestProjects/Authoring-Cadl/Authoring-Cadl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/ClientAndOperationGroup-Cadl/ClientAndOperationGroup.csproj
+++ b/test/TestProjects/ClientAndOperationGroup-Cadl/ClientAndOperationGroup.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Customizations-Cadl/Customizations.csproj
+++ b/test/TestProjects/Customizations-Cadl/Customizations.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/FirstTest-Cadl/FirstTest.csproj
+++ b/test/TestProjects/FirstTest-Cadl/FirstTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Lro-Basic-Cadl/LroBasicCadl.csproj
+++ b/test/TestProjects/Lro-Basic-Cadl/LroBasicCadl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/MixAPIVersion-Cadl/MixAPIVersion.csproj
+++ b/test/TestProjects/MixAPIVersion-Cadl/MixAPIVersion.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Models-Cadl/Models.csproj
+++ b/test/TestProjects/Models-Cadl/Models.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Pagination-Cadl/Pagination.csproj
+++ b/test/TestProjects/Pagination-Cadl/Pagination.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/Parameters-Cadl/ParametersCadl.csproj
+++ b/test/TestProjects/Parameters-Cadl/ParametersCadl.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/PetStore-Cadl/PetStore.csproj
+++ b/test/TestProjects/PetStore-Cadl/PetStore.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/TypeSchemaMapping/TypeSchemaMapping.csproj
+++ b/test/TestProjects/TypeSchemaMapping/TypeSchemaMapping.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.23.0" />
+    <PackageReference Include="Azure.Core" Version="1.26.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
With updated Azure.Core, `RawRequestUriBuilder` can avoid creating strings while parsing URI