### PR TITLE
[CODEOWNERS] Temporary restriction to catch-all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 #####################
 
 # Catch all
-*                                              @m-nash @jsquire
+*                                              @m-nash @jsquire @lirenhe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,12 +11,4 @@
 #####################
 
 # Catch all
-*                                              @AlexanderSher @lirenhe @chunyu3 @m-nash
-
-# Management CSharp CodeReviewers
-/samples/Azure.Management.Storage/             @allenjzhang @m-nash
-/samples/Azure.Network.Management.Interface/   @allenjzhang @m-nash
-/samples/Azure.ResourceManager.*/              @allenjzhang @m-nash
-/src/AutoRest.CSharp/Mgmt/                     @allenjzhang @m-nash
-/src/AutoRest.CSharp/Common/                   @allenjzhang @m-nash
-/test/AutoRest.TestServer.Tests/Mgmt/          @allenjzhang @m-nash
+*                                              @m-nash @jsquire


### PR DESCRIPTION
# Summary

The purpose of these changes is to temporarily restrict the owners so that branch protections can be applied that restrict merging to PRs with Michael or Renhe's approval.   This will be removed when the AutoRest sync pipeline issues have been fixed.