### PR TITLE
Fix the serialization issue when a property with nullable type has been overridden by customization code

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProviderFields.cs
@@ -204,7 +204,19 @@ namespace AutoRest.CSharp.Output.Models.Types
             CodeWriterDeclaration declaration = new CodeWriterDeclaration(existingMember.Name);
             declaration.SetActualName(existingMember.Name);
 
-            return new FieldDeclaration($"Must be removed by post-generation processing,", fieldModifiers, fieldType, valueType, declaration, GetPropertyDefaultValue(originalType, inputModelProperty), inputModelProperty.IsRequired, inputModelProperty.SerializationFormat, existingMember is IFieldSymbol, writeAsProperty, SerializationMapping: serialization);
+            return new FieldDeclaration(
+                Description: $"Must be removed by post-generation processing,",
+                Modifiers: fieldModifiers,
+                Type: fieldType,
+                ValueType: valueType,
+                Declaration: declaration,
+                DefaultValue: GetPropertyDefaultValue(originalType, inputModelProperty),
+                IsRequired: inputModelProperty.IsRequired,
+                SerializationFormat: inputModelProperty.SerializationFormat,
+                IsField: existingMember is IFieldSymbol,
+                WriteAsProperty: writeAsProperty,
+                OptionalViaNullability: optionalViaNullability,
+                SerializationMapping: serialization);
         }
 
         private static bool IsReadOnly(ISymbol existingMember) => existingMember switch

--- a/test/TestProjects/Customizations-TypeSpec/Customizations-TypeSpec.tsp
+++ b/test/TestProjects/Customizations-TypeSpec/Customizations-TypeSpec.tsp
@@ -32,7 +32,10 @@ model ModelToMakeInternal {
 @doc("Renamed model (original name: ModelToRename)")
 model ModelToRename {
   @doc("Required int")
-  requiredInt: int32; 
+  requiredInt: int32;
+
+  @doc("Optional int")
+  optionalInt?: int32; 
 }
 
 @doc("Model moved into custom namespace")

--- a/test/TestProjects/Customizations-TypeSpec/src/Customizations/RenamedModel.cs
+++ b/test/TestProjects/Customizations-TypeSpec/src/Customizations/RenamedModel.cs
@@ -6,5 +6,9 @@ using Azure.Core;
 namespace CustomizationsInCadl.Models
 {
     [CodeGenModel("ModelToRename")]
-    public partial class RenamedModel { }
+    public partial class RenamedModel
+    {
+        /// <summary> Optional int. </summary>
+        public int? OptionalInt { get; set; }
+    }
 }

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/Docs/CustomizationsInCadlClient.xml
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/Docs/CustomizationsInCadlClient.xml
@@ -9,7 +9,10 @@ var client = new CustomizationsInCadlClient();
 
 var input = new RootModel()
 {
-    PropertyModelToRename = new RenamedModel(1234),
+    PropertyModelToRename = new RenamedModel(1234)
+{
+        OptionalInt = 1234,
+    },
     PropertyModelToChangeNamespace = new ModelToChangeNamespace(1234),
     PropertyModelWithCustomizedProperties = new ModelWithCustomizedProperties(1234, 1234, 3.14f, 1234, new TimeSpan(1, 2, 3), "<propertyToMakeString>", new JsonElement(), "<propertyToField>", new string[] 
 {
@@ -51,7 +54,10 @@ var client = new CustomizationsInCadlClient();
 
 var input = new RootModel()
 {
-    PropertyModelToRename = new RenamedModel(1234),
+    PropertyModelToRename = new RenamedModel(1234)
+{
+        OptionalInt = 1234,
+    },
     PropertyModelToChangeNamespace = new ModelToChangeNamespace(1234),
     PropertyModelWithCustomizedProperties = new ModelWithCustomizedProperties(1234, 1234, 3.14f, 1234, new TimeSpan(1, 2, 3), "<propertyToMakeString>", new JsonElement(), "<propertyToField>", new string[] 
 {
@@ -108,6 +114,7 @@ var data = new {
     },
     propertyModelToRename = new {
         requiredInt = 1234,
+        optionalInt = 1234,
     },
     propertyModelToChangeNamespace = new {
         requiredInt = 1234,
@@ -151,6 +158,7 @@ Response response = await client.RoundTripAsync(RequestContent.Create(data), new
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("propertyModelToMakeInternal").GetProperty("requiredInt").ToString());
 Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("requiredInt").ToString());
+Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("optionalInt").ToString());
 Console.WriteLine(result.GetProperty("propertyModelToChangeNamespace").GetProperty("requiredInt").ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToMakeInternal").ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToRename").ToString());
@@ -194,6 +202,7 @@ var data = new {
     },
     propertyModelToRename = new {
         requiredInt = 1234,
+        optionalInt = 1234,
     },
     propertyModelToChangeNamespace = new {
         requiredInt = 1234,
@@ -237,6 +246,7 @@ Response response = client.RoundTrip(RequestContent.Create(data), new RequestCon
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("propertyModelToMakeInternal").GetProperty("requiredInt").ToString());
 Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("requiredInt").ToString());
+Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("optionalInt").ToString());
 Console.WriteLine(result.GetProperty("propertyModelToChangeNamespace").GetProperty("requiredInt").ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToMakeInternal").ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToRename").ToString());

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/RenamedModel.Serialization.cs
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/RenamedModel.Serialization.cs
@@ -18,6 +18,11 @@ namespace CustomizationsInCadl.Models
             writer.WriteStartObject();
             writer.WritePropertyName("requiredInt"u8);
             writer.WriteNumberValue(RequiredInt);
+            if (Optional.IsDefined(OptionalInt))
+            {
+                writer.WritePropertyName("optionalInt"u8);
+                writer.WriteNumberValue(OptionalInt.Value);
+            }
             writer.WriteEndObject();
         }
 
@@ -28,6 +33,7 @@ namespace CustomizationsInCadl.Models
                 return null;
             }
             int requiredInt = default;
+            Optional<int> optionalInt = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("requiredInt"u8))
@@ -35,8 +41,17 @@ namespace CustomizationsInCadl.Models
                     requiredInt = property.Value.GetInt32();
                     continue;
                 }
+                if (property.NameEquals("optionalInt"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    optionalInt = property.Value.GetInt32();
+                    continue;
+                }
             }
-            return new RenamedModel(requiredInt);
+            return new RenamedModel(requiredInt, Optional.ToNullable(optionalInt));
         }
 
         /// <summary> Deserializes the model from a raw response. </summary>

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/RenamedModel.cs
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/RenamedModel.cs
@@ -17,6 +17,15 @@ namespace CustomizationsInCadl.Models
             RequiredInt = requiredInt;
         }
 
+        /// <summary> Initializes a new instance of RenamedModel. </summary>
+        /// <param name="requiredInt"> Required int. </param>
+        /// <param name="optionalInt"> Optional int. </param>
+        internal RenamedModel(int requiredInt, int? optionalInt)
+        {
+            RequiredInt = requiredInt;
+            OptionalInt = optionalInt;
+        }
+
         /// <summary> Required int. </summary>
         public int RequiredInt { get; set; }
     }

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/tspCodeModel.json
@@ -158,6 +158,21 @@
         "IsRequired": true,
         "IsReadOnly": false,
         "IsDiscriminator": false
+       },
+       {
+        "$id": "23",
+        "Name": "optionalInt",
+        "SerializedName": "optionalInt",
+        "Description": "Optional int",
+        "Type": {
+         "$id": "24",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsRequired": false,
+        "IsReadOnly": false,
+        "IsDiscriminator": false
        }
       ]
      },
@@ -166,12 +181,12 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "23",
+     "$id": "25",
      "Name": "propertyModelToChangeNamespace",
      "SerializedName": "propertyModelToChangeNamespace",
      "Description": "ModelToChangeNamespace",
      "Type": {
-      "$id": "24",
+      "$id": "26",
       "Name": "ModelToChangeNamespace",
       "Namespace": "CustomizationsInCadl",
       "Description": "Model moved into custom namespace",
@@ -179,12 +194,12 @@
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "25",
+        "$id": "27",
         "Name": "requiredInt",
         "SerializedName": "requiredInt",
         "Description": "Required int",
         "Type": {
-         "$id": "26",
+         "$id": "28",
          "Name": "int32",
          "Kind": "Int32",
          "IsNullable": false
@@ -200,12 +215,12 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "27",
+     "$id": "29",
      "Name": "propertyModelWithCustomizedProperties",
      "SerializedName": "propertyModelWithCustomizedProperties",
      "Description": "ModelWithCustomizedProperties",
      "Type": {
-      "$id": "28",
+      "$id": "30",
       "Name": "ModelWithCustomizedProperties",
       "Namespace": "CustomizationsInCadl",
       "Description": "Model with customized properties",
@@ -213,25 +228,10 @@
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "29",
+        "$id": "31",
         "Name": "propertyToMakeInternal",
         "SerializedName": "propertyToMakeInternal",
         "Description": "Public property made internal",
-        "Type": {
-         "$id": "30",
-         "Name": "int32",
-         "Kind": "Int32",
-         "IsNullable": false
-        },
-        "IsRequired": true,
-        "IsReadOnly": false,
-        "IsDiscriminator": false
-       },
-       {
-        "$id": "31",
-        "Name": "propertyToRename",
-        "SerializedName": "propertyToRename",
-        "Description": "Renamed property (original name: PropertyToRename)",
         "Type": {
          "$id": "32",
          "Name": "int32",
@@ -244,9 +244,9 @@
        },
        {
         "$id": "33",
-        "Name": "propertyToMakeFloat",
-        "SerializedName": "propertyToMakeFloat",
-        "Description": "Property with type changed to float (original type: int)",
+        "Name": "propertyToRename",
+        "SerializedName": "propertyToRename",
+        "Description": "Renamed property (original name: PropertyToRename)",
         "Type": {
          "$id": "34",
          "Name": "int32",
@@ -259,11 +259,26 @@
        },
        {
         "$id": "35",
+        "Name": "propertyToMakeFloat",
+        "SerializedName": "propertyToMakeFloat",
+        "Description": "Property with type changed to float (original type: int)",
+        "Type": {
+         "$id": "36",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsRequired": true,
+        "IsReadOnly": false,
+        "IsDiscriminator": false
+       },
+       {
+        "$id": "37",
         "Name": "propertyToMakeInt",
         "SerializedName": "propertyToMakeInt",
         "Description": "Property with type changed to int (original type: float)",
         "Type": {
-         "$id": "36",
+         "$id": "38",
          "Name": "float32",
          "Kind": "Float32",
          "IsNullable": false
@@ -273,12 +288,12 @@
         "IsDiscriminator": false
        },
        {
-        "$id": "37",
+        "$id": "39",
         "Name": "propertyToMakeDuration",
         "SerializedName": "propertyToMakeDuration",
         "Description": "Property with type changed to duration (original type: string)",
         "Type": {
-         "$id": "38",
+         "$id": "40",
          "Name": "string",
          "Kind": "String",
          "IsNullable": false
@@ -288,12 +303,12 @@
         "IsDiscriminator": false
        },
        {
-        "$id": "39",
+        "$id": "41",
         "Name": "propertyToMakeString",
         "SerializedName": "propertyToMakeString",
         "Description": "Property with type changed to string (original type: duration)",
         "Type": {
-         "$id": "40",
+         "$id": "42",
          "Name": "duration",
          "Kind": "DurationISO8601",
          "IsNullable": false
@@ -303,25 +318,10 @@
         "IsDiscriminator": false
        },
        {
-        "$id": "41",
+        "$id": "43",
         "Name": "propertyToMakeJsonElement",
         "SerializedName": "propertyToMakeJsonElement",
         "Description": "Property with type changed to JsonElement (original type: string)",
-        "Type": {
-         "$id": "42",
-         "Name": "string",
-         "Kind": "String",
-         "IsNullable": false
-        },
-        "IsRequired": true,
-        "IsReadOnly": false,
-        "IsDiscriminator": false
-       },
-       {
-        "$id": "43",
-        "Name": "propertyToField",
-        "SerializedName": "propertyToField",
-        "Description": "Field that replaces property (original name: PropertyToField)",
         "Type": {
          "$id": "44",
          "Name": "string",
@@ -334,14 +334,29 @@
        },
        {
         "$id": "45",
+        "Name": "propertyToField",
+        "SerializedName": "propertyToField",
+        "Description": "Field that replaces property (original name: PropertyToField)",
+        "Type": {
+         "$id": "46",
+         "Name": "string",
+         "Kind": "String",
+         "IsNullable": false
+        },
+        "IsRequired": true,
+        "IsReadOnly": false,
+        "IsDiscriminator": false
+       },
+       {
+        "$id": "47",
         "Name": "badListName",
         "SerializedName": "badListName",
         "Description": "Property renamed that is list",
         "Type": {
-         "$id": "46",
+         "$id": "48",
          "Name": "Array",
          "ElementType": {
-          "$id": "47",
+          "$id": "49",
           "Name": "string",
           "Kind": "String",
           "IsNullable": false
@@ -353,21 +368,21 @@
         "IsDiscriminator": false
        },
        {
-        "$id": "48",
+        "$id": "50",
         "Name": "badDictionaryName",
         "SerializedName": "badDictionaryName",
         "Description": "Property renamed that is dictionary",
         "Type": {
-         "$id": "49",
+         "$id": "51",
          "Name": "Dictionary",
          "KeyType": {
-          "$id": "50",
+          "$id": "52",
           "Name": "string",
           "Kind": "String",
           "IsNullable": false
          },
          "ValueType": {
-          "$id": "51",
+          "$id": "53",
           "Name": "string",
           "Kind": "String",
           "IsNullable": false
@@ -379,18 +394,18 @@
         "IsDiscriminator": false
        },
        {
-        "$id": "52",
+        "$id": "54",
         "Name": "badListOfListName",
         "SerializedName": "badListOfListName",
         "Description": "Property renamed that is listoflist",
         "Type": {
-         "$id": "53",
+         "$id": "55",
          "Name": "Array",
          "ElementType": {
-          "$id": "54",
+          "$id": "56",
           "Name": "Array",
           "ElementType": {
-           "$id": "55",
+           "$id": "57",
            "Name": "string",
            "Kind": "String",
            "IsNullable": false
@@ -404,24 +419,24 @@
         "IsDiscriminator": false
        },
        {
-        "$id": "56",
+        "$id": "58",
         "Name": "badListOfDictionaryName",
         "SerializedName": "badListOfDictionaryName",
         "Description": "Property renamed that is listofdictionary",
         "Type": {
-         "$id": "57",
+         "$id": "59",
          "Name": "Array",
          "ElementType": {
-          "$id": "58",
+          "$id": "60",
           "Name": "Dictionary",
           "KeyType": {
-           "$id": "59",
+           "$id": "61",
            "Name": "string",
            "Kind": "String",
            "IsNullable": false
           },
           "ValueType": {
-           "$id": "60",
+           "$id": "62",
            "Name": "string",
            "Kind": "String",
            "IsNullable": false
@@ -441,7 +456,7 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "61",
+     "$id": "63",
      "Name": "propertyEnumToRename",
      "SerializedName": "propertyEnumToRename",
      "Description": "EnumToRename",
@@ -453,7 +468,7 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "62",
+     "$id": "64",
      "Name": "propertyEnumWithValueToRename",
      "SerializedName": "propertyEnumWithValueToRename",
      "Description": "EnumWithValueToRename",
@@ -465,7 +480,7 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "63",
+     "$id": "65",
      "Name": "propertyEnumToBeMadeExtensible",
      "SerializedName": "propertyEnumToBeMadeExtensible",
      "Description": "EnumToBeMadeExtensible",
@@ -477,12 +492,12 @@
      "IsDiscriminator": false
     },
     {
-     "$id": "64",
+     "$id": "66",
      "Name": "propertyModelToAddAdditionalSerializableProperty",
      "SerializedName": "propertyModelToAddAdditionalSerializableProperty",
      "Description": "ModelToAddAdditionalSerializableProperty",
      "Type": {
-      "$id": "65",
+      "$id": "67",
       "Name": "ModelToAddAdditionalSerializableProperty",
       "Namespace": "CustomizationsInCadl",
       "Description": "Model to add additional serializable property",
@@ -490,12 +505,12 @@
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "66",
+        "$id": "68",
         "Name": "requiredInt",
         "SerializedName": "requiredInt",
         "Description": "Required int",
         "Type": {
-         "$id": "67",
+         "$id": "69",
          "Name": "int32",
          "Kind": "Int32",
          "IsNullable": false
@@ -519,29 +534,29 @@
    "$ref": "20"
   },
   {
-   "$ref": "24"
+   "$ref": "26"
   },
   {
-   "$ref": "28"
+   "$ref": "30"
   },
   {
-   "$ref": "65"
+   "$ref": "67"
   }
  ],
  "Clients": [
   {
-   "$id": "68",
+   "$id": "70",
    "Name": "CustomizationsInCadlClient",
    "Description": "CADL project to test various types of models.",
    "Operations": [
     {
-     "$id": "69",
+     "$id": "71",
      "Name": "roundTrip",
      "ResourceName": "CustomizationsInCadl",
      "Description": "RoundTrip operation to make RootModel round-trip",
      "Parameters": [
       {
-       "$id": "70",
+       "$id": "72",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -558,11 +573,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "71",
+       "$id": "73",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "72",
+        "$id": "74",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -577,19 +592,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "73",
+        "$id": "75",
         "Type": {
-         "$ref": "72"
+         "$ref": "74"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "74",
+       "$id": "76",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "75",
+        "$id": "77",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -604,20 +619,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "76",
+        "$id": "78",
         "Type": {
-         "$ref": "75"
+         "$ref": "77"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "77",
+       "$id": "79",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "78",
+        "$id": "80",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -632,9 +647,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "79",
+        "$id": "81",
         "Type": {
-         "$id": "80",
+         "$id": "82",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -645,7 +660,7 @@
      ],
      "Responses": [
       {
-       "$id": "81",
+       "$id": "83",
        "StatusCodes": [
         200
        ],
@@ -670,7 +685,7 @@
     }
    ],
    "Protocol": {
-    "$id": "82"
+    "$id": "84"
    },
    "Creatable": true
   }

--- a/test/TestProjects/Customizations-TypeSpec/tests/Generated/Samples/Samples_CustomizationsInCadlClient.cs
+++ b/test/TestProjects/Customizations-TypeSpec/tests/Generated/Samples/Samples_CustomizationsInCadlClient.cs
@@ -49,6 +49,7 @@ namespace CustomizationsInCadl.Samples
                 propertyModelToRename = new
                 {
                     requiredInt = 1234,
+                    optionalInt = 1234,
                 },
                 propertyModelToChangeNamespace = new
                 {
@@ -96,6 +97,7 @@ namespace CustomizationsInCadl.Samples
             JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
             Console.WriteLine(result.GetProperty("propertyModelToMakeInternal").GetProperty("requiredInt").ToString());
             Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("requiredInt").ToString());
+            Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("optionalInt").ToString());
             Console.WriteLine(result.GetProperty("propertyModelToChangeNamespace").GetProperty("requiredInt").ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToMakeInternal").ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToRename").ToString());
@@ -144,6 +146,7 @@ namespace CustomizationsInCadl.Samples
                 propertyModelToRename = new
                 {
                     requiredInt = 1234,
+                    optionalInt = 1234,
                 },
                 propertyModelToChangeNamespace = new
                 {
@@ -191,6 +194,7 @@ namespace CustomizationsInCadl.Samples
             JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
             Console.WriteLine(result.GetProperty("propertyModelToMakeInternal").GetProperty("requiredInt").ToString());
             Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("requiredInt").ToString());
+            Console.WriteLine(result.GetProperty("propertyModelToRename").GetProperty("optionalInt").ToString());
             Console.WriteLine(result.GetProperty("propertyModelToChangeNamespace").GetProperty("requiredInt").ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToMakeInternal").ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("propertyToRename").ToString());
@@ -218,7 +222,10 @@ namespace CustomizationsInCadl.Samples
 
             var input = new RootModel()
             {
-                PropertyModelToRename = new RenamedModel(1234),
+                PropertyModelToRename = new RenamedModel(1234)
+                {
+                    OptionalInt = 1234,
+                },
                 PropertyModelToChangeNamespace = new ModelToChangeNamespace(1234),
                 PropertyModelWithCustomizedProperties = new ModelWithCustomizedProperties(1234, 1234, 3.14f, 1234, new TimeSpan(1, 2, 3), "<propertyToMakeString>", new JsonElement(), "<propertyToField>", new string[]
             {

--- a/test/TestProjects/MgmtCustomizations/Customization/PetStoreProperties.cs
+++ b/test/TestProjects/MgmtCustomizations/Customization/PetStoreProperties.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+namespace MgmtCustomizations.Models
+{
+    public partial class PetStoreProperties
+    {
+        /// verifies this could work
+        public int? Order { get; set; }
+    }
+}

--- a/test/TestProjects/MgmtCustomizations/Generated/Models/PetStoreProperties.cs
+++ b/test/TestProjects/MgmtCustomizations/Generated/Models/PetStoreProperties.cs
@@ -27,9 +27,6 @@ namespace MgmtCustomizations.Models
             Order = order;
             Pet = pet;
         }
-
-        /// <summary> The order. </summary>
-        public int? Order { get; set; }
         /// <summary>
         /// A pet
         /// Please note <see cref="Pet"/> is the base class. According to the scenario, a derived class of the base class might need to be assigned here, or this property needs to be casted to one of the possible derived classes.


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/3474

# Description

It turns out the issue is caused in my last refactor around these things, I forgot to pass the `optionalViaNullability` along the way to the ObjectTypeProperty when constructing the property from an existing member.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first