### PR TITLE
[typespec-csharp] React to Azure/typespec-azure#3177

### DIFF
--- a/src/TypeSpec.Extension/Emitter.Csharp/test/Unit/utils/TestUtil.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/test/Unit/utils/TestUtil.ts
@@ -36,6 +36,7 @@ export async function typeSpecCompile(
     needAzureCore: boolean = false
 ) {
     const namespace = `
+    @useAuth(ApiKeyAuth<ApiKeyLocation.header, "api-key">)
     @service({
       title: "Azure Csharp emitter Testing",
       version: "2023-01-01-preview",
@@ -55,7 +56,6 @@ export async function typeSpecCompile(
     using TypeSpec.Versioning;
     ${needAzureCore ? "using Azure.Core;" : ""}
     
-    ${needAzureCore && needNamespaces ? '@useAuth(AadOauth2Auth<["https://contoso.azure.com/.default"]>)' : ""}
     ${needNamespaces ? namespace : ""}
     ${content}
     `

--- a/src/TypeSpec.Extension/Emitter.Csharp/test/Unit/utils/TestUtil.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/test/Unit/utils/TestUtil.ts
@@ -55,6 +55,7 @@ export async function typeSpecCompile(
     using TypeSpec.Versioning;
     ${needAzureCore ? "using Azure.Core;" : ""}
     
+    ${needAzureCore && needNamespaces ? '@useAuth(AadOauth2Auth<["https://contoso.azure.com/.default"]>)' : ""}
     ${needNamespaces ? namespace : ""}
     ${content}
     `


### PR DESCRIPTION
- New linter rule requires specifying an authentication scheme

Autorest Regen Preview: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2887167&view=results
Autorest Regen Preview (TypeSpecNext): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2887168&view=results