### PR TITLE
build(node): limit node version to 18.13.0

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -47,9 +47,9 @@ stages:
               useGlobalJson: true
               performMultiLevelLookup: true
           - task: NodeTool@0
-            displayName: "Install Node 18.x"
+            displayName: "Install Node 18.13.0"
             inputs:
-              versionSpec: '18.x'
+              versionSpec: '18.13.0'
           - script: |
               npm ci
             displayName: "Install packages"

--- a/eng/pipelines/cadl-ci.yml
+++ b/eng/pipelines/cadl-ci.yml
@@ -22,7 +22,7 @@ variables:
   - name: skipComponentGovernanceDetection
     value: true
   - name: NodeVersion
-    value: '18.x'
+    value: '18.13.0'
   - name: VAR_ARTIFACT_NAME
     value: 'CadlCsharpEmitter'
   - name: VAR_BUILD_ARTIFACT_STAGING_DIRECTORY

--- a/eng/pipelines/mgmt-mocktest.yml
+++ b/eng/pipelines/mgmt-mocktest.yml
@@ -44,9 +44,9 @@ stages:
               useGlobalJson: true
               performMultiLevelLookup: true
           - task: NodeTool@0
-            displayName: "Install Node 18.x"
+            displayName: "Install Node 18.13.0"
             inputs:
-              versionSpec: '18.x'
+              versionSpec: '18.13.0'
           - script: |
               npm ci
             displayName: "Install packages"

--- a/eng/pipelines/smoke-test.yml
+++ b/eng/pipelines/smoke-test.yml
@@ -8,9 +8,9 @@ jobs:
     vmImage: ubuntu-20.04
   steps:
     - task: NodeTool@0
-      displayName: "Install Node 18.x"
+      displayName: "Install Node 18.13.0"
       inputs:
-        versionSpec: '18.x'
+        versionSpec: '18.13.0'
     - task: UseDotNet@2
       displayName: 'Use .NET Core SDK'
       inputs:


### PR DESCRIPTION
limit node version on our build agents to 18.13.0 to avoid mysterious `mocha` not found error

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first