### PR TITLE
Use static string type for buildNumber parameters

### DIFF
--- a/eng/PackEmitter.ps1
+++ b/eng/PackEmitter.ps1
@@ -1,4 +1,4 @@
-param($BuildNumber, $AutorestVersion, $StagingDirectory)
+param([string]$BuildNumber, $AutorestVersion, $StagingDirectory)
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $emitterPath = Resolve-Path (Join-Path $repoRoot 'src' 'TypeSpec.Extension' 'Emitter.Csharp')

--- a/eng/PublishRelease.ps1
+++ b/eng/PublishRelease.ps1
@@ -1,4 +1,4 @@
-param($NpmToken, $GitHubToken, $BuildNumber, $Sha, $AutorestArtifactDirectory, $typespecEmitterDirectory, $CoverageUser, $CoveragePass, $CoverageDirectory)
+param($NpmToken, $GitHubToken, [string]$BuildNumber, $Sha, $AutorestArtifactDirectory, $typespecEmitterDirectory, $CoverageUser, $CoveragePass, $CoverageDirectory)
 
 $AutorestArtifactDirectory = Resolve-Path $AutorestArtifactDirectory
 $RepoRoot = Resolve-Path "$PSScriptRoot/.."


### PR DESCRIPTION
When build numbers are passed as arguments to powershell command lines, if the receiving parameter isn't defined as type `string`, the value is passed unquoted and the value contains only digits and a decimal, then it will be parsed as a float.  This removes leading zeros and trailing zeros after the decimal.  i.e.  `something.ps1 -BuildNumber 0432.10` will be parsed as the float `432.1`.

Defining the script parameter as a string causes it to be parsed at the command line as a string.

This was previously corrected in another script, but some instances remained.