### PR TITLE
fix(dpg): lro sample should use `WaitUntil.Started`

### DIFF
--- a/samples/Azure.AI.DocumentTranslation/Generated/Docs/DocumentTranslationClient.xml
+++ b/samples/Azure.AI.DocumentTranslation/Generated/Docs/DocumentTranslationClient.xml
@@ -1119,7 +1119,7 @@ var data = new {
     },
 };
 
-var operation = await client.StartTranslationAsync(WaitUntil.Completed, RequestContent.Create(data), ContentType.ApplicationOctetStream);
+var operation = await client.StartTranslationAsync(WaitUntil.Started, RequestContent.Create(data), ContentType.ApplicationOctetStream);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1223,7 +1223,7 @@ var data = new {
     },
 };
 
-var operation = client.StartTranslation(WaitUntil.Completed, RequestContent.Create(data), ContentType.ApplicationOctetStream);
+var operation = client.StartTranslation(WaitUntil.Started, RequestContent.Create(data), ContentType.ApplicationOctetStream);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)

--- a/src/AutoRest.CSharp/LowLevel/Generation/LowLevelExampleComposer.cs
+++ b/src/AutoRest.CSharp/LowLevel/Generation/LowLevelExampleComposer.cs
@@ -566,6 +566,12 @@ namespace AutoRest.CSharp.Generation.Writers
                     return "Guid.NewGuid()";
                 }
 
+                if (type == typeof(WaitUntil))
+                {
+                    // use `Started`, since we will generate `operation.WaitForCompletion()` afterwards
+                    return $"{nameof(WaitUntil)}.{nameof(WaitUntil.Started)}";
+                }
+
                 if (type.IsEnum)
                 {
                     return $"{type.Name}.{Enum.GetNames(type)[0]}";

--- a/test/TestProjects/Lro-Basic-Cadl/Generated/Docs/LroBasicCadlClient.xml
+++ b/test/TestProjects/Lro-Basic-Cadl/Generated/Docs/LroBasicCadlClient.xml
@@ -10,7 +10,7 @@ var client = new LroBasicCadlClient(endpoint);
 
 var data = new {};
 
-var operation = await client.CreateProjectAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.CreateProjectAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -25,7 +25,7 @@ var data = new {
     name = "<name>",
 };
 
-var operation = await client.CreateProjectAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.CreateProjectAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -55,7 +55,7 @@ var client = new LroBasicCadlClient(endpoint);
 
 var data = new {};
 
-var operation = client.CreateProject(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.CreateProject(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -70,7 +70,7 @@ var data = new {
     name = "<name>",
 };
 
-var operation = client.CreateProject(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.CreateProject(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -100,7 +100,7 @@ var client = new LroBasicCadlClient(endpoint);
 
 var data = new {};
 
-var operation = await client.UpdateProjectAsync(WaitUntil.Completed, "<id>", RequestContent.Create(data));
+var operation = await client.UpdateProjectAsync(WaitUntil.Started, "<id>", RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -116,7 +116,7 @@ var data = new {
     name = "<name>",
 };
 
-var operation = await client.UpdateProjectAsync(WaitUntil.Completed, "<id>", RequestContent.Create(data));
+var operation = await client.UpdateProjectAsync(WaitUntil.Started, "<id>", RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -159,7 +159,7 @@ var client = new LroBasicCadlClient(endpoint);
 
 var data = new {};
 
-var operation = client.UpdateProject(WaitUntil.Completed, "<id>", RequestContent.Create(data));
+var operation = client.UpdateProject(WaitUntil.Started, "<id>", RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -175,7 +175,7 @@ var data = new {
     name = "<name>",
 };
 
-var operation = client.UpdateProject(WaitUntil.Completed, "<id>", RequestContent.Create(data));
+var operation = client.UpdateProject(WaitUntil.Started, "<id>", RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;

--- a/test/TestServerProjectsLowLevel/dpg-customization/Generated/Docs/DPGClient.xml
+++ b/test/TestServerProjectsLowLevel/dpg-customization/Generated/Docs/DPGClient.xml
@@ -198,7 +198,7 @@ This sample shows how to call LroAsync with required parameters and parse the re
 var credential = new AzureKeyCredential("<key>");
 var client = new DPGClient(credential);
 
-var operation = await client.LroAsync(WaitUntil.Completed, "<mode>");
+var operation = await client.LroAsync(WaitUntil.Started, "<mode>");
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -227,7 +227,7 @@ This sample shows how to call Lro with required parameters and parse the result.
 var credential = new AzureKeyCredential("<key>");
 var client = new DPGClient(credential);
 
-var operation = client.Lro(WaitUntil.Completed, "<mode>");
+var operation = client.Lro(WaitUntil.Started, "<mode>");
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;

--- a/test/TestServerProjectsLowLevel/lro/Generated/Docs/LRORetrysClient.xml
+++ b/test/TestServerProjectsLowLevel/lro/Generated/Docs/LRORetrysClient.xml
@@ -10,7 +10,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -31,7 +31,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -90,7 +90,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = client.Put201CreatingSucceeded200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingSucceeded200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -111,7 +111,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put201CreatingSucceeded200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingSucceeded200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -170,7 +170,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRelativeRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -191,7 +191,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRelativeRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -250,7 +250,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRelativeRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -271,7 +271,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRelativeRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -328,7 +328,7 @@ This sample shows how to call DeleteProvisioning202Accepted200SucceededAsync wit
 var credential = new AzureKeyCredential("<key>");
 var client = new LRORetrysClient(credential);
 
-var operation = await client.DeleteProvisioning202Accepted200SucceededAsync(WaitUntil.Completed);
+var operation = await client.DeleteProvisioning202Accepted200SucceededAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -369,7 +369,7 @@ This sample shows how to call DeleteProvisioning202Accepted200Succeeded with req
 var credential = new AzureKeyCredential("<key>");
 var client = new LRORetrysClient(credential);
 
-var operation = client.DeleteProvisioning202Accepted200Succeeded(WaitUntil.Completed);
+var operation = client.DeleteProvisioning202Accepted200Succeeded(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -410,7 +410,7 @@ This sample shows how to call Delete202Retry200Async with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LRORetrysClient(credential);
 
-var operation = await client.Delete202Retry200Async(WaitUntil.Completed);
+var operation = await client.Delete202Retry200Async(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -424,7 +424,7 @@ This sample shows how to call Delete202Retry200 with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LRORetrysClient(credential);
 
-var operation = client.Delete202Retry200(WaitUntil.Completed);
+var operation = client.Delete202Retry200(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -438,7 +438,7 @@ This sample shows how to call DeleteAsyncRelativeRetrySucceededAsync with requir
 var credential = new AzureKeyCredential("<key>");
 var client = new LRORetrysClient(credential);
 
-var operation = await client.DeleteAsyncRelativeRetrySucceededAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRelativeRetrySucceededAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -452,7 +452,7 @@ This sample shows how to call DeleteAsyncRelativeRetrySucceeded with required pa
 var credential = new AzureKeyCredential("<key>");
 var client = new LRORetrysClient(credential);
 
-var operation = client.DeleteAsyncRelativeRetrySucceeded(WaitUntil.Completed);
+var operation = client.DeleteAsyncRelativeRetrySucceeded(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -468,7 +468,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -488,7 +488,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -524,7 +524,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = client.Post202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -544,7 +544,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -580,7 +580,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRelativeRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -600,7 +600,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRelativeRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -636,7 +636,7 @@ var client = new LRORetrysClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRelativeRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -656,7 +656,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRelativeRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)

--- a/test/TestServerProjectsLowLevel/lro/Generated/Docs/LROsClient.xml
+++ b/test/TestServerProjectsLowLevel/lro/Generated/Docs/LROsClient.xml
@@ -10,7 +10,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put200SucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200SucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -31,7 +31,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put200SucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200SucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -90,7 +90,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put200Succeeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200Succeeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -111,7 +111,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put200Succeeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200Succeeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -170,7 +170,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Patch200SucceededIgnoreHeadersAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Patch200SucceededIgnoreHeadersAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -191,7 +191,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Patch200SucceededIgnoreHeadersAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Patch200SucceededIgnoreHeadersAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -250,7 +250,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Patch200SucceededIgnoreHeaders(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Patch200SucceededIgnoreHeaders(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -271,7 +271,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Patch200SucceededIgnoreHeaders(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Patch200SucceededIgnoreHeaders(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -330,7 +330,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Patch201RetryWithAsyncHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Patch201RetryWithAsyncHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -351,7 +351,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Patch201RetryWithAsyncHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Patch201RetryWithAsyncHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -410,7 +410,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Patch201RetryWithAsyncHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Patch201RetryWithAsyncHeader(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -431,7 +431,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Patch201RetryWithAsyncHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Patch201RetryWithAsyncHeader(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -490,7 +490,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Patch202RetryWithAsyncAndLocationHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Patch202RetryWithAsyncAndLocationHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -511,7 +511,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Patch202RetryWithAsyncAndLocationHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Patch202RetryWithAsyncAndLocationHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -570,7 +570,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Patch202RetryWithAsyncAndLocationHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Patch202RetryWithAsyncAndLocationHeader(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -591,7 +591,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Patch202RetryWithAsyncAndLocationHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Patch202RetryWithAsyncAndLocationHeader(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -650,7 +650,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put201SucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201SucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -671,7 +671,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put201SucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201SucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -730,7 +730,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put201Succeeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201Succeeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -751,7 +751,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put201Succeeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201Succeeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -808,7 +808,7 @@ This sample shows how to call Post202ListAsync with required parameters and pars
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.Post202ListAsync(WaitUntil.Completed);
+var operation = await client.Post202ListAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -849,7 +849,7 @@ This sample shows how to call Post202List with required parameters and parse the
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.Post202List(WaitUntil.Completed);
+var operation = client.Post202List(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -892,7 +892,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put200SucceededNoStateAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200SucceededNoStateAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -913,7 +913,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put200SucceededNoStateAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200SucceededNoStateAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -972,7 +972,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put200SucceededNoState(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200SucceededNoState(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -993,7 +993,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put200SucceededNoState(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200SucceededNoState(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1052,7 +1052,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1073,7 +1073,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1132,7 +1132,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1153,7 +1153,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1212,7 +1212,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1233,7 +1233,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1292,7 +1292,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put201CreatingSucceeded200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingSucceeded200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1313,7 +1313,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put201CreatingSucceeded200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingSucceeded200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1372,7 +1372,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put200UpdatingSucceeded204Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200UpdatingSucceeded204Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1393,7 +1393,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put200UpdatingSucceeded204Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200UpdatingSucceeded204Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1452,7 +1452,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put200UpdatingSucceeded204(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200UpdatingSucceeded204(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1473,7 +1473,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put200UpdatingSucceeded204(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200UpdatingSucceeded204(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1532,7 +1532,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put201CreatingFailed200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingFailed200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1553,7 +1553,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put201CreatingFailed200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingFailed200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1612,7 +1612,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put201CreatingFailed200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingFailed200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1633,7 +1633,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put201CreatingFailed200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingFailed200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1692,7 +1692,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put200Acceptedcanceled200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200Acceptedcanceled200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1713,7 +1713,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put200Acceptedcanceled200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200Acceptedcanceled200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1772,7 +1772,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Put200Acceptedcanceled200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200Acceptedcanceled200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1793,7 +1793,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put200Acceptedcanceled200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200Acceptedcanceled200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1852,7 +1852,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutNoHeaderInRetryAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNoHeaderInRetryAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1873,7 +1873,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutNoHeaderInRetryAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNoHeaderInRetryAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1932,7 +1932,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutNoHeaderInRetry(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNoHeaderInRetry(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1953,7 +1953,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutNoHeaderInRetry(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNoHeaderInRetry(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2012,7 +2012,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2033,7 +2033,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2092,7 +2092,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2113,7 +2113,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2172,7 +2172,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncNoRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNoRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2193,7 +2193,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncNoRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNoRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2252,7 +2252,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncNoRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNoRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2273,7 +2273,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncNoRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNoRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2332,7 +2332,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRetryFailedAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRetryFailedAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2353,7 +2353,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRetryFailedAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRetryFailedAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2412,7 +2412,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRetryFailed(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRetryFailed(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2433,7 +2433,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRetryFailed(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRetryFailed(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2492,7 +2492,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncNoRetrycanceledAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNoRetrycanceledAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2513,7 +2513,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncNoRetrycanceledAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNoRetrycanceledAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2572,7 +2572,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncNoRetrycanceled(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNoRetrycanceled(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2593,7 +2593,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncNoRetrycanceled(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNoRetrycanceled(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2652,7 +2652,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncNoHeaderInRetryAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNoHeaderInRetryAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2673,7 +2673,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncNoHeaderInRetryAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNoHeaderInRetryAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2732,7 +2732,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncNoHeaderInRetry(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNoHeaderInRetry(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2753,7 +2753,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncNoHeaderInRetry(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNoHeaderInRetry(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2812,7 +2812,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutNonResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2828,7 +2828,7 @@ var data = new {
     id = "<id>",
 };
 
-var operation = await client.PutNonResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2868,7 +2868,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutNonResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2884,7 +2884,7 @@ var data = new {
     id = "<id>",
 };
 
-var operation = client.PutNonResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2924,7 +2924,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncNonResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNonResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2940,7 +2940,7 @@ var data = new {
     id = "<id>",
 };
 
-var operation = await client.PutAsyncNonResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncNonResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2980,7 +2980,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncNonResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNonResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2996,7 +2996,7 @@ var data = new {
     id = "<id>",
 };
 
-var operation = client.PutAsyncNonResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncNonResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3036,7 +3036,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutSubResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutSubResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3053,7 +3053,7 @@ var data = new {
     },
 };
 
-var operation = await client.PutSubResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutSubResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3100,7 +3100,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutSubResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutSubResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3117,7 +3117,7 @@ var data = new {
     },
 };
 
-var operation = client.PutSubResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutSubResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3164,7 +3164,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncSubResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncSubResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3181,7 +3181,7 @@ var data = new {
     },
 };
 
-var operation = await client.PutAsyncSubResourceAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncSubResourceAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3228,7 +3228,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncSubResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncSubResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3245,7 +3245,7 @@ var data = new {
     },
 };
 
-var operation = client.PutAsyncSubResource(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncSubResource(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3290,7 +3290,7 @@ This sample shows how to call DeleteProvisioning202Accepted200SucceededAsync wit
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteProvisioning202Accepted200SucceededAsync(WaitUntil.Completed);
+var operation = await client.DeleteProvisioning202Accepted200SucceededAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3331,7 +3331,7 @@ This sample shows how to call DeleteProvisioning202Accepted200Succeeded with req
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteProvisioning202Accepted200Succeeded(WaitUntil.Completed);
+var operation = client.DeleteProvisioning202Accepted200Succeeded(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3372,7 +3372,7 @@ This sample shows how to call DeleteProvisioning202DeletingFailed200Async with r
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteProvisioning202DeletingFailed200Async(WaitUntil.Completed);
+var operation = await client.DeleteProvisioning202DeletingFailed200Async(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3413,7 +3413,7 @@ This sample shows how to call DeleteProvisioning202DeletingFailed200 with requir
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteProvisioning202DeletingFailed200(WaitUntil.Completed);
+var operation = client.DeleteProvisioning202DeletingFailed200(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3454,7 +3454,7 @@ This sample shows how to call DeleteProvisioning202Deletingcanceled200Async with
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteProvisioning202Deletingcanceled200Async(WaitUntil.Completed);
+var operation = await client.DeleteProvisioning202Deletingcanceled200Async(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3495,7 +3495,7 @@ This sample shows how to call DeleteProvisioning202Deletingcanceled200 with requ
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteProvisioning202Deletingcanceled200(WaitUntil.Completed);
+var operation = client.DeleteProvisioning202Deletingcanceled200(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3536,7 +3536,7 @@ This sample shows how to call Delete204SucceededAsync with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.Delete204SucceededAsync(WaitUntil.Completed);
+var operation = await client.Delete204SucceededAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3550,7 +3550,7 @@ This sample shows how to call Delete204Succeeded with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.Delete204Succeeded(WaitUntil.Completed);
+var operation = client.Delete204Succeeded(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3564,7 +3564,7 @@ This sample shows how to call Delete202Retry200Async with required parameters an
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.Delete202Retry200Async(WaitUntil.Completed);
+var operation = await client.Delete202Retry200Async(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3605,7 +3605,7 @@ This sample shows how to call Delete202Retry200 with required parameters and par
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.Delete202Retry200(WaitUntil.Completed);
+var operation = client.Delete202Retry200(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3646,7 +3646,7 @@ This sample shows how to call Delete202NoRetry204Async with required parameters 
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.Delete202NoRetry204Async(WaitUntil.Completed);
+var operation = await client.Delete202NoRetry204Async(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3687,7 +3687,7 @@ This sample shows how to call Delete202NoRetry204 with required parameters and p
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.Delete202NoRetry204(WaitUntil.Completed);
+var operation = client.Delete202NoRetry204(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3728,7 +3728,7 @@ This sample shows how to call DeleteNoHeaderInRetryAsync with required parameter
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteNoHeaderInRetryAsync(WaitUntil.Completed);
+var operation = await client.DeleteNoHeaderInRetryAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3742,7 +3742,7 @@ This sample shows how to call DeleteNoHeaderInRetry with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteNoHeaderInRetry(WaitUntil.Completed);
+var operation = client.DeleteNoHeaderInRetry(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3756,7 +3756,7 @@ This sample shows how to call DeleteAsyncNoHeaderInRetryAsync with required para
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteAsyncNoHeaderInRetryAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncNoHeaderInRetryAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3770,7 +3770,7 @@ This sample shows how to call DeleteAsyncNoHeaderInRetry with required parameter
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteAsyncNoHeaderInRetry(WaitUntil.Completed);
+var operation = client.DeleteAsyncNoHeaderInRetry(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3784,7 +3784,7 @@ This sample shows how to call DeleteAsyncRetrySucceededAsync with required param
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteAsyncRetrySucceededAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRetrySucceededAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3798,7 +3798,7 @@ This sample shows how to call DeleteAsyncRetrySucceeded with required parameters
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteAsyncRetrySucceeded(WaitUntil.Completed);
+var operation = client.DeleteAsyncRetrySucceeded(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3812,7 +3812,7 @@ This sample shows how to call DeleteAsyncNoRetrySucceededAsync with required par
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteAsyncNoRetrySucceededAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncNoRetrySucceededAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3826,7 +3826,7 @@ This sample shows how to call DeleteAsyncNoRetrySucceeded with required paramete
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteAsyncNoRetrySucceeded(WaitUntil.Completed);
+var operation = client.DeleteAsyncNoRetrySucceeded(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3840,7 +3840,7 @@ This sample shows how to call DeleteAsyncRetryFailedAsync with required paramete
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteAsyncRetryFailedAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRetryFailedAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3854,7 +3854,7 @@ This sample shows how to call DeleteAsyncRetryFailed with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteAsyncRetryFailed(WaitUntil.Completed);
+var operation = client.DeleteAsyncRetryFailed(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3868,7 +3868,7 @@ This sample shows how to call DeleteAsyncRetrycanceledAsync with required parame
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.DeleteAsyncRetrycanceledAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRetrycanceledAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3882,7 +3882,7 @@ This sample shows how to call DeleteAsyncRetrycanceled with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.DeleteAsyncRetrycanceled(WaitUntil.Completed);
+var operation = client.DeleteAsyncRetrycanceled(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -3896,7 +3896,7 @@ This sample shows how to call Post200WithPayloadAsync with required parameters a
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.Post200WithPayloadAsync(WaitUntil.Completed);
+var operation = await client.Post200WithPayloadAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3925,7 +3925,7 @@ This sample shows how to call Post200WithPayload with required parameters and pa
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.Post200WithPayload(WaitUntil.Completed);
+var operation = client.Post200WithPayload(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -3956,7 +3956,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -3976,7 +3976,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -4012,7 +4012,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Post202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -4032,7 +4032,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -4068,7 +4068,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202NoRetry204Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202NoRetry204Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4089,7 +4089,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202NoRetry204Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202NoRetry204Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4148,7 +4148,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.Post202NoRetry204(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202NoRetry204(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4169,7 +4169,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202NoRetry204(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202NoRetry204(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4226,7 +4226,7 @@ This sample shows how to call PostDoubleHeadersFinalLocationGetAsync with requir
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.PostDoubleHeadersFinalLocationGetAsync(WaitUntil.Completed);
+var operation = await client.PostDoubleHeadersFinalLocationGetAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4267,7 +4267,7 @@ This sample shows how to call PostDoubleHeadersFinalLocationGet with required pa
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.PostDoubleHeadersFinalLocationGet(WaitUntil.Completed);
+var operation = client.PostDoubleHeadersFinalLocationGet(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4308,7 +4308,7 @@ This sample shows how to call PostDoubleHeadersFinalAzureHeaderGetAsync with req
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.PostDoubleHeadersFinalAzureHeaderGetAsync(WaitUntil.Completed);
+var operation = await client.PostDoubleHeadersFinalAzureHeaderGetAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4349,7 +4349,7 @@ This sample shows how to call PostDoubleHeadersFinalAzureHeaderGet with required
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.PostDoubleHeadersFinalAzureHeaderGet(WaitUntil.Completed);
+var operation = client.PostDoubleHeadersFinalAzureHeaderGet(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4390,7 +4390,7 @@ This sample shows how to call PostDoubleHeadersFinalAzureHeaderGetDefaultAsync w
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = await client.PostDoubleHeadersFinalAzureHeaderGetDefaultAsync(WaitUntil.Completed);
+var operation = await client.PostDoubleHeadersFinalAzureHeaderGetDefaultAsync(WaitUntil.Started);
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4431,7 +4431,7 @@ This sample shows how to call PostDoubleHeadersFinalAzureHeaderGetDefault with r
 var credential = new AzureKeyCredential("<key>");
 var client = new LROsClient(credential);
 
-var operation = client.PostDoubleHeadersFinalAzureHeaderGetDefault(WaitUntil.Completed);
+var operation = client.PostDoubleHeadersFinalAzureHeaderGetDefault(WaitUntil.Started);
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4474,7 +4474,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4495,7 +4495,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4554,7 +4554,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4575,7 +4575,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4634,7 +4634,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncNoRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncNoRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4655,7 +4655,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncNoRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncNoRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4714,7 +4714,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncNoRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncNoRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4735,7 +4735,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncNoRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncNoRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -4794,7 +4794,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRetryFailedAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetryFailedAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -4814,7 +4814,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRetryFailedAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetryFailedAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -4850,7 +4850,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRetryFailed(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetryFailed(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -4870,7 +4870,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRetryFailed(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetryFailed(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -4906,7 +4906,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRetrycanceledAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetrycanceledAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -4926,7 +4926,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRetrycanceledAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetrycanceledAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -4962,7 +4962,7 @@ var client = new LROsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRetrycanceled(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetrycanceled(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -4982,7 +4982,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRetrycanceled(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetrycanceled(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)

--- a/test/TestServerProjectsLowLevel/lro/Generated/Docs/LROsCustomHeaderClient.xml
+++ b/test/TestServerProjectsLowLevel/lro/Generated/Docs/LROsCustomHeaderClient.xml
@@ -10,7 +10,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -31,7 +31,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -90,7 +90,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -111,7 +111,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -170,7 +170,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -191,7 +191,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put201CreatingSucceeded200Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -250,7 +250,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = client.Put201CreatingSucceeded200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingSucceeded200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -271,7 +271,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put201CreatingSucceeded200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put201CreatingSucceeded200(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -330,7 +330,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -350,7 +350,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202Retry200Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202Retry200Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -386,7 +386,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = client.Post202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -406,7 +406,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202Retry200(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202Retry200(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -442,7 +442,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -462,7 +462,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRetrySucceededAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -498,7 +498,7 @@ var client = new LROsCustomHeaderClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -518,7 +518,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRetrySucceeded(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRetrySucceeded(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)

--- a/test/TestServerProjectsLowLevel/lro/Generated/Docs/LrosaDsClient.xml
+++ b/test/TestServerProjectsLowLevel/lro/Generated/Docs/LrosaDsClient.xml
@@ -10,7 +10,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutNonRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -31,7 +31,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutNonRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -90,7 +90,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutNonRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -111,7 +111,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutNonRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -170,7 +170,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutNonRetry201Creating400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonRetry201Creating400Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -191,7 +191,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutNonRetry201Creating400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonRetry201Creating400Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -250,7 +250,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutNonRetry201Creating400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonRetry201Creating400(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -271,7 +271,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutNonRetry201Creating400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonRetry201Creating400(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -330,7 +330,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutNonRetry201Creating400InvalidJsonAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonRetry201Creating400InvalidJsonAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -351,7 +351,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutNonRetry201Creating400InvalidJsonAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutNonRetry201Creating400InvalidJsonAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -410,7 +410,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutNonRetry201Creating400InvalidJson(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonRetry201Creating400InvalidJson(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -431,7 +431,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutNonRetry201Creating400InvalidJson(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutNonRetry201Creating400InvalidJson(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -490,7 +490,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRelativeRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -511,7 +511,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRelativeRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -570,7 +570,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRelativeRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -591,7 +591,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRelativeRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -648,7 +648,7 @@ This sample shows how to call DeleteNonRetry400Async with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.DeleteNonRetry400Async(WaitUntil.Completed);
+var operation = await client.DeleteNonRetry400Async(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -662,7 +662,7 @@ This sample shows how to call DeleteNonRetry400 with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.DeleteNonRetry400(WaitUntil.Completed);
+var operation = client.DeleteNonRetry400(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -676,7 +676,7 @@ This sample shows how to call Delete202NonRetry400Async with required parameters
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.Delete202NonRetry400Async(WaitUntil.Completed);
+var operation = await client.Delete202NonRetry400Async(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -690,7 +690,7 @@ This sample shows how to call Delete202NonRetry400 with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.Delete202NonRetry400(WaitUntil.Completed);
+var operation = client.Delete202NonRetry400(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -704,7 +704,7 @@ This sample shows how to call DeleteAsyncRelativeRetry400Async with required par
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.DeleteAsyncRelativeRetry400Async(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRelativeRetry400Async(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -718,7 +718,7 @@ This sample shows how to call DeleteAsyncRelativeRetry400 with required paramete
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.DeleteAsyncRelativeRetry400(WaitUntil.Completed);
+var operation = client.DeleteAsyncRelativeRetry400(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -734,7 +734,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostNonRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostNonRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -754,7 +754,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostNonRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostNonRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -790,7 +790,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PostNonRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostNonRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -810,7 +810,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostNonRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostNonRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -846,7 +846,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202NonRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202NonRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -866,7 +866,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202NonRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202NonRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -902,7 +902,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.Post202NonRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202NonRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -922,7 +922,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202NonRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202NonRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -958,7 +958,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRelativeRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -978,7 +978,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRelativeRetry400Async(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetry400Async(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1014,7 +1014,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRelativeRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1034,7 +1034,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRelativeRetry400(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetry400(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1070,7 +1070,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutError201NoProvisioningStatePayloadAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutError201NoProvisioningStatePayloadAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1091,7 +1091,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutError201NoProvisioningStatePayloadAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutError201NoProvisioningStatePayloadAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1150,7 +1150,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutError201NoProvisioningStatePayload(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutError201NoProvisioningStatePayload(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1171,7 +1171,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutError201NoProvisioningStatePayload(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutError201NoProvisioningStatePayload(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1230,7 +1230,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRelativeRetryNoStatusAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryNoStatusAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1251,7 +1251,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRelativeRetryNoStatusAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryNoStatusAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1310,7 +1310,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRelativeRetryNoStatus(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryNoStatus(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1331,7 +1331,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRelativeRetryNoStatus(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryNoStatus(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1390,7 +1390,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRelativeRetryNoStatusPayloadAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryNoStatusPayloadAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1411,7 +1411,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRelativeRetryNoStatusPayloadAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryNoStatusPayloadAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1470,7 +1470,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRelativeRetryNoStatusPayload(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryNoStatusPayload(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1491,7 +1491,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRelativeRetryNoStatusPayload(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryNoStatusPayload(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1548,7 +1548,7 @@ This sample shows how to call Delete204SucceededAsync with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.Delete204SucceededAsync(WaitUntil.Completed);
+var operation = await client.Delete204SucceededAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1562,7 +1562,7 @@ This sample shows how to call Delete204Succeeded with required parameters.
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.Delete204Succeeded(WaitUntil.Completed);
+var operation = client.Delete204Succeeded(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1576,7 +1576,7 @@ This sample shows how to call DeleteAsyncRelativeRetryNoStatusAsync with require
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.DeleteAsyncRelativeRetryNoStatusAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRelativeRetryNoStatusAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1590,7 +1590,7 @@ This sample shows how to call DeleteAsyncRelativeRetryNoStatus with required par
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.DeleteAsyncRelativeRetryNoStatus(WaitUntil.Completed);
+var operation = client.DeleteAsyncRelativeRetryNoStatus(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1606,7 +1606,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202NoLocationAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202NoLocationAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1626,7 +1626,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202NoLocationAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202NoLocationAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1662,7 +1662,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.Post202NoLocation(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202NoLocation(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1682,7 +1682,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202NoLocation(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202NoLocation(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1718,7 +1718,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRelativeRetryNoPayloadAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetryNoPayloadAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1738,7 +1738,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRelativeRetryNoPayloadAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetryNoPayloadAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -1774,7 +1774,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRelativeRetryNoPayload(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetryNoPayload(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1794,7 +1794,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRelativeRetryNoPayload(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetryNoPayload(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -1830,7 +1830,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.Put200InvalidJsonAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200InvalidJsonAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1851,7 +1851,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Put200InvalidJsonAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Put200InvalidJsonAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1910,7 +1910,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.Put200InvalidJson(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200InvalidJson(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1931,7 +1931,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Put200InvalidJson(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Put200InvalidJson(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -1990,7 +1990,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2011,7 +2011,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2070,7 +2070,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRelativeRetryInvalidHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryInvalidHeader(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2091,7 +2091,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRelativeRetryInvalidHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryInvalidHeader(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2150,7 +2150,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PutAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2171,7 +2171,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PutAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PutAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = await operation.WaitForCompletionAsync();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2230,7 +2230,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PutAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2251,7 +2251,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PutAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PutAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Started, RequestContent.Create(data));
 
 BinaryData data = operation.WaitForCompletion();
 JsonElement result = JsonDocument.Parse(data.ToStream()).RootElement;
@@ -2308,7 +2308,7 @@ This sample shows how to call Delete202RetryInvalidHeaderAsync with required par
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.Delete202RetryInvalidHeaderAsync(WaitUntil.Completed);
+var operation = await client.Delete202RetryInvalidHeaderAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2322,7 +2322,7 @@ This sample shows how to call Delete202RetryInvalidHeader with required paramete
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.Delete202RetryInvalidHeader(WaitUntil.Completed);
+var operation = client.Delete202RetryInvalidHeader(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2336,7 +2336,7 @@ This sample shows how to call DeleteAsyncRelativeRetryInvalidHeaderAsync with re
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.DeleteAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2350,7 +2350,7 @@ This sample shows how to call DeleteAsyncRelativeRetryInvalidHeader with require
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.DeleteAsyncRelativeRetryInvalidHeader(WaitUntil.Completed);
+var operation = client.DeleteAsyncRelativeRetryInvalidHeader(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2364,7 +2364,7 @@ This sample shows how to call DeleteAsyncRelativeRetryInvalidJsonPollingAsync wi
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = await client.DeleteAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Completed);
+var operation = await client.DeleteAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2378,7 +2378,7 @@ This sample shows how to call DeleteAsyncRelativeRetryInvalidJsonPolling with re
 var credential = new AzureKeyCredential("<key>");
 var client = new LrosaDsClient(credential);
 
-var operation = client.DeleteAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Completed);
+var operation = client.DeleteAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Started);
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2394,7 +2394,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.Post202RetryInvalidHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202RetryInvalidHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2414,7 +2414,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.Post202RetryInvalidHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.Post202RetryInvalidHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2450,7 +2450,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.Post202RetryInvalidHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202RetryInvalidHeader(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2470,7 +2470,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.Post202RetryInvalidHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.Post202RetryInvalidHeader(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2506,7 +2506,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2526,7 +2526,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetryInvalidHeaderAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2562,7 +2562,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRelativeRetryInvalidHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetryInvalidHeader(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2582,7 +2582,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRelativeRetryInvalidHeader(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetryInvalidHeader(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2618,7 +2618,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = await client.PostAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2638,7 +2638,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = await client.PostAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Completed, RequestContent.Create(data));
+var operation = await client.PostAsyncRelativeRetryInvalidJsonPollingAsync(WaitUntil.Started, RequestContent.Create(data));
 
 var response = await operation.WaitForCompletionResponseAsync();
 Console.WriteLine(response.Status)
@@ -2674,7 +2674,7 @@ var client = new LrosaDsClient(credential);
 
 var data = new {};
 
-var operation = client.PostAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)
@@ -2694,7 +2694,7 @@ var data = new {
     location = "<location>",
 };
 
-var operation = client.PostAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Completed, RequestContent.Create(data));
+var operation = client.PostAsyncRelativeRetryInvalidJsonPolling(WaitUntil.Started, RequestContent.Create(data));
 
 var response = operation.WaitForCompletionResponse();
 Console.WriteLine(response.Status)

--- a/test/TestServerProjectsLowLevel/paging/Generated/Docs/PagingClient.xml
+++ b/test/TestServerProjectsLowLevel/paging/Generated/Docs/PagingClient.xml
@@ -1306,7 +1306,7 @@ This sample shows how to call GetMultiplePagesLROAsync with required parameters 
 var credential = new AzureKeyCredential("<key>");
 var client = new PagingClient(credential);
 
-var operation = await client.GetMultiplePagesLROAsync(WaitUntil.Completed);
+var operation = await client.GetMultiplePagesLROAsync(WaitUntil.Started);
 
 var response = await operation.WaitForCompletionAsync();
 await foreach (var data in response.Value)
@@ -1320,7 +1320,7 @@ This sample shows how to call GetMultiplePagesLROAsync with all parameters, and 
 var credential = new AzureKeyCredential("<key>");
 var client = new PagingClient(credential);
 
-var operation = await client.GetMultiplePagesLROAsync(WaitUntil.Completed, "<clientRequestId>", 1234, 1234);
+var operation = await client.GetMultiplePagesLROAsync(WaitUntil.Started, "<clientRequestId>", 1234, 1234);
 
 var response = await operation.WaitForCompletionAsync();
 await foreach (var data in response.Value)
@@ -1354,7 +1354,7 @@ This sample shows how to call GetMultiplePagesLRO with required parameters and p
 var credential = new AzureKeyCredential("<key>");
 var client = new PagingClient(credential);
 
-var operation = client.GetMultiplePagesLRO(WaitUntil.Completed);
+var operation = client.GetMultiplePagesLRO(WaitUntil.Started);
 
 var response = operation.WaitForCompletion();
 foreach (var data in response.Value)
@@ -1368,7 +1368,7 @@ This sample shows how to call GetMultiplePagesLRO with all parameters, and how t
 var credential = new AzureKeyCredential("<key>");
 var client = new PagingClient(credential);
 
-var operation = client.GetMultiplePagesLRO(WaitUntil.Completed, "<clientRequestId>", 1234, 1234);
+var operation = client.GetMultiplePagesLRO(WaitUntil.Started, "<clientRequestId>", 1234, 1234);
 
 var response = operation.WaitForCompletion();
 foreach (var data in response.Value)


### PR DESCRIPTION
- change `LowLevelExampleComposer` to use `WaitUntil.Started` when mocking method parameter values
- update samples/tests

fix #2978

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first