### PR TITLE
step 2 of renaming GenerateTests to GenerateTest

### DIFF
--- a/eng/UpdateAzureSdkForNet.ps1
+++ b/eng/UpdateAzureSdkForNet.ps1
@@ -17,4 +17,4 @@ $CadlEmitterProps = "$SdkRepoRoot\eng\emitter-package.json"
     Set-Content $CadlEmitterProps -NoNewline
 
 dotnet msbuild /restore /t:GenerateCode "$SdkRepoRoot\eng\service.proj"
-dotnet msbuild /restore /t:GenerateTests "$SdkRepoRoot\eng\service.proj"
+dotnet msbuild /restore /t:GenerateTest "$SdkRepoRoot\eng\service.proj"


### PR DESCRIPTION
This is to work with azure-sdk-for-net PR https://github.com/Azure/azure-sdk-for-net/pull/33940, assumed to be merged immediately after the SDK PR get approved and merged.