### PR TITLE
fix the serialization duplicated check in DPG

### DIFF
--- a/samples/AnomalyDetector/src/Generated/Models/AlignPolicy.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/AlignPolicy.Serialization.cs
@@ -18,39 +18,18 @@ namespace AnomalyDetector.Models
             writer.WriteStartObject();
             if (Optional.IsDefined(AlignMode))
             {
-                if (AlignMode != null)
-                {
-                    writer.WritePropertyName("alignMode"u8);
-                    writer.WriteStringValue(AlignMode.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("alignMode");
-                }
+                writer.WritePropertyName("alignMode"u8);
+                writer.WriteStringValue(AlignMode.Value.ToSerialString());
             }
             if (Optional.IsDefined(FillNAMethod))
             {
-                if (FillNAMethod != null)
-                {
-                    writer.WritePropertyName("fillNAMethod"u8);
-                    writer.WriteStringValue(FillNAMethod.Value.ToString());
-                }
-                else
-                {
-                    writer.WriteNull("fillNAMethod");
-                }
+                writer.WritePropertyName("fillNAMethod"u8);
+                writer.WriteStringValue(FillNAMethod.Value.ToString());
             }
             if (Optional.IsDefined(PaddingValue))
             {
-                if (PaddingValue != null)
-                {
-                    writer.WritePropertyName("paddingValue"u8);
-                    writer.WriteNumberValue(PaddingValue.Value);
-                }
-                else
-                {
-                    writer.WriteNull("paddingValue");
-                }
+                writer.WritePropertyName("paddingValue"u8);
+                writer.WriteNumberValue(PaddingValue.Value);
             }
             writer.WriteEndObject();
         }
@@ -61,16 +40,15 @@ namespace AnomalyDetector.Models
             {
                 return null;
             }
-            Optional<AlignMode?> alignMode = default;
-            Optional<FillNAMethod?> fillNAMethod = default;
-            Optional<float?> paddingValue = default;
+            Optional<AlignMode> alignMode = default;
+            Optional<FillNAMethod> fillNAMethod = default;
+            Optional<float> paddingValue = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("alignMode"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        alignMode = null;
                         continue;
                     }
                     alignMode = property.Value.GetString().ToAlignMode();
@@ -80,7 +58,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        fillNAMethod = null;
                         continue;
                     }
                     fillNAMethod = new FillNAMethod(property.Value.GetString());
@@ -90,7 +67,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        paddingValue = null;
                         continue;
                     }
                     paddingValue = property.Value.GetSingle();

--- a/samples/AnomalyDetector/src/Generated/Models/AnomalyInterpretation.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/AnomalyInterpretation.Serialization.cs
@@ -20,7 +20,7 @@ namespace AnomalyDetector.Models
                 return null;
             }
             Optional<string> variable = default;
-            Optional<float?> contributionScore = default;
+            Optional<float> contributionScore = default;
             Optional<CorrelationChanges> correlationChanges = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -33,7 +33,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        contributionScore = null;
                         continue;
                     }
                     contributionScore = property.Value.GetSingle();

--- a/samples/AnomalyDetector/src/Generated/Models/ModelInfo.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/ModelInfo.Serialization.cs
@@ -22,15 +22,8 @@ namespace AnomalyDetector.Models
             writer.WriteStringValue(DataSource);
             if (Optional.IsDefined(DataSchema))
             {
-                if (DataSchema != null)
-                {
-                    writer.WritePropertyName("dataSchema"u8);
-                    writer.WriteStringValue(DataSchema.Value.ToString());
-                }
-                else
-                {
-                    writer.WriteNull("dataSchema");
-                }
+                writer.WritePropertyName("dataSchema"u8);
+                writer.WriteStringValue(DataSchema.Value.ToString());
             }
             writer.WritePropertyName("startTime"u8);
             writer.WriteStringValue(StartTime, "O");
@@ -43,15 +36,8 @@ namespace AnomalyDetector.Models
             }
             if (Optional.IsDefined(SlidingWindow))
             {
-                if (SlidingWindow != null)
-                {
-                    writer.WritePropertyName("slidingWindow"u8);
-                    writer.WriteNumberValue(SlidingWindow.Value);
-                }
-                else
-                {
-                    writer.WriteNull("slidingWindow");
-                }
+                writer.WritePropertyName("slidingWindow"u8);
+                writer.WriteNumberValue(SlidingWindow.Value);
             }
             if (Optional.IsDefined(AlignPolicy))
             {
@@ -60,15 +46,8 @@ namespace AnomalyDetector.Models
             }
             if (Optional.IsDefined(Status))
             {
-                if (Status != null)
-                {
-                    writer.WritePropertyName("status"u8);
-                    writer.WriteStringValue(Status.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("status");
-                }
+                writer.WritePropertyName("status"u8);
+                writer.WriteStringValue(Status.Value.ToSerialString());
             }
             if (Optional.IsDefined(DiagnosticsInfo))
             {
@@ -85,13 +64,13 @@ namespace AnomalyDetector.Models
                 return null;
             }
             string dataSource = default;
-            Optional<DataSchema?> dataSchema = default;
+            Optional<DataSchema> dataSchema = default;
             DateTimeOffset startTime = default;
             DateTimeOffset endTime = default;
             Optional<string> displayName = default;
-            Optional<int?> slidingWindow = default;
+            Optional<int> slidingWindow = default;
             Optional<AlignPolicy> alignPolicy = default;
-            Optional<ModelStatus?> status = default;
+            Optional<ModelStatus> status = default;
             Optional<IReadOnlyList<ErrorResponse>> errors = default;
             Optional<DiagnosticsInfo> diagnosticsInfo = default;
             foreach (var property in element.EnumerateObject())
@@ -105,7 +84,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        dataSchema = null;
                         continue;
                     }
                     dataSchema = new DataSchema(property.Value.GetString());
@@ -130,7 +108,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        slidingWindow = null;
                         continue;
                     }
                     slidingWindow = property.Value.GetInt32();
@@ -149,7 +126,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        status = null;
                         continue;
                     }
                     status = property.Value.GetString().ToModelStatus();

--- a/samples/AnomalyDetector/src/Generated/Models/TimeSeriesPoint.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/TimeSeriesPoint.Serialization.cs
@@ -17,15 +17,8 @@ namespace AnomalyDetector.Models
             writer.WriteStartObject();
             if (Optional.IsDefined(Timestamp))
             {
-                if (Timestamp != null)
-                {
-                    writer.WritePropertyName("timestamp"u8);
-                    writer.WriteStringValue(Timestamp.Value, "O");
-                }
-                else
-                {
-                    writer.WriteNull("timestamp");
-                }
+                writer.WritePropertyName("timestamp"u8);
+                writer.WriteStringValue(Timestamp.Value, "O");
             }
             writer.WritePropertyName("value"u8);
             writer.WriteNumberValue(Value);

--- a/samples/AnomalyDetector/src/Generated/Models/UnivariateChangePointDetectionOptions.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/UnivariateChangePointDetectionOptions.Serialization.cs
@@ -26,51 +26,23 @@ namespace AnomalyDetector.Models
             writer.WriteStringValue(Granularity.ToSerialString());
             if (Optional.IsDefined(CustomInterval))
             {
-                if (CustomInterval != null)
-                {
-                    writer.WritePropertyName("customInterval"u8);
-                    writer.WriteNumberValue(CustomInterval.Value);
-                }
-                else
-                {
-                    writer.WriteNull("customInterval");
-                }
+                writer.WritePropertyName("customInterval"u8);
+                writer.WriteNumberValue(CustomInterval.Value);
             }
             if (Optional.IsDefined(Period))
             {
-                if (Period != null)
-                {
-                    writer.WritePropertyName("period"u8);
-                    writer.WriteNumberValue(Period.Value);
-                }
-                else
-                {
-                    writer.WriteNull("period");
-                }
+                writer.WritePropertyName("period"u8);
+                writer.WriteNumberValue(Period.Value);
             }
             if (Optional.IsDefined(StableTrendWindow))
             {
-                if (StableTrendWindow != null)
-                {
-                    writer.WritePropertyName("stableTrendWindow"u8);
-                    writer.WriteNumberValue(StableTrendWindow.Value);
-                }
-                else
-                {
-                    writer.WriteNull("stableTrendWindow");
-                }
+                writer.WritePropertyName("stableTrendWindow"u8);
+                writer.WriteNumberValue(StableTrendWindow.Value);
             }
             if (Optional.IsDefined(Threshold))
             {
-                if (Threshold != null)
-                {
-                    writer.WritePropertyName("threshold"u8);
-                    writer.WriteNumberValue(Threshold.Value);
-                }
-                else
-                {
-                    writer.WriteNull("threshold");
-                }
+                writer.WritePropertyName("threshold"u8);
+                writer.WriteNumberValue(Threshold.Value);
             }
             writer.WriteEndObject();
         }

--- a/samples/AnomalyDetector/src/Generated/Models/UnivariateChangePointDetectionResult.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/UnivariateChangePointDetectionResult.Serialization.cs
@@ -20,7 +20,7 @@ namespace AnomalyDetector.Models
             {
                 return null;
             }
-            Optional<int?> period = default;
+            Optional<int> period = default;
             Optional<IReadOnlyList<bool>> isChangePoint = default;
             Optional<IReadOnlyList<float>> confidenceScores = default;
             foreach (var property in element.EnumerateObject())
@@ -29,7 +29,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        period = null;
                         continue;
                     }
                     period = property.Value.GetInt32();

--- a/samples/AnomalyDetector/src/Generated/Models/UnivariateDetectionOptions.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/UnivariateDetectionOptions.Serialization.cs
@@ -24,87 +24,38 @@ namespace AnomalyDetector.Models
             writer.WriteEndArray();
             if (Optional.IsDefined(Granularity))
             {
-                if (Granularity != null)
-                {
-                    writer.WritePropertyName("granularity"u8);
-                    writer.WriteStringValue(Granularity.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("granularity");
-                }
+                writer.WritePropertyName("granularity"u8);
+                writer.WriteStringValue(Granularity.Value.ToSerialString());
             }
             if (Optional.IsDefined(CustomInterval))
             {
-                if (CustomInterval != null)
-                {
-                    writer.WritePropertyName("customInterval"u8);
-                    writer.WriteNumberValue(CustomInterval.Value);
-                }
-                else
-                {
-                    writer.WriteNull("customInterval");
-                }
+                writer.WritePropertyName("customInterval"u8);
+                writer.WriteNumberValue(CustomInterval.Value);
             }
             if (Optional.IsDefined(Period))
             {
-                if (Period != null)
-                {
-                    writer.WritePropertyName("period"u8);
-                    writer.WriteNumberValue(Period.Value);
-                }
-                else
-                {
-                    writer.WriteNull("period");
-                }
+                writer.WritePropertyName("period"u8);
+                writer.WriteNumberValue(Period.Value);
             }
             if (Optional.IsDefined(MaxAnomalyRatio))
             {
-                if (MaxAnomalyRatio != null)
-                {
-                    writer.WritePropertyName("maxAnomalyRatio"u8);
-                    writer.WriteNumberValue(MaxAnomalyRatio.Value);
-                }
-                else
-                {
-                    writer.WriteNull("maxAnomalyRatio");
-                }
+                writer.WritePropertyName("maxAnomalyRatio"u8);
+                writer.WriteNumberValue(MaxAnomalyRatio.Value);
             }
             if (Optional.IsDefined(Sensitivity))
             {
-                if (Sensitivity != null)
-                {
-                    writer.WritePropertyName("sensitivity"u8);
-                    writer.WriteNumberValue(Sensitivity.Value);
-                }
-                else
-                {
-                    writer.WriteNull("sensitivity");
-                }
+                writer.WritePropertyName("sensitivity"u8);
+                writer.WriteNumberValue(Sensitivity.Value);
             }
             if (Optional.IsDefined(ImputeMode))
             {
-                if (ImputeMode != null)
-                {
-                    writer.WritePropertyName("imputeMode"u8);
-                    writer.WriteStringValue(ImputeMode.Value.ToString());
-                }
-                else
-                {
-                    writer.WriteNull("imputeMode");
-                }
+                writer.WritePropertyName("imputeMode"u8);
+                writer.WriteStringValue(ImputeMode.Value.ToString());
             }
             if (Optional.IsDefined(ImputeFixedValue))
             {
-                if (ImputeFixedValue != null)
-                {
-                    writer.WritePropertyName("imputeFixedValue"u8);
-                    writer.WriteNumberValue(ImputeFixedValue.Value);
-                }
-                else
-                {
-                    writer.WriteNull("imputeFixedValue");
-                }
+                writer.WritePropertyName("imputeFixedValue"u8);
+                writer.WriteNumberValue(ImputeFixedValue.Value);
             }
             writer.WriteEndObject();
         }

--- a/samples/AnomalyDetector/src/Generated/Models/UnivariateLastDetectionResult.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/UnivariateLastDetectionResult.Serialization.cs
@@ -27,7 +27,7 @@ namespace AnomalyDetector.Models
             bool isAnomaly = default;
             bool isNegativeAnomaly = default;
             bool isPositiveAnomaly = default;
-            Optional<float?> severity = default;
+            Optional<float> severity = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("period"u8))
@@ -74,7 +74,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        severity = null;
                         continue;
                     }
                     severity = property.Value.GetSingle();

--- a/samples/AnomalyDetector/src/Generated/Models/VariableState.Serialization.cs
+++ b/samples/AnomalyDetector/src/Generated/Models/VariableState.Serialization.cs
@@ -24,51 +24,23 @@ namespace AnomalyDetector.Models
             }
             if (Optional.IsDefined(FilledNARatio))
             {
-                if (FilledNARatio != null)
-                {
-                    writer.WritePropertyName("filledNARatio"u8);
-                    writer.WriteNumberValue(FilledNARatio.Value);
-                }
-                else
-                {
-                    writer.WriteNull("filledNARatio");
-                }
+                writer.WritePropertyName("filledNARatio"u8);
+                writer.WriteNumberValue(FilledNARatio.Value);
             }
             if (Optional.IsDefined(EffectiveCount))
             {
-                if (EffectiveCount != null)
-                {
-                    writer.WritePropertyName("effectiveCount"u8);
-                    writer.WriteNumberValue(EffectiveCount.Value);
-                }
-                else
-                {
-                    writer.WriteNull("effectiveCount");
-                }
+                writer.WritePropertyName("effectiveCount"u8);
+                writer.WriteNumberValue(EffectiveCount.Value);
             }
             if (Optional.IsDefined(FirstTimestamp))
             {
-                if (FirstTimestamp != null)
-                {
-                    writer.WritePropertyName("firstTimestamp"u8);
-                    writer.WriteStringValue(FirstTimestamp.Value, "O");
-                }
-                else
-                {
-                    writer.WriteNull("firstTimestamp");
-                }
+                writer.WritePropertyName("firstTimestamp"u8);
+                writer.WriteStringValue(FirstTimestamp.Value, "O");
             }
             if (Optional.IsDefined(LastTimestamp))
             {
-                if (LastTimestamp != null)
-                {
-                    writer.WritePropertyName("lastTimestamp"u8);
-                    writer.WriteStringValue(LastTimestamp.Value, "O");
-                }
-                else
-                {
-                    writer.WriteNull("lastTimestamp");
-                }
+                writer.WritePropertyName("lastTimestamp"u8);
+                writer.WriteStringValue(LastTimestamp.Value, "O");
             }
             writer.WriteEndObject();
         }
@@ -80,10 +52,10 @@ namespace AnomalyDetector.Models
                 return null;
             }
             Optional<string> variable = default;
-            Optional<float?> filledNARatio = default;
-            Optional<int?> effectiveCount = default;
-            Optional<DateTimeOffset?> firstTimestamp = default;
-            Optional<DateTimeOffset?> lastTimestamp = default;
+            Optional<float> filledNARatio = default;
+            Optional<int> effectiveCount = default;
+            Optional<DateTimeOffset> firstTimestamp = default;
+            Optional<DateTimeOffset> lastTimestamp = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("variable"u8))
@@ -95,7 +67,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        filledNARatio = null;
                         continue;
                     }
                     filledNARatio = property.Value.GetSingle();
@@ -105,7 +76,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        effectiveCount = null;
                         continue;
                     }
                     effectiveCount = property.Value.GetInt32();
@@ -115,7 +85,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        firstTimestamp = null;
                         continue;
                     }
                     firstTimestamp = property.Value.GetDateTimeOffset("O");
@@ -125,7 +94,6 @@ namespace AnomalyDetector.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        lastTimestamp = null;
                         continue;
                     }
                     lastTimestamp = property.Value.GetDateTimeOffset("O");

--- a/src/AutoRest.CSharp/Common/Output/Models/FieldDeclaration.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/FieldDeclaration.cs
@@ -8,15 +8,39 @@ using AutoRest.CSharp.Output.Models.Serialization;
 
 namespace AutoRest.CSharp.Output.Models
 {
-    internal record FieldDeclaration(FormattableString? Description, FieldModifiers Modifiers, CSharpType Type, CodeWriterDeclaration Declaration, FormattableString? DefaultValue, bool IsRequired, SerializationFormat SerializationFormat, bool IsField = false, bool WriteAsProperty = false, FieldModifiers? GetterModifiers = null, FieldModifiers? SetterModifiers = null)
+    internal record FieldDeclaration(FormattableString? Description, FieldModifiers Modifiers, CSharpType Type, CSharpType ValueType, CodeWriterDeclaration Declaration, FormattableString? DefaultValue, bool IsRequired, SerializationFormat SerializationFormat, bool IsField = false, bool WriteAsProperty = false, FieldModifiers? GetterModifiers = null, FieldModifiers? SetterModifiers = null)
     {
         public string Name => Declaration.ActualName;
         public string Accessibility => (Modifiers & FieldModifiers.Public) > 0 ? "public" : "internal";
 
-        public FieldDeclaration(FieldModifiers modifiers, CSharpType type, string name, bool writeAsProperty = false) : this(null, modifiers, type, name, SerializationFormat.Default, writeAsProperty: writeAsProperty) { }
-        public FieldDeclaration(FieldModifiers modifiers, CSharpType type, string name, FormattableString? defaultValue, SerializationFormat serializationFormat, bool writeAsProperty = false) : this(null, modifiers, type, name, defaultValue, false, serializationFormat, writeAsProperty: writeAsProperty) { }
-        public FieldDeclaration(FormattableString? description, FieldModifiers modifiers, CSharpType type, string name, SerializationFormat serializationFormat, bool writeAsProperty = false) : this(description, modifiers, type, new CodeWriterDeclaration(name), null, false, serializationFormat, false, writeAsProperty) { }
-        public FieldDeclaration(FormattableString? description, FieldModifiers modifiers, CSharpType type, string name, FormattableString? defaultValue, bool isRequired, SerializationFormat serializationFormat, bool isField = false, bool writeAsProperty = false) : this(description, modifiers, type, new CodeWriterDeclaration(name), defaultValue, isRequired, serializationFormat, isField, writeAsProperty) { }
+        public FieldDeclaration(FieldModifiers modifiers, CSharpType type, string name, bool writeAsProperty = false)
+            : this(null, modifiers, type, name, SerializationFormat.Default, writeAsProperty: writeAsProperty) { }
+        public FieldDeclaration(FieldModifiers modifiers, CSharpType type, string name, FormattableString? defaultValue, SerializationFormat serializationFormat, bool writeAsProperty = false)
+            : this(Description: null,
+                  Modifiers: modifiers,
+                  Type: type,
+                  ValueType: type,
+                  Declaration: new CodeWriterDeclaration(name),
+                  DefaultValue: defaultValue,
+                  IsRequired: false,
+                  SerializationFormat: serializationFormat,
+                  IsField: false,
+                  WriteAsProperty: writeAsProperty,
+                  GetterModifiers: null,
+                  SetterModifiers: null)
+        { }
+        public FieldDeclaration(FormattableString? description, FieldModifiers modifiers, CSharpType type, string name, SerializationFormat serializationFormat, bool writeAsProperty = false)
+            : this(Description: description,
+                  Modifiers: modifiers,
+                  Type: type,
+                  ValueType: type,
+                  Declaration: new CodeWriterDeclaration(name),
+                  DefaultValue: null,
+                  IsRequired: false,
+                  SerializationFormat: serializationFormat,
+                  IsField: false,
+                  WriteAsProperty: writeAsProperty)
+        { }
     }
 
     [Flags]

--- a/src/AutoRest.CSharp/Common/Output/Models/FieldDeclaration.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/FieldDeclaration.cs
@@ -14,7 +14,14 @@ namespace AutoRest.CSharp.Output.Models
         public string Accessibility => (Modifiers & FieldModifiers.Public) > 0 ? "public" : "internal";
 
         public FieldDeclaration(FieldModifiers modifiers, CSharpType type, string name, bool writeAsProperty = false)
-            : this(null, modifiers, type, name, SerializationFormat.Default, writeAsProperty: writeAsProperty) { }
+            : this(description: null,
+                  modifiers: modifiers,
+                  type: type,
+                  name: name,
+                  serializationFormat: SerializationFormat.Default,
+                  writeAsProperty: writeAsProperty)
+        { }
+
         public FieldDeclaration(FieldModifiers modifiers, CSharpType type, string name, FormattableString? defaultValue, SerializationFormat serializationFormat, bool writeAsProperty = false)
             : this(Description: null,
                   Modifiers: modifiers,
@@ -29,6 +36,7 @@ namespace AutoRest.CSharp.Output.Models
                   GetterModifiers: null,
                   SetterModifiers: null)
         { }
+
         public FieldDeclaration(FormattableString? description, FieldModifiers modifiers, CSharpType type, string name, SerializationFormat serializationFormat, bool writeAsProperty = false)
             : this(Description: description,
                   Modifiers: modifiers,

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
@@ -156,6 +156,11 @@ namespace AutoRest.CSharp.Output.Models.Types
             CodeWriterDeclaration declaration = new CodeWriterDeclaration(existingMember.Name);
             declaration.SetActualName(existingMember.Name);
 
+            // TODO -- come up a way to get the value type from customized code
+            // when creating field from existing member (customized code), here we use the same type as its value type.
+            // for 2 reasons:
+            // 1. it works
+            // 2. we do not really have an efficiant way to get the value type of a property because we really cannot relying on the information in the schema when you have to do a customization, and from the csharp code, there is a lot of information we cannot get.
             return new FieldDeclaration($"Must be removed by post-generation processing,", fieldModifiers, fieldType, fieldType, declaration, GetPropertyDefaultValue(originalType, inputModelProperty), inputModelProperty.IsRequired, inputModelProperty.SerializationFormat, existingMember is IFieldSymbol, writeAsProperty);
         }
 

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
@@ -42,7 +42,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             {
                 var originalFieldName = discriminator.ToCleanName();
                 var inputModelProperty = new InputModelProperty(discriminator, discriminator, "Discriminator", InputPrimitiveType.String, true, false, true);
-                var field = CreateField(originalFieldName, typeof(string), inputModel, inputModelProperty);
+                var field = CreateField(originalFieldName, typeof(string), typeof(string), inputModel, inputModelProperty);
                 fields.Add(field);
                 fieldsToInputs[field] = inputModelProperty;
                 var parameter = Parameter.FromModelProperty(inputModelProperty, field.Name.ToVariableName(), field.Type);
@@ -53,12 +53,12 @@ namespace AutoRest.CSharp.Output.Models.Types
             foreach (var inputModelProperty in inputModel.Properties)
             {
                 var originalFieldName = inputModelProperty.Name.ToCleanName();
-                var originalFieldType = GetPropertyDefaultType(inputModel.Usage, inputModelProperty, typeFactory);
+                var (originalFieldType, fieldValueType) = GetPropertyDefaultType(inputModel.Usage, inputModelProperty, typeFactory);
 
                 var existingMember = sourceTypeMapping?.GetForMember(originalFieldName)?.ExistingMember;
                 var field = existingMember is not null
                     ? CreateFieldFromExisting(existingMember, originalFieldType, inputModel, inputModelProperty, typeFactory)
-                    : CreateField(originalFieldName, originalFieldType, inputModel, inputModelProperty);
+                    : CreateField(originalFieldName, originalFieldType, fieldValueType, inputModel, inputModelProperty);
 
                 fields.Add(field);
                 fieldsToInputs[field] = inputModelProperty;
@@ -91,7 +91,7 @@ namespace AutoRest.CSharp.Output.Models.Types
         public IEnumerator<FieldDeclaration> GetEnumerator() => _fields.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        private static FieldDeclaration CreateField(string fieldName, CSharpType fieldType, InputModelType inputModel, InputModelProperty inputModelProperty)
+        private static FieldDeclaration CreateField(string fieldName, CSharpType fieldType, CSharpType fieldValueType, InputModelType inputModel, InputModelProperty inputModelProperty)
         {
             var propertyIsCollection = inputModelProperty.Type is InputDictionaryType or InputListType ||
                 // This is a temporary work around as we don't convert collection type to InputListType or InputDictionaryType in MPG for now
@@ -122,6 +122,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                 $"{inputModelProperty.Description}",
                 fieldModifiers,
                 fieldType,
+                fieldValueType,
                 declaration,
                 GetPropertyDefaultValue(fieldType, inputModelProperty),
                 inputModelProperty.IsRequired,
@@ -155,25 +156,26 @@ namespace AutoRest.CSharp.Output.Models.Types
             CodeWriterDeclaration declaration = new CodeWriterDeclaration(existingMember.Name);
             declaration.SetActualName(existingMember.Name);
 
-            return new FieldDeclaration($"Must be removed by post-generation processing,", fieldModifiers, fieldType, declaration, GetPropertyDefaultValue(originalType, inputModelProperty), inputModelProperty.IsRequired, inputModelProperty.SerializationFormat, existingMember is IFieldSymbol, writeAsProperty);
+            return new FieldDeclaration($"Must be removed by post-generation processing,", fieldModifiers, fieldType, fieldType, declaration, GetPropertyDefaultValue(originalType, inputModelProperty), inputModelProperty.IsRequired, inputModelProperty.SerializationFormat, existingMember is IFieldSymbol, writeAsProperty);
         }
 
-        private static CSharpType GetPropertyDefaultType(in InputModelTypeUsage modelUsage, in InputModelProperty property, TypeFactory typeFactory)
+        private static (CSharpType PropertyType, CSharpType ValueType) GetPropertyDefaultType(in InputModelTypeUsage modelUsage, in InputModelProperty property, TypeFactory typeFactory)
         {
-            var valueType = typeFactory.CreateType(property.Type);
+            var propertyType = typeFactory.CreateType(property.Type);
 
             if (modelUsage == InputModelTypeUsage.Output ||
                 property.IsReadOnly)
             {
-                valueType = TypeFactory.GetOutputType(valueType);
+                propertyType = TypeFactory.GetOutputType(propertyType);
             }
 
-            if (valueType.IsValueType && !property.IsRequired)
+            var valueType = propertyType;
+            if (propertyType.IsValueType && !property.IsRequired)
             {
-                valueType = valueType.WithNullable(true);
+                propertyType = propertyType.WithNullable(true);
             }
 
-            return valueType;
+            return (propertyType, valueType);
         }
 
         private static FormattableString? GetPropertyDefaultValue(CSharpType propertyType, InputModelProperty inputModelProperty)

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectTypeProperty.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectTypeProperty.cs
@@ -21,6 +21,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                   isReadOnly: field.Modifiers.HasFlag(FieldModifiers.ReadOnly),
                   schemaProperty: null,
                   isRequired: field.IsRequired,
+                  valueType: field.ValueType,
                   inputModelProperty: inputModelProperty,
                   getterModifiers: field.GetterModifiers,
                   setterModifiers: field.SetterModifiers,

--- a/test/CadlRanchProjects/type/property/optional/src/Generated/Models/DatetimeProperty.Serialization.cs
+++ b/test/CadlRanchProjects/type/property/optional/src/Generated/Models/DatetimeProperty.Serialization.cs
@@ -19,15 +19,8 @@ namespace _Type.Property.Optional.Models
             writer.WriteStartObject();
             if (Azure.Core.Optional.IsDefined(Property))
             {
-                if (Property != null)
-                {
-                    writer.WritePropertyName("property"u8);
-                    writer.WriteStringValue(Property.Value, "O");
-                }
-                else
-                {
-                    writer.WriteNull("property");
-                }
+                writer.WritePropertyName("property"u8);
+                writer.WriteStringValue(Property.Value, "O");
             }
             writer.WriteEndObject();
         }
@@ -38,14 +31,13 @@ namespace _Type.Property.Optional.Models
             {
                 return null;
             }
-            Optional<DateTimeOffset?> property = default;
+            Optional<DateTimeOffset> property = default;
             foreach (var property0 in element.EnumerateObject())
             {
                 if (property0.NameEquals("property"u8))
                 {
                     if (property0.Value.ValueKind == JsonValueKind.Null || property0.Value.ValueKind == JsonValueKind.String && property0.Value.GetString().Length == 0)
                     {
-                        property = null;
                         continue;
                     }
                     property = property0.Value.GetDateTimeOffset("O");

--- a/test/CadlRanchProjects/type/property/optional/src/Generated/Models/DurationProperty.Serialization.cs
+++ b/test/CadlRanchProjects/type/property/optional/src/Generated/Models/DurationProperty.Serialization.cs
@@ -19,15 +19,8 @@ namespace _Type.Property.Optional.Models
             writer.WriteStartObject();
             if (Azure.Core.Optional.IsDefined(Property))
             {
-                if (Property != null)
-                {
-                    writer.WritePropertyName("property"u8);
-                    writer.WriteStringValue(Property.Value, "P");
-                }
-                else
-                {
-                    writer.WriteNull("property");
-                }
+                writer.WritePropertyName("property"u8);
+                writer.WriteStringValue(Property.Value, "P");
             }
             writer.WriteEndObject();
         }
@@ -38,14 +31,13 @@ namespace _Type.Property.Optional.Models
             {
                 return null;
             }
-            Optional<TimeSpan?> property = default;
+            Optional<TimeSpan> property = default;
             foreach (var property0 in element.EnumerateObject())
             {
                 if (property0.NameEquals("property"u8))
                 {
                     if (property0.Value.ValueKind == JsonValueKind.Null || property0.Value.ValueKind == JsonValueKind.String && property0.Value.GetString().Length == 0)
                     {
-                        property = null;
                         continue;
                     }
                     property = property0.Value.GetTimeSpan("P");

--- a/test/TestProjects/Customizations-Typespec/src/Generated/Models/RootModel.Serialization.cs
+++ b/test/TestProjects/Customizations-Typespec/src/Generated/Models/RootModel.Serialization.cs
@@ -38,39 +38,18 @@ namespace CustomizationsInCadl.Models
             }
             if (Optional.IsDefined(PropertyEnumToRename))
             {
-                if (PropertyEnumToRename != null)
-                {
-                    writer.WritePropertyName("propertyEnumToRename"u8);
-                    writer.WriteStringValue(PropertyEnumToRename.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("propertyEnumToRename");
-                }
+                writer.WritePropertyName("propertyEnumToRename"u8);
+                writer.WriteStringValue(PropertyEnumToRename.Value.ToSerialString());
             }
             if (Optional.IsDefined(PropertyEnumWithValueToRename))
             {
-                if (PropertyEnumWithValueToRename != null)
-                {
-                    writer.WritePropertyName("propertyEnumWithValueToRename"u8);
-                    writer.WriteStringValue(PropertyEnumWithValueToRename.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("propertyEnumWithValueToRename");
-                }
+                writer.WritePropertyName("propertyEnumWithValueToRename"u8);
+                writer.WriteStringValue(PropertyEnumWithValueToRename.Value.ToSerialString());
             }
             if (Optional.IsDefined(PropertyEnumToBeMadeExtensible))
             {
-                if (PropertyEnumToBeMadeExtensible != null)
-                {
-                    writer.WritePropertyName("propertyEnumToBeMadeExtensible"u8);
-                    writer.WriteStringValue(PropertyEnumToBeMadeExtensible.Value.ToString());
-                }
-                else
-                {
-                    writer.WriteNull("propertyEnumToBeMadeExtensible");
-                }
+                writer.WritePropertyName("propertyEnumToBeMadeExtensible"u8);
+                writer.WriteStringValue(PropertyEnumToBeMadeExtensible.Value.ToString());
             }
             writer.WriteEndObject();
         }
@@ -85,9 +64,9 @@ namespace CustomizationsInCadl.Models
             Optional<RenamedModel> propertyModelToRename = default;
             Optional<ModelToChangeNamespace> propertyModelToChangeNamespace = default;
             Optional<ModelWithCustomizedProperties> propertyModelWithCustomizedProperties = default;
-            Optional<RenamedEnum?> propertyEnumToRename = default;
-            Optional<EnumWithValueToRename?> propertyEnumWithValueToRename = default;
-            Optional<EnumToBeMadeExtensible?> propertyEnumToBeMadeExtensible = default;
+            Optional<RenamedEnum> propertyEnumToRename = default;
+            Optional<EnumWithValueToRename> propertyEnumWithValueToRename = default;
+            Optional<EnumToBeMadeExtensible> propertyEnumToBeMadeExtensible = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("propertyModelToMakeInternal"u8))
@@ -130,7 +109,6 @@ namespace CustomizationsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        propertyEnumToRename = null;
                         continue;
                     }
                     propertyEnumToRename = property.Value.GetString().ToRenamedEnum();
@@ -140,7 +118,6 @@ namespace CustomizationsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        propertyEnumWithValueToRename = null;
                         continue;
                     }
                     propertyEnumWithValueToRename = property.Value.GetString().ToEnumWithValueToRename();
@@ -150,7 +127,6 @@ namespace CustomizationsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        propertyEnumToBeMadeExtensible = null;
                         continue;
                     }
                     propertyEnumToBeMadeExtensible = new EnumToBeMadeExtensible(property.Value.GetString());

--- a/test/TestProjects/FirstTest-Typespec/src/Generated/Models/RoundTripModel.Serialization.cs
+++ b/test/TestProjects/FirstTest-Typespec/src/Generated/Models/RoundTripModel.Serialization.cs
@@ -38,15 +38,8 @@ namespace TypeSpecFirstTest.Models
             writer.WriteObjectValue(RequiredModel);
             if (Optional.IsDefined(IntExtensibleEnum))
             {
-                if (IntExtensibleEnum != null)
-                {
-                    writer.WritePropertyName("intExtensibleEnum"u8);
-                    writer.WriteNumberValue(IntExtensibleEnum.Value.ToSerialInt32());
-                }
-                else
-                {
-                    writer.WriteNull("intExtensibleEnum");
-                }
+                writer.WritePropertyName("intExtensibleEnum"u8);
+                writer.WriteNumberValue(IntExtensibleEnum.Value.ToSerialInt32());
             }
             if (Optional.IsCollectionDefined(IntExtensibleEnumCollection))
             {
@@ -60,15 +53,8 @@ namespace TypeSpecFirstTest.Models
             }
             if (Optional.IsDefined(FloatExtensibleEnum))
             {
-                if (FloatExtensibleEnum != null)
-                {
-                    writer.WritePropertyName("floatExtensibleEnum"u8);
-                    writer.WriteNumberValue(FloatExtensibleEnum.Value.ToSerialInt32());
-                }
-                else
-                {
-                    writer.WriteNull("floatExtensibleEnum");
-                }
+                writer.WritePropertyName("floatExtensibleEnum"u8);
+                writer.WriteNumberValue(FloatExtensibleEnum.Value.ToSerialInt32());
             }
             if (Optional.IsCollectionDefined(FloatExtensibleEnumCollection))
             {
@@ -82,15 +68,8 @@ namespace TypeSpecFirstTest.Models
             }
             if (Optional.IsDefined(FloatFixedEnum))
             {
-                if (FloatFixedEnum != null)
-                {
-                    writer.WritePropertyName("floatFixedEnum"u8);
-                    writer.WriteNumberValue(FloatFixedEnum.Value.ToSerialSingle());
-                }
-                else
-                {
-                    writer.WriteNull("floatFixedEnum");
-                }
+                writer.WritePropertyName("floatFixedEnum"u8);
+                writer.WriteNumberValue(FloatFixedEnum.Value.ToSerialSingle());
             }
             if (Optional.IsCollectionDefined(FloatFixedEnumCollection))
             {
@@ -104,15 +83,8 @@ namespace TypeSpecFirstTest.Models
             }
             if (Optional.IsDefined(IntFixedEnum))
             {
-                if (IntFixedEnum != null)
-                {
-                    writer.WritePropertyName("intFixedEnum"u8);
-                    writer.WriteNumberValue((int)IntFixedEnum.Value);
-                }
-                else
-                {
-                    writer.WriteNull("intFixedEnum");
-                }
+                writer.WritePropertyName("intFixedEnum"u8);
+                writer.WriteNumberValue((int)IntFixedEnum.Value);
             }
             if (Optional.IsCollectionDefined(IntFixedEnumCollection))
             {
@@ -126,15 +98,8 @@ namespace TypeSpecFirstTest.Models
             }
             if (Optional.IsDefined(StringFixedEnum))
             {
-                if (StringFixedEnum != null)
-                {
-                    writer.WritePropertyName("stringFixedEnum"u8);
-                    writer.WriteStringValue(StringFixedEnum.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("stringFixedEnum");
-                }
+                writer.WritePropertyName("stringFixedEnum"u8);
+                writer.WriteStringValue(StringFixedEnum.Value.ToSerialString());
             }
             writer.WritePropertyName("requiredUnknown"u8);
 #if NET6_0_OR_GREATER

--- a/test/TestProjects/FirstTest-Typespec/src/Generated/Models/Thing.Serialization.cs
+++ b/test/TestProjects/FirstTest-Typespec/src/Generated/Models/Thing.Serialization.cs
@@ -35,39 +35,18 @@ namespace TypeSpecFirstTest.Models
             }
             if (Optional.IsDefined(OptionalLiteralInt))
             {
-                if (OptionalLiteralInt != null)
-                {
-                    writer.WritePropertyName("optionalLiteralInt"u8);
-                    writer.WriteNumberValue(OptionalLiteralInt.Value);
-                }
-                else
-                {
-                    writer.WriteNull("optionalLiteralInt");
-                }
+                writer.WritePropertyName("optionalLiteralInt"u8);
+                writer.WriteNumberValue(OptionalLiteralInt.Value);
             }
             if (Optional.IsDefined(OptionalLiteralDouble))
             {
-                if (OptionalLiteralDouble != null)
-                {
-                    writer.WritePropertyName("optionalLiteralDouble"u8);
-                    writer.WriteNumberValue(OptionalLiteralDouble.Value);
-                }
-                else
-                {
-                    writer.WriteNull("optionalLiteralDouble");
-                }
+                writer.WritePropertyName("optionalLiteralDouble"u8);
+                writer.WriteNumberValue(OptionalLiteralDouble.Value);
             }
             if (Optional.IsDefined(OptionalLiteralBool))
             {
-                if (OptionalLiteralBool != null)
-                {
-                    writer.WritePropertyName("optionalLiteralBool"u8);
-                    writer.WriteBooleanValue(OptionalLiteralBool.Value);
-                }
-                else
-                {
-                    writer.WriteNull("optionalLiteralBool");
-                }
+                writer.WritePropertyName("optionalLiteralBool"u8);
+                writer.WriteBooleanValue(OptionalLiteralBool.Value);
             }
             writer.WritePropertyName("requiredBadDescription"u8);
             writer.WriteStringValue(RequiredBadDescription);

--- a/test/TestProjects/Models-Typespec/src/Generated/Models/RoundTripOptionalModel.Serialization.cs
+++ b/test/TestProjects/Models-Typespec/src/Generated/Models/RoundTripOptionalModel.Serialization.cs
@@ -25,15 +25,8 @@ namespace ModelsInCadl.Models
             }
             if (Optional.IsDefined(OptionalInt))
             {
-                if (OptionalInt != null)
-                {
-                    writer.WritePropertyName("optionalInt"u8);
-                    writer.WriteNumberValue(OptionalInt.Value);
-                }
-                else
-                {
-                    writer.WriteNull("optionalInt");
-                }
+                writer.WritePropertyName("optionalInt"u8);
+                writer.WriteNumberValue(OptionalInt.Value);
             }
             if (Optional.IsCollectionDefined(OptionalStringList))
             {
@@ -77,27 +70,13 @@ namespace ModelsInCadl.Models
             }
             if (Optional.IsDefined(OptionalFixedStringEnum))
             {
-                if (OptionalFixedStringEnum != null)
-                {
-                    writer.WritePropertyName("optionalFixedStringEnum"u8);
-                    writer.WriteStringValue(OptionalFixedStringEnum.Value.ToSerialString());
-                }
-                else
-                {
-                    writer.WriteNull("optionalFixedStringEnum");
-                }
+                writer.WritePropertyName("optionalFixedStringEnum"u8);
+                writer.WriteStringValue(OptionalFixedStringEnum.Value.ToSerialString());
             }
             if (Optional.IsDefined(OptionalExtensibleEnum))
             {
-                if (OptionalExtensibleEnum != null)
-                {
-                    writer.WritePropertyName("optionalExtensibleEnum"u8);
-                    writer.WriteStringValue(OptionalExtensibleEnum.Value.ToString());
-                }
-                else
-                {
-                    writer.WriteNull("optionalExtensibleEnum");
-                }
+                writer.WritePropertyName("optionalExtensibleEnum"u8);
+                writer.WriteStringValue(OptionalExtensibleEnum.Value.ToString());
             }
             if (Optional.IsCollectionDefined(OptionalIntRecord))
             {
@@ -134,27 +113,13 @@ namespace ModelsInCadl.Models
             }
             if (Optional.IsDefined(OptionalPlainDate))
             {
-                if (OptionalPlainDate != null)
-                {
-                    writer.WritePropertyName("optionalPlainDate"u8);
-                    writer.WriteStringValue(OptionalPlainDate.Value, "D");
-                }
-                else
-                {
-                    writer.WriteNull("optionalPlainDate");
-                }
+                writer.WritePropertyName("optionalPlainDate"u8);
+                writer.WriteStringValue(OptionalPlainDate.Value, "D");
             }
             if (Optional.IsDefined(OptionalPlainTime))
             {
-                if (OptionalPlainTime != null)
-                {
-                    writer.WritePropertyName("optionalPlainTime"u8);
-                    writer.WriteStringValue(OptionalPlainTime.Value, "T");
-                }
-                else
-                {
-                    writer.WriteNull("optionalPlainTime");
-                }
+                writer.WritePropertyName("optionalPlainTime"u8);
+                writer.WriteStringValue(OptionalPlainTime.Value, "T");
             }
             if (Optional.IsCollectionDefined(OptionalCollectionWithNullableIntElement))
             {
@@ -181,19 +146,19 @@ namespace ModelsInCadl.Models
                 return null;
             }
             Optional<string> optionalString = default;
-            Optional<int?> optionalInt = default;
+            Optional<int> optionalInt = default;
             Optional<IList<string>> optionalStringList = default;
             Optional<IList<int>> optionalIntList = default;
             Optional<IList<CollectionItem>> optionalModelCollection = default;
             Optional<DerivedModel> optionalModel = default;
             Optional<DerivedModelWithProperties> optionalModelWithPropertiesOnBase = default;
-            Optional<FixedStringEnum?> optionalFixedStringEnum = default;
-            Optional<ExtensibleEnum?> optionalExtensibleEnum = default;
+            Optional<FixedStringEnum> optionalFixedStringEnum = default;
+            Optional<ExtensibleEnum> optionalExtensibleEnum = default;
             Optional<IDictionary<string, int>> optionalIntRecord = default;
             Optional<IDictionary<string, string>> optionalStringRecord = default;
             Optional<IDictionary<string, RecordItem>> optionalModelRecord = default;
-            Optional<DateTimeOffset?> optionalPlainDate = default;
-            Optional<TimeSpan?> optionalPlainTime = default;
+            Optional<DateTimeOffset> optionalPlainDate = default;
+            Optional<TimeSpan> optionalPlainTime = default;
             Optional<IList<int?>> optionalCollectionWithNullableIntElement = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -206,7 +171,6 @@ namespace ModelsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalInt = null;
                         continue;
                     }
                     optionalInt = property.Value.GetInt32();
@@ -276,7 +240,6 @@ namespace ModelsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalFixedStringEnum = null;
                         continue;
                     }
                     optionalFixedStringEnum = property.Value.GetString().ToFixedStringEnum();
@@ -286,7 +249,6 @@ namespace ModelsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalExtensibleEnum = null;
                         continue;
                     }
                     optionalExtensibleEnum = new ExtensibleEnum(property.Value.GetString());
@@ -338,7 +300,6 @@ namespace ModelsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalPlainDate = null;
                         continue;
                     }
                     optionalPlainDate = property.Value.GetDateTimeOffset("D");
@@ -348,7 +309,6 @@ namespace ModelsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalPlainTime = null;
                         continue;
                     }
                     optionalPlainTime = property.Value.GetTimeSpan("T");

--- a/test/TestProjects/Models-Typespec/src/Generated/Models/RoundTripReadOnlyModel.Serialization.cs
+++ b/test/TestProjects/Models-Typespec/src/Generated/Models/RoundTripReadOnlyModel.Serialization.cs
@@ -23,7 +23,7 @@ namespace ModelsInCadl.Models
             string requiredReadonlyString = default;
             int requiredReadonlyInt = default;
             Optional<string> optionalReadonlyString = default;
-            Optional<int?> optionalReadonlyInt = default;
+            Optional<int> optionalReadonlyInt = default;
             DerivedModel requiredReadonlyModel = default;
             Optional<DerivedModel> optionalReadonlyModel = default;
             FixedStringEnum requiredReadonlyFixedStringEnum = default;
@@ -65,7 +65,6 @@ namespace ModelsInCadl.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        optionalReadonlyInt = null;
                         continue;
                     }
                     optionalReadonlyInt = property.Value.GetInt32();

--- a/test/TestProjects/Spread-Typespec/src/Generated/Models/SpreadAliasWithOptionalPropsRequest.Serialization.cs
+++ b/test/TestProjects/Spread-Typespec/src/Generated/Models/SpreadAliasWithOptionalPropsRequest.Serialization.cs
@@ -24,15 +24,8 @@ namespace Spread.Models
             }
             if (Optional.IsDefined(Age))
             {
-                if (Age != null)
-                {
-                    writer.WritePropertyName("age"u8);
-                    writer.WriteNumberValue(Age.Value);
-                }
-                else
-                {
-                    writer.WriteNull("age");
-                }
+                writer.WritePropertyName("age"u8);
+                writer.WriteNumberValue(Age.Value);
             }
             writer.WritePropertyName("items"u8);
             writer.WriteStartArray();


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/3418

# Description

Now our serialization code in DPG is doing something like this when the type of this property is a nullable value type:
```csharp
        if (Optional.IsDefined(OptionalInt))
        {
            if (OptionalInt != null)
            {
                writer.WritePropertyName("optionalInt"u8);
                writer.WriteNumberValue(OptionalInt.Value);
            }
            else
            {
                writer.WriteNull("optionalInt");
            }
        }
```

The inner check is redundant, and the else branch is unreachable. Because the implementation of Optional.IsDefined for a nullable struct is just
```csharp
        public static bool IsDefined<T>(T? value) where T: struct
        {
            return value.HasValue;
        }
```
`OptionalInt.HasValue` and `OptionalInt != null` are identical, therefore the above code is actually:
```csharp
        if (OptionalInt != null)
        {
            if (OptionalInt != null)
            {
                writer.WritePropertyName("optionalInt"u8);
                writer.WriteNumberValue(OptionalInt.Value);
            }
            else
            {
                writer.WriteNull("optionalInt");
            }
        }
```
And we could simplify it to:
```csharp
        if (Optional.IsDefined(OptionalInt))
        {
                writer.WritePropertyName("optionalInt"u8);
                writer.WriteNumberValue(OptionalInt.Value);
        }
```
This is all the changes we have in the generated code.

The reason why we have this issue is that in mgmt/HLC's model generation, we are distinguish `property.Declaration.Type` and `property.ValueType`. The declaration type is the actual type generated in the API, and the value type is the type of its value.
For an optional int, its declaration type should be `int?` and its value type is `int`.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first