### PR TITLE
Add dynamic matrix generation for sdk-for-net

### DIFF
--- a/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
+++ b/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
@@ -93,4 +93,3 @@ $projectGroups = Split-Items -Items $projects
 $propsFiles = New-PropsFiles -ProjectGroups $projectGroups -PropsFilePrefix 'projects_'
 $matrix = New-Matrix -PropsFiles $propsFiles
 Write-JsonVariable "matrix" $matrix
-Write-JsonVariable "matrix-dependsOn" $matrix.Keys

--- a/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
+++ b/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
@@ -39,8 +39,6 @@ function New-PropsFiles($ProjectGroups, $PropsFilePrefix) {
     Throw "There should be some project files in the group. Please check the given project list."
   }
 
-  Push-Location $SdkForNetPath
-
   $numOfGroups = $ProjectGroups.Count
 
   for ($i = 0; $i -lt $numOfGroups; $i++) {
@@ -60,10 +58,7 @@ function New-PropsFiles($ProjectGroups, $PropsFilePrefix) {
     }
 
     $document.Save($filePath) | Out-Null
-    Write-Output $propsFilePath
   }
-
-  Pop-Location
 }
 
 function Get-ProjectsWithAutorest() {

--- a/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
+++ b/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
@@ -44,19 +44,19 @@ function New-PropsFiles($ProjectGroups, $PropsFilePrefix) {
   for ($i = 0; $i -lt $numOfGroups; $i++) {
     $propsFilePath = "$PropsFilePrefix$i.props"
     $filePath = Join-Path $OutputFolder $propsFilePath
-    $document=[xml]'<Project></Project>'
-    $projectNode = $document.SelectNodes("/Project")
-    $itemGroupNode = $projectNode.AppendChild($document.CreateElement("ItemGroup"))
+    $projectNode=[Xml.Linq.XElement]'<Project />'
+    $itemGroupNode = [Xml.Linq.XElement]'<ItemGroup />'
+    $projectNode.Add($itemGroupNode)
     foreach($projectPath in $ProjectGroups[$i]) {
       $rootedPath = $projectPath.Replace($SdkForNetPath, '$(RepoRoot)', 'OrdinalIgnoreCase')
-      $newElem = $document.CreateElement("ProjectReference")
-      $newElemAttr = $document.CreateAttribute("Include")
-      $newElemAttr.InnerText = $rootedPath
-      $newElem.Attributes.Append($newElemAttr) | Out-Null
-      $itemGroupNode.AppendChild($newElem) | Out-Null
+      $newElemAttr = [Xml.Linq.XAttribute]::new('Include', $rootedPath)
+      $newElem = [Xml.Linq.XElement]::new('ProjectReference', $newElemAttr)
+      $itemGroupNode.Add($newElem)
     }
 
-    $document.Save($filePath) | Out-Null
+    $projectNode.Save($filePath) | Out-Null
+
+    Write-Host "$propsFilePath`:`n$($projectNode.ToString())`n"
     Write-Output $propsFilePath
   }
 }
@@ -92,5 +92,4 @@ $propsFiles = New-PropsFiles -ProjectGroups $projectGroups -PropsFilePrefix 'pro
 $matrix = New-Matrix -PropsFiles $propsFiles
 Write-JsonVariable "matrix" $matrix
 
-Write-Output "Matrix:"
-Write-Output (ConvertTo-Json $matrix -Depth 100)
+Write-Host "Matrix:`n$(ConvertTo-Json $matrix -Depth 100)"

--- a/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
+++ b/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
@@ -44,7 +44,6 @@ function New-PropsFiles($ProjectGroups, $PropsFilePrefix) {
   for ($i = 0; $i -lt $numOfGroups; $i++) {
     $propsFilePath = "$PropsFilePrefix$i.props"
     $filePath = Join-Path $OutputFolder $propsFilePath
-    # Retain the structure without ProjectReference.
     $document=[xml]'<Project></Project>'
     $projectNode = $document.SelectNodes("/Project")
     $itemGroupNode = $projectNode.AppendChild($document.CreateElement("ItemGroup"))
@@ -58,18 +57,17 @@ function New-PropsFiles($ProjectGroups, $PropsFilePrefix) {
     }
 
     $document.Save($filePath) | Out-Null
+    Write-Output $propsFilePath
   }
 }
 
 function Get-ProjectsWithAutorest() {
-  Push-Location $SdkForNetPath
   $sdkProjects = Get-Item "$SdkForNetPath/sdk/*/*/src/*.csproj"
 
   [array]$projects = $sdkProjects
   | Where-Object { (Join-Path $_.DirectoryName 'autorest.md'| Test-Path -PathType Leaf) -or (Join-Path $_.DirectoryName '../tsp-location.yaml'| Test-Path -PathType Leaf)  }
   | Select-Object -ExpandProperty FullName
 
-  Pop-Location
   return ,$projects
 }
 
@@ -93,3 +91,6 @@ $projectGroups = Split-Items -Items $projects
 $propsFiles = New-PropsFiles -ProjectGroups $projectGroups -PropsFilePrefix 'projects_'
 $matrix = New-Matrix -PropsFiles $propsFiles
 Write-JsonVariable "matrix" $matrix
+
+Write-Output "Matrix:"
+Write-Output (ConvertTo-Json $matrix -Depth 100)

--- a/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
+++ b/eng/GenerateSdkForNetCodeGenerationMatrix.ps1
@@ -1,0 +1,101 @@
+[CmdLetBinding()]
+param (
+  [Parameter()]
+  [string]$SdkForNetPath,
+    
+  [Parameter()]
+  [int]$GroupCount,
+
+  [Parameter()]
+  [string]$OutputFolder
+)
+
+# Divide the items into groups of approximately equal size.
+function Split-Items([array]$Items) {
+  # given $Items.Length = 22 and $GroupCount = 5
+  # then $itemsPerGroup = 4
+  # and $largeGroupCount = 2
+  # and $group.Length = 5, 5, 4, 4, 4
+  $itemsPerGroup = [math]::Floor($Items.Length / $GroupCount)
+  $largeGroupCount = $Items.Length % $itemsPerGroup
+  $groups = [object[]]::new($GroupCount)
+
+  $i = 0
+  for($g = 0;$g -lt $GroupCount;$g++) {
+    $groupLength = if($g -lt $largeGroupCount) { $itemsPerGroup + 1 } else { $itemsPerGroup }
+    $group = [string[]]::new($groupLength)
+    $groups[$g] = $group
+    for($gi = 0;$gi -lt $groupLength;$gi++) {
+      $group[$gi] = $Items[$i++]
+    }
+  }
+
+  return ,$groups
+}
+
+# Write each project group into a props file and return the array of generated project file paths
+function New-PropsFiles($ProjectGroups, $PropsFilePrefix) {
+  if (!$ProjectGroups -or !$ProjectGroups[0]) {
+    Throw "There should be some project files in the group. Please check the given project list."
+  }
+
+  Push-Location $SdkForNetPath
+
+  $numOfGroups = $ProjectGroups.Count
+
+  for ($i = 0; $i -lt $numOfGroups; $i++) {
+    $propsFilePath = "$PropsFilePrefix$i.props"
+    $filePath = Join-Path $OutputFolder $propsFilePath
+    # Retain the structure without ProjectReference.
+    $document=[xml]'<Project></Project>'
+    $projectNode = $document.SelectNodes("/Project")
+    $itemGroupNode = $projectNode.AppendChild($document.CreateElement("ItemGroup"))
+    foreach($projectPath in $ProjectGroups[$i]) {
+      $rootedPath = $projectPath.Replace($SdkForNetPath, '$(RepoRoot)', 'OrdinalIgnoreCase')
+      $newElem = $document.CreateElement("ProjectReference")
+      $newElemAttr = $document.CreateAttribute("Include")
+      $newElemAttr.InnerText = $rootedPath
+      $newElem.Attributes.Append($newElemAttr) | Out-Null
+      $itemGroupNode.AppendChild($newElem) | Out-Null
+    }
+
+    $document.Save($filePath) | Out-Null
+    Write-Output $propsFilePath
+  }
+
+  Pop-Location
+}
+
+function Get-ProjectsWithAutorest() {
+  Push-Location $SdkForNetPath
+  $sdkProjects = Get-Item "$SdkForNetPath/sdk/*/*/src/*.csproj"
+
+  [array]$projects = $sdkProjects
+  | Where-Object { (Join-Path $_.DirectoryName 'autorest.md'| Test-Path -PathType Leaf) -or (Join-Path $_.DirectoryName '../tsp-location.yaml'| Test-Path -PathType Leaf)  }
+  | Select-Object -ExpandProperty FullName
+
+  Pop-Location
+  return ,$projects
+}
+
+function New-Matrix([array]$PropsFiles) {
+  $matrix = [ordered]@{}
+  for($i=0;$i -lt $PropsFiles.Length;$i++) {
+    $matrix["Set_$i"] = @{ 'ProjectListOverrideFile' = $PropsFiles[$i] }
+  }
+  return $matrix
+}
+
+function Write-JsonVariable($VariableName, $Value) {
+  $compressed = ConvertTo-Json $Value -Depth 100 -Compress
+  Write-Output "##vso[task.setVariable variable=$VariableName;isOutput=true]$compressed"
+}
+
+New-Item -Path $OutputFolder -ItemType "directory" -Force | Out-Null
+
+$projects = Get-ProjectsWithAutorest
+$projectGroups = Split-Items -Items $projects
+$propsFiles = New-PropsFiles -ProjectGroups $projectGroups -PropsFilePrefix 'projects_'
+$matrix = New-Matrix -PropsFiles $propsFiles
+Write-JsonVariable "matrix" $matrix
+Write-JsonVariable "matrix-dependsOn" $matrix.Keys

--- a/eng/UpdateAzureSdkCodes.ps1
+++ b/eng/UpdateAzureSdkCodes.ps1
@@ -3,26 +3,44 @@ param(
     [string]$SdkRepoRoot,
 
     [string[]]$ServiceDirectoryFilters = @("*"),
+
+    [string]$ProjectListOverrideFile = '',
     
     [switch]$ShowSummary
-    )
+)
 
 $ErrorActionPreference = 'Stop'
 
 Write-Host "Generating Azure SDK Codes..."
-foreach ($filter in $ServiceDirectoryFilters) {
-    Write-Host 'Generating projects under service directory ' -ForegroundColor Green -NoNewline
-    Write-Host "$filter" -ForegroundColor Yellow
-    if ($ShowSummary)
-    {
-        dotnet msbuild /restore /t:GenerateCode /p:ServiceDirectory=$filter /v:n /ds "$SdkRepoRoot\eng\service.proj"
+if($ProjectListOverrideFile) {
+    Write-Host 'Generating projects in override file ' -ForegroundColor Green -NoNewline
+    Write-Host "$ProjectListOverrideFile" -ForegroundColor Yellow
+    if ($ShowSummary) {
+        dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$ProjectListOverrideFile /v:n /ds "$SdkRepoRoot\eng\service.proj"
     }
-    else
-    {
-        dotnet msbuild /restore /t:GenerateCode /p:ServiceDirectory=$filter "$SdkRepoRoot\eng\service.proj"
+    else {
+        dotnet msbuild /restore /t:GenerateCode /p:ProjectListOverrideFile=$ProjectListOverrideFile "$SdkRepoRoot\eng\service.proj"
     }
     if ($LastExitCode -ne 0) {
         Write-Error 'Generation error'
         exit 1
+    }
+}
+else {
+    foreach ($filter in $ServiceDirectoryFilters) {
+        Write-Host 'Generating projects under service directory ' -ForegroundColor Green -NoNewline
+        Write-Host "$filter" -ForegroundColor Yellow
+        if ($ShowSummary)
+        {
+            dotnet msbuild /restore /t:GenerateCode /p:ServiceDirectory=$filter /v:n /ds "$SdkRepoRoot\eng\service.proj"
+        }
+        else
+        {
+            dotnet msbuild /restore /t:GenerateCode /p:ServiceDirectory=$filter "$SdkRepoRoot\eng\service.proj"
+        }
+        if ($LastExitCode -ne 0) {
+            Write-Error 'Generation error'
+            exit 1
+        }
     }
 }

--- a/eng/UpdateAzureSdkForNet.ps1
+++ b/eng/UpdateAzureSdkForNet.ps1
@@ -10,6 +10,8 @@ param(
     
     [string[]]$ServiceDirectoryFilters = @("*"),
 
+    [string]$ProjectListOverrideFile,
+
     [switch]$ShowSummary,
 
     [bool]$UseInternalFeed = $false)
@@ -18,4 +20,4 @@ $ErrorActionPreference = 'Stop'
 
 Invoke-Expression "$PSScriptRoot\UpdateGeneratorMetadata.ps1 -AutorestCSharpVersion $AutorestCSharpVersion -CadlEmitterVersion $CadlEmitterVersion -SdkRepoRoot $SdkRepoRoot -UseInternalFeed `$$UseInternalFeed"
 
-Invoke-Expression "$PSScriptRoot\UpdateAzureSdkCodes.ps1 -SdkRepoRoot $SdkRepoRoot -ServiceDirectoryFilters $($ServiceDirectoryFilters -Join ',') $(if ($ShowSummary) {'-ShowSummary'})"
+Invoke-Expression "$PSScriptRoot\UpdateAzureSdkCodes.ps1 -SdkRepoRoot $SdkRepoRoot -ServiceDirectoryFilters $($ServiceDirectoryFilters -Join ',') -ProjectListOverrideFile $ProjectListOverrideFile $(if ($ShowSummary) {'-ShowSummary'})"

--- a/eng/UpdateAzureSdkSamples.ps1
+++ b/eng/UpdateAzureSdkSamples.ps1
@@ -3,6 +3,8 @@ param(
     [string]$SdkRepoRoot,
 
     [string[]]$ServiceDirectoryFilters = @("*"),
+
+    [string]$ProjectListOverrideFile = '',
     
     [switch]$ShowSummary
     )
@@ -10,17 +12,33 @@ param(
 $ErrorActionPreference = 'Stop'
 
 Write-Host "Generating Azure SDK Samples..."
-foreach ($filter in $ServiceDirectoryFilters) {
-    Write-Host 'Generating projects under service directory ' -ForegroundColor Green -NoNewline
-    Write-Host "$filter" -ForegroundColor Yellow
+if($ProjectListOverrideFile) {
+    Write-Host 'Generating projects in override file ' -ForegroundColor Green -NoNewline
+    Write-Host "$ProjectListOverrideFile" -ForegroundColor Yellow
     if ($ShowSummary) {
-        dotnet msbuild /restore /t:GenerateTests /p:ServiceDirectory=$filter /v:n /ds "$SdkRepoRoot\eng\service.proj"
+        dotnet msbuild /restore /t:GenerateTests /p:ProjectListOverrideFile=$ProjectListOverrideFile /v:n /ds "$SdkRepoRoot\eng\service.proj"
     }
     else {
-        dotnet msbuild /restore /t:GenerateTests /p:ServiceDirectory=$filter "$SdkRepoRoot\eng\service.proj"
+        dotnet msbuild /restore /t:GenerateTests /p:ProjectListOverrideFile=$ProjectListOverrideFile "$SdkRepoRoot\eng\service.proj"
     }
     if ($LastExitCode -ne 0) {
         Write-Error 'Generation error'
         exit 1
+    }
+}
+else {
+    foreach ($filter in $ServiceDirectoryFilters) {
+        Write-Host 'Generating projects under service directory ' -ForegroundColor Green -NoNewline
+        Write-Host "$filter" -ForegroundColor Yellow
+        if ($ShowSummary) {
+            dotnet msbuild /restore /t:GenerateTests /p:ServiceDirectory=$filter /v:n /ds "$SdkRepoRoot\eng\service.proj"
+        }
+        else {
+            dotnet msbuild /restore /t:GenerateTests /p:ServiceDirectory=$filter "$SdkRepoRoot\eng\service.proj"
+        }
+        if ($LastExitCode -ne 0) {
+            Write-Error 'Generation error'
+            exit 1
+        }
     }
 }

--- a/eng/pipelines/generate-sdk-job-matrix-files.yml
+++ b/eng/pipelines/generate-sdk-job-matrix-files.yml
@@ -1,0 +1,31 @@
+parameters:
+  JobCount: 0
+  Name: ""
+  
+jobs:
+- job: ${{ parameters.Name }}
+  timeoutInMinutes: 60
+  pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
+    vmImage: ubuntu-20.04
+  
+  steps:
+  - checkout: self
+    fetchDepth: 1
+  - checkout: azure-sdk-tools
+    fetchDepth: 1
+  - template: eng/common/pipelines/templates/steps/sparse-checkout.yml@azure-sdk-tools
+    parameters:
+      Paths:
+      - "/*"
+      - "!SessionRecords"
+      Repositories:
+      - Name: Azure/azure-sdk-for-net
+        WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
+      SkipCheckoutNone: true
+  - pwsh: ./eng/GenerateSdkForNetCodeGenerationMatrix.ps1 -SdkForNetPath $(Build.SourcesDirectory)/azure-sdk-for-net -GroupCount ${{ parameters.JobCount }} -OutputFolder $(System.DefaultWorkingDirectory)/output
+    displayName: "Generate Matrix Files"
+    name: generate_job_matrix
+    workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
+  - publish: $(System.DefaultWorkingDirectory)/output
+    artifact: matrix-props

--- a/eng/pipelines/sdk-update.yml
+++ b/eng/pipelines/sdk-update.yml
@@ -13,7 +13,6 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
-      ref: refs/tags/azure-sdk-tools_20220404.3
 
 stages:
   - stage: 'Build_and_Publish'
@@ -86,65 +85,22 @@ stages:
           AutorestCSharpVersion: $(AutorestCSharpVersion)
           CadlEmitterVersion: $(CadlEmitterVersion)
           IsInternalFeed: true
+      - template: generate-sdk-job-matrix-files.yml
+        parameters:
+          Name: GenerateJobMatrix
+          JobCount: 7
       - template: update-azure-sdk-for-net-codes.yml
         parameters:
-          name: Update_Codes_A_C
-          filter: "a*,b*,c*"
+          Name: Update_Codes_
+          Matrix: $[dependencies.GenerateJobMatrix.outputs['generate_job_matrix.matrix']]
           AutorestCSharpVersion: $(AutorestCSharpVersion)
           CadlEmitterVersion: $(CadlEmitterVersion)
           IsInternalFeed: true
-      - template: update-azure-sdk-for-net-codes.yml
-        parameters:
-          name: Update_Codes_D_E
-          filter: "d*,e*"
-          AutorestCSharpVersion: $(AutorestCSharpVersion)
-          CadlEmitterVersion: $(CadlEmitterVersion)
-          IsInternalFeed: true
-      - template: update-azure-sdk-for-net-codes.yml
-        parameters:
-          name: Update_Codes_F_L
-          filter: "f*,g*,h*,i*,j*,k*,l*"
-          AutorestCSharpVersion: $(AutorestCSharpVersion)
-          CadlEmitterVersion: $(CadlEmitterVersion)
-          IsInternalFeed: true
-      - template: update-azure-sdk-for-net-codes.yml
-        parameters:
-          name: Update_Codes_M_O
-          filter: "m*,n*,o*"
-          AutorestCSharpVersion: $(AutorestCSharpVersion)
-          CadlEmitterVersion: $(CadlEmitterVersion)
-          IsInternalFeed: true
-      - template: update-azure-sdk-for-net-codes.yml
-        parameters:
-          name: Update_Codes_P_R
-          filter: "p*,q*,r*"
-          AutorestCSharpVersion: $(AutorestCSharpVersion)
-          CadlEmitterVersion: $(CadlEmitterVersion)
-          IsInternalFeed: true
-      - template: update-azure-sdk-for-net-codes.yml
-        parameters:
-          name: Update_Codes_S_U
-          filter: "s*,t*,u*"
-          AutorestCSharpVersion: $(AutorestCSharpVersion)
-          CadlEmitterVersion: $(CadlEmitterVersion)
-          IsInternalFeed: true
-      - template: update-azure-sdk-for-net-codes.yml
-        parameters:
-          name: Update_Codes_V_Z
-          filter: "v*,w*,x*,y*,z*"
-          AutorestCSharpVersion: $(AutorestCSharpVersion)
-          CadlEmitterVersion: $(CadlEmitterVersion)
-          IsInternalFeed: true
+          DependsOn: GenerateJobMatrix
       - job: Create_PR
         dependsOn: 
           - Update_Generator_Versions
-          - Update_Codes_A_C
-          - Update_Codes_D_E
-          - Update_Codes_F_L
-          - Update_Codes_M_O
-          - Update_Codes_P_R
-          - Update_Codes_S_U
-          - Update_Codes_V_Z
+          - Update_Codes_
         steps:
           - checkout: self
             fetchDepth: 1

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: Download job matrix props files
     inputs:
       artifact: matrix-props
-      targetPath: $(Build.SourcesDirectory)/azure-sdk-for-net/matrix-props
+      targetPath: $(Build.SourcesDirectory)/azure-sdk-for-net/artifacts/matrix-props
 
   - ${{ if eq(parameters.IsInternalFeed, true) }}:
     - pwsh: ./eng/GenerateInternalNpmrc.ps1 -ContainingFolder $(Build.SourcesDirectory)/azure-sdk-for-net
@@ -59,7 +59,7 @@ jobs:
         -AutorestCSharpVersion ${{ parameters.AutorestCSharpVersion }}
         -CadlEmitterVersion ${{ parameters.CadlEmitterVersion }}
         -SdkRepoRoot $(Build.SourcesDirectory)/azure-sdk-for-net
-        -ProjectListOverrideFile matrix-props/$(ProjectListOverrideFile)
+        -ProjectListOverrideFile artifacts/matrix-props/$(ProjectListOverrideFile)
         -ShowSummary
         -UseInternalFeed $${{parameters.IsInternalFeed}}
       failOnStderr: false

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -1,29 +1,47 @@
 # Generate SDK codes
 
 parameters:
-  name: ''
-  filter: ''
+  Name: ''
   AutorestCSharpVersion: ''
   CadlEmitterVersion: ''
   IsInternalFeed: false
+  Matrix: {}
+  DependsOn: []
 
 jobs:
-- job: ${{ parameters.name }}
+- job: ${{ parameters.Name }}
   timeoutInMinutes: 60
   pool:
     name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: ubuntu-20.04
+  strategy:
+    matrix: ${{ parameters.Matrix }}
+  dependsOn: ${{ parameters.DependsOn }}
   steps:
   - checkout: self
     fetchDepth: 1
-  - checkout: azure-sdk-for-net
   - checkout: azure-sdk-tools
     fetchDepth: 1
+  - template: eng/common/pipelines/templates/steps/sparse-checkout.yml@azure-sdk-tools
+    parameters:
+      Paths:
+      - "/*"
+      - "!SessionRecords"
+      Repositories:
+      - Name: Azure/azure-sdk-for-net
+        WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
+      SkipCheckoutNone: true
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'
     inputs:
       useGlobalJson: true
       performMultiLevelLookup: true
+  - task: DownloadPipelineArtifact@2
+    displayName: Download job matrix props files
+    inputs:
+      artifact: matrix-props
+      targetPath: $(Build.SourcesDirectory)/azure-sdk-for-net/matrix-props
+
   - ${{ if eq(parameters.IsInternalFeed, true) }}:
     - pwsh: ./eng/GenerateInternalNpmrc.ps1 -ContainingFolder $(Build.SourcesDirectory)/azure-sdk-for-net
       displayName: "Generate Internal Npmrc"
@@ -33,7 +51,7 @@ jobs:
         workingFile: '$(Build.SourcesDirectory)/azure-sdk-for-net/.npmrc'
       displayName: Setup Internal NPM Auth
   - task: Powershell@2
-    displayName: Update SDK codes ${{ parameters.filter }}
+    displayName: Update SDK codes
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/autorest.csharp/eng/UpdateAzureSdkForNet.ps1
@@ -41,7 +59,7 @@ jobs:
         -AutorestCSharpVersion ${{ parameters.AutorestCSharpVersion }}
         -CadlEmitterVersion ${{ parameters.CadlEmitterVersion }}
         -SdkRepoRoot $(Build.SourcesDirectory)/azure-sdk-for-net
-        -ServiceDirectoryFilters ${{ parameters.filter}}
+        -ProjectListOverrideFile matrix-props/$(ProjectListOverrideFile)
         -ShowSummary
         -UseInternalFeed $${{parameters.IsInternalFeed}}
       failOnStderr: false


### PR DESCRIPTION
- Add script to generate props files containing sets of service projects to build
- Add job yaml for creating job matrix
- Use sparse-checkout steps from eng/common to reduce per-agent overhead
- Use override file instead of project filter when building service.proj in azure-sdk-for-net