### PR TITLE
Optimize serialization writers

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
@@ -88,6 +88,9 @@ namespace AutoRest.CSharp.AutoRest.Plugins
             foreach (var task in documents)
             {
                 var processed = await task;
+
+                processed = await Simplifier.ReduceAsync(processed);
+                processed = await Formatter.FormatAsync(processed);
                 var text = await processed.GetSyntaxTreeAsync();
                 yield return (processed.Name, text!.ToString());
             }
@@ -108,8 +111,6 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 document = document.WithSyntaxRoot(rewriter.Visit(await syntaxTree.GetRootAsync()));
             }
 
-            document = await Simplifier.ReduceAsync(document);
-            document = await Formatter.FormatAsync(document);
             return document;
         }
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriter.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriter.cs
@@ -142,9 +142,6 @@ namespace AutoRest.CSharp.Generation.Writers
                     case FormattableString fs:
                         Append(fs);
                         break;
-                    case CodeWriterDelegate d:
-                        Append(d);
-                        break;
                     case Type t:
                         AppendType(new CSharpType(t));
                         break;
@@ -538,12 +535,6 @@ namespace AutoRest.CSharp.Generation.Writers
         {
             declaration.SetActualName(GetTemporaryVariable(declaration.RequestedName));
             return Declaration(declaration.ActualName);
-        }
-
-        public CodeWriter Append(CodeWriterDelegate writerDelegate)
-        {
-            writerDelegate(this);
-            return this;
         }
 
         public override string ToString()

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterDelegate.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterDelegate.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-namespace AutoRest.CSharp.Generation.Writers
-{
-    internal delegate void CodeWriterDelegate(CodeWriter writer);
-}

--- a/src/AutoRest.CSharp/Common/Generation/Writers/ResponseWriterHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/ResponseWriterHelpers.cs
@@ -17,7 +17,7 @@ namespace AutoRest.CSharp.Generation.Writers
     {
         public static void WriteStatusCodeSwitch(CodeWriter writer, string messageVariableName, RestClientMethod operation, bool async, FieldDeclaration? clientDiagnosticsField)
         {
-            string responseVariable = $"{messageVariableName}.Response";
+            FormattableString responseVariable = $"{messageVariableName}.Response";
 
             var returnType = operation.ReturnType;
             var headersModelType = operation.HeaderModel?.Type;
@@ -74,12 +74,7 @@ namespace AutoRest.CSharp.Generation.Writers
                         {
                             case ObjectResponseBody objectResponseBody:
                                 writer.Line($"{responseBody.Type} {valueVariable:D} = default;");
-                                writer.WriteDeserializationForMethods(
-                                    objectResponseBody.Serialization,
-                                    async,
-                                    v => writer.Line($"{valueVariable} = {v};"),
-                                    responseVariable,
-                                    objectResponseBody.Type);
+                                writer.WriteDeserializationForMethods(objectResponseBody.Serialization, async, valueVariable, responseVariable, objectResponseBody.Type);
                                 value = new Reference(valueVariable.ActualName, responseBody.Type);
                                 break;
                             case StreamResponseBody _:

--- a/src/AutoRest.CSharp/Common/Generation/Writers/SerializationWriter.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/SerializationWriter.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml;
 using System.Xml.Linq;
 using AutoRest.CSharp.Common.Output.Models.Types;
 using AutoRest.CSharp.Generation.Types;
-using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Output.Models;
 using AutoRest.CSharp.Output.Models.Serialization.Json;
 using AutoRest.CSharp.Output.Models.Serialization.Xml;
@@ -147,22 +147,32 @@ namespace AutoRest.CSharp.Generation.Writers
             }
         }
 
-        private static void WriteXmlSerialize(CodeWriter writer, XmlElementSerialization serialization)
+        private static void WriteXmlSerialize(CodeWriter writer, XmlObjectSerialization serialization)
         {
-            const string namehint = "nameHint";
-            writer.Append($"void {typeof(IXmlSerializable)}.{nameof(IXmlSerializable.Write)}({typeof(XmlWriter)} writer, {typeof(string)} {namehint})");
+            var nameHint = new CodeWriterDeclaration("nameHint");
+            writer.Append($"void {typeof(IXmlSerializable)}.{nameof(IXmlSerializable.Write)}({typeof(XmlWriter)} writer, {typeof(string)} {nameHint:D})");
             using (writer.Scope())
             {
-                writer.ToSerializeCall(serialization, $"this", null, namehint);
+                writer.ToSerializeCall(serialization, nameHint);
             }
             writer.Line();
         }
 
         private static void WriteXmlDeserialize(CodeWriter writer, TypeDeclarationOptions declaration, XmlObjectSerialization serialization)
         {
-            using (writer.Scope($"internal static {serialization.Type} Deserialize{declaration.Name}({typeof(XElement)} element)"))
+            var element = new CodeWriterDeclaration("element");
+            using (writer.Scope($"internal static {serialization.Type} Deserialize{declaration.Name}({typeof(XElement)} {element:D})"))
             {
-                writer.ToDeserializeCall(serialization, $"element", v => writer.Line($"return {v};"), true);
+                var propertyVariables = writer.ToDeserializeObjectCall(serialization, element);
+                var initializers = new List<PropertyInitializer>();
+                foreach (var propertyVariable in propertyVariables)
+                {
+                    var property = propertyVariable.Key;
+                    initializers.Add(new PropertyInitializer(property.PropertyName, property.PropertyType, property.ShouldSkipSerialization, $"{propertyVariable.Value.ActualName}"));
+                }
+
+                var objectType = (ObjectType) serialization.Type.Implementation;
+                writer.WriteInitialization(v => writer.Line($"return {v};"), objectType, objectType.SerializationConstructor, initializers);
             }
             writer.Line();
         }
@@ -171,16 +181,16 @@ namespace AutoRest.CSharp.Generation.Writers
         {
             using (writer.Scope($"internal static {serialization.Type} Deserialize{declaration.Name}({typeof(JsonElement)} element)"))
             {
-                bool hasDecendants = serialization.Discriminator is null ? false : serialization.Discriminator.HasDescendants;
-                bool isThisTheDefaultDerivedType = serialization.Type.Equals(serialization.Discriminator?.DefaultObjectType?.Type);
-                if (serialization.Discriminator is not null && hasDecendants)
+                var discriminator = serialization.Discriminator;
+
+                if (discriminator is not null && discriminator.HasDescendants)
                 {
-                    using (writer.Scope($"if (element.TryGetProperty({serialization.Discriminator.SerializedName:L}, out {typeof(JsonElement)} discriminator))"))
+                    using (writer.Scope($"if (element.TryGetProperty({discriminator.SerializedName:L}, out {typeof(JsonElement)} discriminator))"))
                     {
                         writer.Line($"switch (discriminator.GetString())");
                         using (writer.Scope())
                         {
-                            foreach (var implementation in serialization.Discriminator.Implementations)
+                            foreach (var implementation in discriminator.Implementations)
                             {
                                 var implementationFormattable = JsonCodeWriterExtensions.GetDeserializeImplementationFormattable(implementation.Type.Implementation, $"element", JsonSerializationOptions.None);
                                 writer.Line($"case {implementation.Key:L}: return {implementationFormattable};");
@@ -189,9 +199,9 @@ namespace AutoRest.CSharp.Generation.Writers
                     }
                 }
 
-                if (serialization.Discriminator is not null && !isThisTheDefaultDerivedType && !serialization.Type.HasParent)
+                if (discriminator is not null && !serialization.Type.HasParent && !serialization.Type.Equals(discriminator.DefaultObjectType.Type))
                 {
-                    writer.Line($"return {JsonCodeWriterExtensions.GetDeserializeImplementationFormattable(serialization.Discriminator.DefaultObjectType.Type.Implementation, $"element", JsonSerializationOptions.None)};");
+                    writer.Line($"return {JsonCodeWriterExtensions.GetDeserializeImplementationFormattable(discriminator.DefaultObjectType.Type.Implementation, $"element", JsonSerializationOptions.None)};");
                 }
                 else
                 {
@@ -203,7 +213,6 @@ namespace AutoRest.CSharp.Generation.Writers
 
         private static void WriteJsonSerialize(CodeWriter writer, JsonObjectSerialization jsonSerialization)
         {
-
             using (writer.Scope($"void {typeof(IUtf8JsonSerializable)}.{nameof(IUtf8JsonSerializable.Write)}({typeof(Utf8JsonWriter)} writer)"))
             {
                 writer.ToSerializeCall(jsonSerialization);

--- a/src/AutoRest.CSharp/Common/Generation/Writers/XmlCodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/XmlCodeWriterExtensions.cs
@@ -3,24 +3,64 @@
 
 using System;
 using System.Collections.Generic;
+using System.Xml;
 using System.Xml.Linq;
 using AutoRest.CSharp.Generation.Types;
-using AutoRest.CSharp.Output.Models.Requests;
 using AutoRest.CSharp.Output.Models.Serialization;
 using AutoRest.CSharp.Output.Models.Serialization.Xml;
 using AutoRest.CSharp.Output.Models.Types;
 using AutoRest.CSharp.Utilities;
 using Azure.Core;
-using Azure.ResourceManager;
 
 namespace AutoRest.CSharp.Generation.Writers
 {
     internal static class XmlCodeWriterExtensions
     {
+        public static void ToSerializeCall(this CodeWriter writer, XmlObjectSerialization objectSerialization, CodeWriterDeclaration nameHint)
+        {
+            FormattableString writerName = $"writer";
+            writer.Line($"{writerName}.WriteStartElement({nameHint} ?? {objectSerialization.Name:L});");
+
+            foreach (XmlObjectAttributeSerialization property in objectSerialization.Attributes)
+            {
+                using (writer.WriteDefinedCheck(property))
+                using (writer.WritePropertyNullCheckIf(property))
+                {
+                    writer.Line($"{writerName}.WriteStartAttribute({property.SerializedName:L});");
+                    writer.ToSerializeValueCall($"{property.PropertyName}", writerName, property.ValueSerialization);
+                    writer.Line($"{writerName}.WriteEndAttribute();");
+                }
+            }
+
+            foreach (XmlObjectElementSerialization property in objectSerialization.Elements)
+            {
+                using (writer.WriteDefinedCheck(property))
+                using (writer.WritePropertyNullCheckIf(property))
+                {
+                    writer.ToSerializeCall(property.ValueSerialization, $"{property.PropertyName}");
+                }
+            }
+
+            foreach (XmlObjectArraySerialization property in objectSerialization.EmbeddedArrays)
+            {
+                using (writer.WriteDefinedCheck(property))
+                using (writer.WritePropertyNullCheckIf(property))
+                {
+                    writer.ToSerializeCall(property.ArraySerialization, $"{property.PropertyName}");
+                }
+            }
+
+            if (objectSerialization.ContentSerialization is { } contentSerialization)
+            {
+                writer.ToSerializeValueCall($"{contentSerialization.PropertyName}", writerName, contentSerialization.ValueSerialization);
+            }
+
+            writer.Line($"{writerName}.WriteEndElement();");
+        }
+
         public static void ToSerializeCall(this CodeWriter writer, XmlElementSerialization serialization, FormattableString name, FormattableString? writerName = null, string? nameHint = null)
         {
             writerName ??= $"writer";
-
             switch (serialization)
             {
                 case XmlArraySerialization array:
@@ -52,58 +92,7 @@ namespace AutoRest.CSharp.Generation.Writers
 
                     break;
 
-                case XmlObjectSerialization objectSerialization:
-                    if (nameHint != null)
-                    {
-                        writer.Line($"{writerName}.WriteStartElement({nameHint} ?? {objectSerialization.Name:L});");
-                    }
-                    else
-                    {
-                        writer.Line($"{writerName}.WriteStartElement({objectSerialization.Name:L});");
-                    }
-
-                    foreach (XmlObjectAttributeSerialization property in objectSerialization.Attributes)
-                    {
-                        using (writer.WriteDefinedCheck(property))
-                        using (writer.WritePropertyNullCheckIf(property))
-                        {
-                            writer.Line($"{writerName}.WriteStartAttribute({property.SerializedName:L});");
-                            writer.ToSerializeValueCall($"{property.PropertyName}", writerName, property.ValueSerialization);
-                            writer.Line($"{writerName}.WriteEndAttribute();");
-                        }
-                    }
-
-                    foreach (XmlObjectElementSerialization property in objectSerialization.Elements)
-                    {
-                        using (writer.WriteDefinedCheck(property))
-                        using (writer.WritePropertyNullCheckIf(property))
-                        {
-                            writer.ToSerializeCall(property.ValueSerialization, $"{property.PropertyName}");
-                        }
-                    }
-
-                    foreach (XmlObjectArraySerialization property in objectSerialization.EmbeddedArrays)
-                    {
-                        using (writer.WriteDefinedCheck(property))
-                        using (writer.WritePropertyNullCheckIf(property))
-                        {
-                            writer.ToSerializeCall(property.ArraySerialization, $"{property.PropertyName}");
-                        }
-                    }
-
-                    if (objectSerialization.ContentSerialization is { } contentSerialization)
-                    {
-                        writer.ToSerializeValueCall(
-                            $"{contentSerialization.PropertyName}",
-                            writerName,
-                            contentSerialization.ValueSerialization);
-                    }
-
-                    writer.Line($"{writerName}.WriteEndElement();");
-                    return;
-
                 case XmlElementValueSerialization elementValueSerialization:
-
                     var type = elementValueSerialization.Value.Type;
 
                     string elementName = elementValueSerialization.Name;
@@ -168,7 +157,7 @@ namespace AutoRest.CSharp.Generation.Writers
             writer.Append($"{writerName}.WriteValue({name}")
                 .AppendNullableValue(implementationType);
 
-            if (writeFormat && valueSerialization.Format.ToFormatSpecifier() is string formatString)
+            if (writeFormat && valueSerialization.Format.ToFormatSpecifier() is { } formatString)
             {
                 writer.Append($", {formatString:L}");
             }
@@ -176,131 +165,99 @@ namespace AutoRest.CSharp.Generation.Writers
             writer.LineRaw(");");
         }
 
-        public static void ToDeserializeCall(this CodeWriter writer, XmlElementSerialization serialization, FormattableString element, Action<FormattableString> valueCallback, bool isElement = false)
+        public static Dictionary<PropertySerialization, CodeWriterDeclaration> ToDeserializeObjectCall(this CodeWriter writer, XmlObjectSerialization objectSerialization, CodeWriterDeclaration variable)
         {
-            if (isElement)
+            var propertyVariables = new Dictionary<PropertySerialization, CodeWriterDeclaration>();
+
+            CollectProperties(propertyVariables, objectSerialization);
+
+            foreach (var propertyVariable in propertyVariables)
             {
-                writer.ToDeserializeElementCall(serialization, valueCallback, element);
+                var property = propertyVariable.Key;
+                writer.Line($"{property.PropertyType} {propertyVariable.Value:D} = default;");
             }
-            else
+
+            foreach (XmlObjectAttributeSerialization attribute in objectSerialization.Attributes)
             {
-                writer.ToDeserializeCall(serialization, valueCallback, element);
+                var attributeVariable = new CodeWriterDeclaration(attribute.PropertyName.ToVariableName() + "Attribute");
+                using (writer.Scope($"if ({variable}.Attribute({attribute.SerializedName:L}) is {typeof(XAttribute)} {attributeVariable:D})"))
+                {
+                    writer.Line($"{propertyVariables[attribute]} = {GetDeserializeValueCallFormattable(attribute.ValueSerialization, $"{attributeVariable}")};");
+                }
             }
+
+            foreach (XmlObjectElementSerialization elem in objectSerialization.Elements)
+            {
+                writer.ToDeserializeCall(elem.ValueSerialization, propertyVariables[elem], variable);
+            }
+
+            foreach (XmlObjectArraySerialization embeddedArray in objectSerialization.EmbeddedArrays)
+            {
+                writer.ToDeserializeCall(embeddedArray.ArraySerialization, propertyVariables[embeddedArray], variable);
+            }
+
+            if (objectSerialization.ContentSerialization is { } contentSerialization)
+            {
+                writer.Line($"{propertyVariables[contentSerialization]} = {GetDeserializeValueCallFormattable(contentSerialization.ValueSerialization, $"{variable}.Value")};");
+            }
+
+            return propertyVariables;
         }
 
-        private static void ToDeserializeCall(this CodeWriter writer, XmlElementSerialization serialization, Action<FormattableString> valueCallback, FormattableString element)
+        private static void ToDeserializeCall(this CodeWriter writer, XmlElementSerialization serialization, CodeWriterDeclaration propertyVariable, CodeWriterDeclaration variable)
         {
-            if (serialization is XmlArraySerialization arraySerialization && !arraySerialization.Wrapped)
+            if (serialization is XmlArraySerialization { Wrapped: false })
             {
-                writer.ToDeserializeElementCall(serialization, valueCallback, element);
+                writer.DeserializeElementIntoVariable(serialization, variable, propertyVariable);
                 return;
             }
 
             var elementVariable = new CodeWriterDeclaration(serialization.Name.ToVariableName() + "Element");
-            writer.Line($"if ({element}.Element({serialization.Name:L}) is {typeof(XElement)} {elementVariable:D})");
-            using (writer.Scope())
+            using (writer.Scope($"if ({variable}.Element({serialization.Name:L}) is {typeof(XElement)} {elementVariable:D})"))
             {
-                writer.ToDeserializeElementCall(serialization, valueCallback, $"{elementVariable}");
+                writer.DeserializeElementIntoVariable(serialization, elementVariable, propertyVariable);
             }
         }
 
-        private static void ToDeserializeElementCall(this CodeWriter writer, XmlElementSerialization serialization, Action<FormattableString> valueCallback, FormattableString element)
+        private static void DeserializeElementIntoVariable(this CodeWriter writer, XmlElementSerialization serialization, CodeWriterDeclaration xElement, CodeWriterDeclaration variable)
+            => writer.Line($"{variable} = {writer.ToDeserializeElementCall(serialization, xElement)};");
+
+        private static FormattableString ToDeserializeElementCall(this CodeWriter writer, XmlElementSerialization serialization, CodeWriterDeclaration variable)
         {
             switch (serialization)
             {
                 case XmlArraySerialization arraySerialization:
-                {
                     var arrayVariable = new CodeWriterDeclaration("array");
                     var childElementVariable = new CodeWriterDeclaration("e");
 
                     writer.Line($"var {arrayVariable:D} = new {arraySerialization.Type}();");
-
-                    using (writer.Scope($"foreach (var {childElementVariable:D} in {element}.Elements({arraySerialization.ValueSerialization.Name:L}))"))
+                    using (writer.Scope($"foreach (var {childElementVariable:D} in {variable}.Elements({arraySerialization.ValueSerialization.Name:L}))"))
                     {
-                        writer.ToDeserializeCall(arraySerialization.ValueSerialization, $"{childElementVariable}", v => writer.Line($"{arrayVariable}.Add({v});"), true);
+                        writer.Line($"{arrayVariable}.Add({writer.ToDeserializeElementCall(arraySerialization.ValueSerialization, childElementVariable)});");
                     }
 
-                    valueCallback($"{arrayVariable:I}");
-                    return;
-                }
+                    return $"{arrayVariable:I}";
                 case XmlDictionarySerialization dictionarySerialization:
-                {
                     var dictionaryVariable = new CodeWriterDeclaration("dictionary");
                     writer.Line($"var {dictionaryVariable:D} = new {dictionarySerialization.Type}();");
 
                     var elementVariable = new CodeWriterDeclaration("e");
 
-                    using (writer.Scope($"foreach (var {elementVariable:D} in {element}.Elements())"))
+                    using (writer.Scope($"foreach (var {elementVariable:D} in {variable}.Elements())"))
                     {
-                        writer.ToDeserializeCall(dictionarySerialization.ValueSerialization, $"{elementVariable}", v => writer.Line($"{dictionaryVariable}.Add({elementVariable}.Name.LocalName, {v});"), true);
+                        writer.Line($"{dictionaryVariable}.Add({elementVariable}.Name.LocalName, {writer.ToDeserializeElementCall(dictionarySerialization.ValueSerialization, elementVariable)});");
                     }
 
-                    valueCallback($"{dictionaryVariable}");
-                    return;
-                }
-                case XmlObjectSerialization elementSerialization:
-
-                    var propertyVariables = new Dictionary<PropertySerialization, CodeWriterDeclaration>();
-
-                    CollectProperties(propertyVariables, elementSerialization);
-
-                    foreach (var variable in propertyVariables)
-                    {
-                        var property = variable.Key;
-                        writer.Line($"{property.PropertyType} {variable.Value:D} = default;");
-                    }
-
-
-                    foreach (XmlObjectAttributeSerialization attribute in elementSerialization.Attributes)
-                    {
-                        var attributeVariable = new CodeWriterDeclaration(attribute.PropertyName.ToVariableName() + "Attribute");
-                        using (writer.Scope($"if ({element}.Attribute({attribute.SerializedName:L}) is {typeof(XAttribute)} {attributeVariable:D})"))
-                        {
-                            writer.Append($"{propertyVariables[attribute]} = ");
-                            writer.Append(GetDeserializeValueCallFormattable(attribute.ValueSerialization, $"{attributeVariable}"));
-                            writer.Line($";");
-                        }
-                    }
-
-                    foreach (XmlObjectElementSerialization elem in elementSerialization.Elements)
-                    {
-                        writer.ToDeserializeCall(elem.ValueSerialization, element, v => writer.Line($"{propertyVariables[elem]} = {v};"));
-                    }
-
-                    foreach (var embeddedArray in elementSerialization.EmbeddedArrays)
-                    {
-                        writer.ToDeserializeCall(embeddedArray.ArraySerialization, v => writer.Line($"{propertyVariables[embeddedArray]} = {v};"), element);
-                    }
-
-                    if (elementSerialization.ContentSerialization is { } contentSerialization)
-                    {
-                        writer.Append($"{propertyVariables[contentSerialization]} = ");
-                        writer.Append(GetDeserializeValueCallFormattable(contentSerialization.ValueSerialization, $"{element}.Value"));
-                        writer.Line($";");
-                    }
-
-                    var initializers = new List<PropertyInitializer>();
-                    foreach (var variable in propertyVariables)
-                    {
-                        var property = variable.Key;
-                        initializers.Add(new PropertyInitializer(property.PropertyName, property.PropertyType, property.ShouldSkipSerialization, $"{variable.Value.ActualName}"));
-                    }
-
-                    var objectType = (ObjectType) elementSerialization.Type.Implementation;
-
-                    writer.WriteInitialization(valueCallback, objectType, objectType.SerializationConstructor, initializers);
-
-                    return;
+                    return $"{dictionaryVariable}";
                 case XmlElementValueSerialization valueSerialization:
-                {
                     writer.UseNamespace(typeof(XElementExtensions).Namespace!);
-                    valueCallback(GetDeserializeValueCallFormattable(valueSerialization.Value, element));
-                    return;
-                }
+                    return GetDeserializeValueCallFormattable(valueSerialization.Value, $"{variable}");
+                default:
+                    throw new InvalidOperationException($"Unexpected {nameof(XmlElementSerialization)} type.");
             }
         }
 
-        private static FormattableString GetDeserializeValueCallFormattable(XmlValueSerialization serialization, FormattableString element)
+        private static FormattableString GetDeserializeValueCallFormattable(XmlValueSerialization serialization, FormattableString reference)
         {
             var type = serialization.Type;
 
@@ -318,27 +275,27 @@ namespace AutoRest.CSharp.Generation.Writers
                     frameworkType == typeof(string)
                 )
                 {
-                    return $"({type}){element}";
+                    return $"({type}){reference}";
                 }
 
-                if (frameworkType == typeof(Azure.Core.ResourceIdentifier))
+                if (frameworkType == typeof(ResourceIdentifier))
                 {
-                    return $"new {typeof(Azure.Core.ResourceIdentifier)}(({typeof(string)}){element})";
+                    return $"new {typeof(ResourceIdentifier)}(({typeof(string)}){reference})";
                 }
 
-                if (frameworkType == typeof(Azure.Core.ResourceType))
+                if (frameworkType == typeof(ResourceType))
                 {
-                    return $"({typeof(string)}){element}";
+                    return $"({typeof(string)}){reference}";
                 }
 
                 if (frameworkType == typeof(Guid))
                 {
-                    return $"new {typeof(Guid)}({element}.Value)";
+                    return $"new {typeof(Guid)}({reference}.Value)";
                 }
 
                 if (frameworkType == typeof(Uri))
                 {
-                    return $"new {typeof(Uri)}(({typeof(string)}){element})";
+                    return $"new {typeof(Uri)}(({typeof(string)}){reference})";
                 }
 
                 var methodName = string.Empty;
@@ -363,30 +320,54 @@ namespace AutoRest.CSharp.Generation.Writers
                     methodName = "GetObjectValue";
                 }
 
-                return $"{element}.{methodName}({serialization.Format.ToFormatSpecifier():L})";
+                return $"{reference}.{methodName}({serialization.Format.ToFormatSpecifier():L})";
             }
 
             switch (type.Implementation)
             {
                 case ObjectType _:
                     var nonNullable = type.WithNullable(false);
-                    return $"{nonNullable}.Deserialize{nonNullable.Name}({element})";
+                    return $"{nonNullable}.Deserialize{nonNullable.Name}({reference})";
 
                 case EnumType clientEnum:
                     return clientEnum.IsExtensible
-                        ? $"new {clientEnum.Type}({element}.Value)"
-                        : (FormattableString)$"{element}.Value.To{clientEnum.Type:D}()";
+                        ? $"new {clientEnum.Type}({reference}.Value)"
+                        : (FormattableString)$"{reference}.Value.To{clientEnum.Type:D}()";
 
                 default:
                     throw new NotSupportedException();
             }
         }
 
-        public static void WriteDeserializationForMethods(this CodeWriter writer, XmlElementSerialization serialization, Action<FormattableString> valueCallback, string response)
+        public static void WriteDeserializationForMethods(this CodeWriter writer, XmlElementSerialization serialization, CodeWriterDeclaration? variable, FormattableString response)
         {
             var document = new CodeWriterDeclaration("document");
             writer.Line($"var {document:D} = {typeof(XDocument)}.Load({response}.ContentStream, LoadOptions.PreserveWhitespace);");
-            writer.ToDeserializeCall(serialization, $"{document}", valueCallback);
+            if (serialization is XmlArraySerialization { Wrapped: false })
+            {
+                if (variable is not null)
+                {
+                    writer.DeserializeElementIntoVariable(serialization, document, variable);
+                }
+                else
+                {
+                    writer.Line($"return {writer.ToDeserializeElementCall(serialization, document)};");
+                }
+                return;
+            }
+
+            var elementVariable = new CodeWriterDeclaration(serialization.Name.ToVariableName() + "Element");
+            using (writer.Scope($"if ({document}.Element({serialization.Name:L}) is {typeof(XElement)} {elementVariable:D})"))
+            {
+                if (variable is not null)
+                {
+                    writer.DeserializeElementIntoVariable(serialization, elementVariable, variable);
+                }
+                else
+                {
+                    writer.Line($"return {writer.ToDeserializeElementCall(serialization, document)};");
+                }
+            }
         }
 
         private static void CollectProperties(Dictionary<PropertySerialization, CodeWriterDeclaration> propertyVariables, XmlObjectSerialization element)

--- a/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using AutoRest.CSharp.Common.Input;
 using AutoRest.CSharp.Generation.Types;
+using AutoRest.CSharp.Generation.Writers;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Output.Models.Serialization;
 using AutoRest.CSharp.Output.Models.Serialization.Json;
@@ -176,11 +178,7 @@ namespace AutoRest.CSharp.Output.Builders
                         type.IsNullable);
                 default:
                     JsonSerializationOptions options = IsManagedServiceIdentityV3(schema, type) ? JsonSerializationOptions.UseManagedServiceIdentityV3 : JsonSerializationOptions.None;
-                    return new JsonValueSerialization(
-                        type,
-                        BuilderHelpers.GetSerializationFormat(schema),
-                        type.IsNullable,
-                        options);
+                    return new JsonValueSerialization(type, BuilderHelpers.GetSerializationFormat(schema), type.IsNullable, options);
             }
         }
 
@@ -351,9 +349,9 @@ namespace AutoRest.CSharp.Output.Builders
                 return null;
             }
 
-            var valueSerialization = BuildSerialization(
-                inheritedDictionarySchema.ElementType,
-                TypeFactory.GetElementType(additionalPropertiesProperty.Declaration.Type));
+            var dictionaryValueType = additionalPropertiesProperty.Declaration.Type.Arguments[1];
+            Debug.Assert(!dictionaryValueType.IsNullable, $"{typeof(JsonCodeWriterExtensions)} implicitly relies on {additionalPropertiesProperty.Declaration.Name} dictionary value being non-nullable");
+            var valueSerialization = BuildSerialization(inheritedDictionarySchema.ElementType, dictionaryValueType);
 
             return new JsonAdditionalPropertiesSerialization(
                     additionalPropertiesProperty,

--- a/src/AutoRest.CSharp/Common/Output/Models/Serialization/Xml/XmlObjectSerialization.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Serialization/Xml/XmlObjectSerialization.cs
@@ -6,7 +6,7 @@ using AutoRest.CSharp.Generation.Types;
 
 namespace AutoRest.CSharp.Output.Models.Serialization.Xml
 {
-    internal class XmlObjectSerialization: XmlElementSerialization
+    internal class XmlObjectSerialization
     {
         public XmlObjectSerialization(string name,
             CSharpType type,
@@ -23,7 +23,7 @@ namespace AutoRest.CSharp.Output.Models.Serialization.Xml
             ContentSerialization = contentSerialization;
         }
 
-        public override string Name { get; }
+        public string Name { get; }
         public XmlObjectElementSerialization[] Elements { get; }
         public XmlObjectAttributeSerialization[] Attributes { get; }
         public XmlObjectArraySerialization[] EmbeddedArrays { get; }

--- a/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoRest.CSharp.Generation.Types;
@@ -11,6 +12,8 @@ using AutoRest.CSharp.Generation.Writers;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
 using AutoRest.CSharp.Mgmt.Output;
+using AutoRest.CSharp.Output.Models.Serialization;
+using AutoRest.CSharp.Output.Models.Serialization.Json;
 using AutoRest.CSharp.Utilities;
 using Azure;
 using Azure.Core;
@@ -62,7 +65,10 @@ namespace AutoRest.CSharp.Mgmt.Generation
                     }
 
                     _writer.Line();
-                    WriteCreateResult("response");
+                    WriteCreateResult();
+
+                    _writer.Line();
+                    WriteCreateResultAsync();
 
                     if (_operationIdMappings is not null)
                     {
@@ -110,39 +116,59 @@ namespace AutoRest.CSharp.Mgmt.Generation
             }
         }
 
-        public void WriteCreateResult(string responseVariable)
-        {
-            Action<FormattableString> valueCallback = fs => _writer.Line($"return {fs};");
-            if (_opSource.IsReturningResource)
-            {
-                valueCallback = fs =>
-                {
-                    var data = new CodeWriterDeclaration("data");
-                    FormattableString dataString = _operationIdMappings is null ? (FormattableString)$"var {data:D} = {fs};" : (FormattableString)$"var {data:D} = ScrubId({fs});";
-                    _writer.Line(dataString);
-                    if (_opSource.Resource!.ResourceData.ShouldSetResourceIdentifier)
-                    {
-                        _writer.Line($"{data}.Id = {_opSource.ArmClientField.Name}.Id;");
-                    }
-                    _writer.Line($"return new {_opSource.Resource.Type}({_opSource.ArmClientField.Name}, {data});");
-                };
-            }
-
-            using (_writer.Scope($"{_opSource.ReturnType} {_opSource.Interface}.CreateResult({typeof(Response)} {responseVariable:D}, {typeof(CancellationToken)} cancellationToken)"))
-            {
-                _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, false, valueCallback, responseVariable, _opSource.ReturnType);
-            }
-            _writer.Line();
-
-            using (_writer.Scope($"async {new CSharpType(typeof(ValueTask<>), _opSource.ReturnType)} {_opSource.Interface}.CreateResultAsync({typeof(Response)} {responseVariable:D}, {typeof(CancellationToken)} cancellationToken)"))
-            {
-                _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, true, valueCallback, responseVariable, _opSource.ReturnType);
-            }
-        }
-
         public override string ToString()
         {
             return _writer.ToString();
+        }
+
+        private void WriteCreateResult()
+        {
+            var responseVariable = new CodeWriterDeclaration("response");
+            using (_writer.Scope($"{_opSource.ReturnType} {_opSource.Interface}.CreateResult({typeof(Response)} {responseVariable:D}, {typeof(CancellationToken)} cancellationToken)"))
+            {
+                WriteCreateResultBody(responseVariable, false);
+            }
+        }
+
+        private void WriteCreateResultAsync()
+        {
+            var responseVariable = new CodeWriterDeclaration("response");
+            using (_writer.Scope($"async {new CSharpType(typeof(ValueTask<>), _opSource.ReturnType)} {_opSource.Interface}.CreateResultAsync({typeof(Response)} {responseVariable:D}, {typeof(CancellationToken)} cancellationToken)"))
+            {
+                WriteCreateResultBody(responseVariable, true);
+            }
+        }
+
+        private void WriteCreateResultBody(CodeWriterDeclaration responseVariable, bool async)
+        {
+            if (_opSource.IsReturningResource)
+            {
+                var resourceData = _opSource.Resource!.ResourceData;
+                Debug.Assert(resourceData.IncludeDeserializer);
+
+                _writer.WriteParseJsonDocument(responseVariable, async, out var documentVariable);
+
+                var dataVariable = new CodeWriterDeclaration("data");
+                var deserializeExpression = JsonCodeWriterExtensions.GetDeserializeImplementationFormattable(resourceData, $"{documentVariable}.RootElement", JsonSerializationOptions.None);
+                if (_operationIdMappings is not null)
+                {
+                    _writer.Line($"var {dataVariable:D} = ScrubId({deserializeExpression});");
+                }
+                else
+                {
+                    _writer.Line($"var {dataVariable:D} = {deserializeExpression};");
+                }
+
+                if (resourceData.ShouldSetResourceIdentifier)
+                {
+                    _writer.Line($"{dataVariable}.Id = {_opSource.ArmClientField.Name}.Id;");
+                }
+                _writer.Line($"return new {_opSource.Resource.Type}({_opSource.ArmClientField.Name}, {dataVariable});");
+            }
+            else
+            {
+                _writer.WriteDeserializationForMethods(_opSource.ResponseSerialization, async, null, $"{responseVariable}", _opSource.ReturnType);
+            }
         }
     }
 }


### PR DESCRIPTION
- Removes all callbacks
- Removes some code paths that weren't used
- Represent one line expressions as formattable strings

Pure refactoring, no changes should happen in generated code