### PR TITLE
Use ref from azure-sdk-for-net repo in sparse checkout

### DIFF
--- a/eng/pipelines/sdk-update.yml
+++ b/eng/pipelines/sdk-update.yml
@@ -5,9 +5,6 @@ parameters:
     type: boolean
     default: false
 
-variables:
-  NugetSecurityAnalysisWarningLevel: 'none'
-
 resources:
   repositories:
     - repository: azure-sdk-tools
@@ -25,6 +22,11 @@ resources:
       name: internal/azure-sdk-build-tools
       ref: refs/tags/azure-sdk-build-tools_20230307.1
 
+variables:
+  NugetSecurityAnalysisWarningLevel: 'none'
+  AzureSdkForNetRef: $[ resources.repositories['azure-sdk-for-net'].ref ]
+  jsonResources: $[ convertToJson(resources) ]
+
 stages:
   - stage: 'Build_and_Test'
     jobs:
@@ -34,6 +36,12 @@ stages:
           name: azsdk-pool-mms-win-2022-general
           vmImage: windows-2022
         steps:
+          - pwsh: |
+                Write-Host $env:jsonResources
+                Write-Host ''
+                gci env:* | sort-object name
+            env:
+              jsonResources: $(jsonResources)
           - checkout: self
             fetchDepth: 1
           - checkout: azure-sdk-tools
@@ -182,6 +190,7 @@ stages:
           AutorestCSharpVersion: $(AutorestCSharpVersion)
           TypeSpecEmitterVersion: $(TypeSpecEmitterVersion)
           IsInternalFeed: true
+          AzureSdkForNetCommitish: $(AzureSdkForNetRef)
           DependsOn: Generate_Job_Matrix
       - job: Create_PR
         dependsOn: 

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -30,6 +30,7 @@ jobs:
       Repositories:
       - Name: Azure/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
+        Commitish: $[ resources.repositories['azure-sdk-for-net'].ref ]
       SkipCheckoutNone: true
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -4,6 +4,7 @@ parameters:
   Name: ''
   AutorestCSharpVersion: ''
   TypeSpecEmitterVersion: ''
+  AzureSdkForNetCommitish: ''
   IsInternalFeed: false
   Matrix: {}
   DependsOn: []
@@ -30,7 +31,7 @@ jobs:
       Repositories:
       - Name: Azure/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
-        Commitish: $[ resources.repositories['azure-sdk-for-net'].ref ]
+        Commitish: ${{ parameters.AzureSdkForNetCommitish }}}
       SkipCheckoutNone: true
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'


### PR DESCRIPTION
When using the sparse checkout step, we typically don't pass a commitish.  Git then uses the repo's default branch for checkout. This breaks scenarios where we want to change the checked out commit by using the resources tab when queuing the build.  Adding the `Commitish` parameter and using the repository resource's ref corrects this.