### PR TITLE
Use the job name suffix in the commit message

### DIFF
--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -10,6 +10,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.Name }}
+  displayName: Update SDK Code
   timeoutInMinutes: 60
   pool:
     name: azsdk-pool-mms-ubuntu-2004-general
@@ -81,7 +82,7 @@ jobs:
     parameters:
       BaseRepoBranch: auto-update-autorest-${{ parameters.AutorestCSharpVersion }}
       BaseRepoOwner: azure-sdk
-      CommitMsg: Update SDK codes ${{ parameters.filter }}
+      CommitMsg: $(System.JobDisplayName)
       TargetRepoOwner: Azure
       TargetRepoName: azure-sdk-for-net
       WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net


### PR DESCRIPTION
Originally, the `filter` parameter was passed into the commit message for the static for_net code generation legs.   When the job was changed to use a matrix, the filter parameter was no longer used and the commit message per leg no longer referenced the leg that generated the commit.  This corrects that by putting the job name suffix, i.e. matric key, in the commit message.