### PR TITLE
wrap reference type property as nullable

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
@@ -54,7 +54,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             foreach (var inputModelProperty in inputModel.Properties)
             {
                 var originalFieldName = inputModelProperty.Name.ToCleanName();
-                var originalFieldType = GetPropertyDefaultType(inputModel.Usage, inputModelProperty, typeFactory);
+                var originalFieldType = GetPropertyDefaultValueType(inputModel.Usage, inputModelProperty, typeFactory);
 
                 var existingMember = sourceTypeMapping?.GetForMember(originalFieldName)?.ExistingMember;
                 var field = existingMember is not null
@@ -131,7 +131,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             return new FieldDeclaration($"Must be removed by post-generation processing,", fieldModifiers, fieldType, declaration, GetPropertyDefaultValue(originalType, inputModelProperty), inputModelProperty.IsRequired, existingMember is IFieldSymbol, writeAsProperty);
         }
 
-        private static CSharpType GetPropertyDefaultType(in InputModelTypeUsage modelUsage, in InputModelProperty property, TypeFactory typeFactory)
+        private static CSharpType GetPropertyDefaultValueType(in InputModelTypeUsage modelUsage, in InputModelProperty property, TypeFactory typeFactory)
         {
             var valueType = typeFactory.CreateType(property.Type);
 
@@ -140,8 +140,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             {
                 valueType = TypeFactory.GetOutputType(valueType);
             }
-
-            if (valueType.IsValueType && !property.IsRequired)
+            if (!property.IsRequired)
             {
                 valueType = valueType.WithNullable(true);
             }


### PR DESCRIPTION
# Description

- resolve the issue: deserialize optional property, generate `property.ThrowNonNullablePropertyIsNull()` which is unexpected. 

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first