### PR TITLE
Make coverage report upload conditional on project name

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -132,9 +132,9 @@ stages:
             artifact: CoverageReport
           - ${{if eq(variables['System.TeamProject'], 'internal')}}:
             - task: AzureCLI@2
-                displayName: 'Upload to Cadl Ranch Coverage Report'
-                condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
-                inputs:
+              displayName: 'Upload to Cadl Ranch Coverage Report'
+              condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
+              inputs:
                 azureSubscription: "Cadl Ranch Storage"
                 scriptType: "bash"
                 scriptLocation: "inlineScript"

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -130,15 +130,16 @@ stages:
               workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
           - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage/cadl-ranch-coverage-csharp.json
             artifact: CoverageReport
-          - task: AzureCLI@2
-            displayName: 'Upload to Cadl Ranch Coverage Report'
-            condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
-            inputs:
-              azureSubscription: "Cadl Ranch Storage"
-              scriptType: "bash"
-              scriptLocation: "inlineScript"
-              inlineScript: npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/CADL.Extension/Emitter.Csharp/package.json').version")
-              workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
+          - ${{if eq(variables['System.TeamProject'], 'internal')}}:
+            - task: AzureCLI@2
+                displayName: 'Upload to Cadl Ranch Coverage Report'
+                condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
+                inputs:
+                azureSubscription: "Cadl Ranch Storage"
+                scriptType: "bash"
+                scriptLocation: "inlineScript"
+                inlineScript: npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/CADL.Extension/Emitter.Csharp/package.json').version")
+                workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
       - template: check-code-generation.yml
         parameters:
           name: Check_Code_Generation_A_C


### PR DESCRIPTION
The public ci/pr build is currently failing because it doesn't have access to a required service connection.  Making the publish step conditional on project should allow the build to proceed to the smoke test jobs.