### PR TITLE
Use 1ES pools

### DIFF
--- a/eng/pipelines/cadl-ci.yml
+++ b/eng/pipelines/cadl-ci.yml
@@ -16,7 +16,7 @@ pr:
 
 pool:
   name: "azsdk-pool-mms-ubuntu-2004-general"
-  vmImage: "MMSUbuntu20.04"
+  vmImage: "ubuntu-20.04"
 
 variables:
   - name: skipComponentGovernanceDetection

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -8,6 +8,7 @@ jobs:
 - job: ${{ parameters.name }}
   timeoutInMinutes: 60
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: ubuntu-20.04
   variables:
     AutorestCSharpVersion: $[stageDependencies.Build_and_Test.Build.outputs['Package.AutorestCSharpVersion']]

--- a/eng/pipelines/update-azure-sdk-for-net-samples.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-samples.yml
@@ -8,6 +8,7 @@ jobs:
 - job: ${{ parameters.name }}
   timeoutInMinutes: 60
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: ubuntu-20.04
   variables:
     AutorestCSharpVersion: $[stageDependencies.Build_and_Test.Build.outputs['Package.AutorestCSharpVersion']]

--- a/eng/pipelines/update-generator-versions.yml
+++ b/eng/pipelines/update-generator-versions.yml
@@ -3,6 +3,7 @@
 jobs:
 - job: Update_Generator_Versions
   pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: ubuntu-20.04
   variables:
     AutorestCSharpVersion: $[stageDependencies.Build_and_Test.Build.outputs['Package.AutorestCSharpVersion']]


### PR DESCRIPTION
- All Windows and Linux builds should use 1ES pools
- 1ES pool agents are also larger machines which should improve build perf