### PR TITLE
[DoNotMerge] Ambiguous call with null

### DIFF
--- a/test/TestProjects/Spread-TypeSpec/Spread-TypeSpec.tsp
+++ b/test/TestProjects/Spread-TypeSpec/Spread-TypeSpec.tsp
@@ -33,10 +33,10 @@ model Thing {
 }
 
 alias ThingAlias = {
-  @doc("name of the Thing")
-  name: string;
   @doc("age of the Thing")
-  age: int32;
+  age?: int32;
+  @doc("name of the Thing")
+  name?: string;
 };
 
 alias ThingAliasWithModel = {

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/Docs/SpreadTypeSpecClient.xml
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/Docs/SpreadTypeSpecClient.xml
@@ -59,38 +59,48 @@ Console.WriteLine(response.Status);
 ]]></code>
 </example>
     </member>
-    <member name="SpreadAliasAsync(string,int,CancellationToken)">
+    <member name="SpreadAliasAsync(int?,string,CancellationToken)">
 <example>
 This sample shows how to call SpreadAliasAsync with required parameters.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
-var result = await client.SpreadAliasAsync("<name>", 1234);
+var result = await client.SpreadAliasAsync(1234, "<name>");
 ]]></code>
 </example>
     </member>
-    <member name="SpreadAlias(string,int,CancellationToken)">
+    <member name="SpreadAlias(int?,string,CancellationToken)">
 <example>
 This sample shows how to call SpreadAlias with required parameters.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
-var result = client.SpreadAlias("<name>", 1234);
+var result = client.SpreadAlias(1234, "<name>");
 ]]></code>
 </example>
     </member>
     <member name="SpreadAliasAsync(RequestContent,RequestContext)">
 <example>
-This sample shows how to call SpreadAliasAsync with required request content.
+This sample shows how to call SpreadAliasAsync.
+<code><![CDATA[
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new SpreadTypeSpecClient(endpoint);
+
+var data = new {};
+
+Response response = await client.SpreadAliasAsync(RequestContent.Create(data));
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call SpreadAliasAsync with all request content.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
 var data = new {
-    name = "<name>",
     age = 1234,
+    name = "<name>",
 };
 
 Response response = await client.SpreadAliasAsync(RequestContent.Create(data));
@@ -100,14 +110,24 @@ Console.WriteLine(response.Status);
     </member>
     <member name="SpreadAlias(RequestContent,RequestContext)">
 <example>
-This sample shows how to call SpreadAlias with required request content.
+This sample shows how to call SpreadAlias.
+<code><![CDATA[
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new SpreadTypeSpecClient(endpoint);
+
+var data = new {};
+
+Response response = client.SpreadAlias(RequestContent.Create(data));
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call SpreadAlias with all request content.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
 var data = new {
-    name = "<name>",
     age = 1234,
+    name = "<name>",
 };
 
 Response response = client.SpreadAlias(RequestContent.Create(data));
@@ -229,38 +249,48 @@ Console.WriteLine(response.Status);
 ]]></code>
 </example>
     </member>
-    <member name="SpreadAliasWithSpreadAliasAsync(string,int,string,int,CancellationToken)">
+    <member name="SpreadAliasWithSpreadAliasAsync(string,int,int?,string,CancellationToken)">
 <example>
 This sample shows how to call SpreadAliasWithSpreadAliasAsync with required parameters.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
-var result = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, "<name>", 1234);
+var result = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, 1234, "<name>");
 ]]></code>
 </example>
     </member>
-    <member name="SpreadAliasWithSpreadAlias(string,int,string,int,CancellationToken)">
+    <member name="SpreadAliasWithSpreadAlias(string,int,int?,string,CancellationToken)">
 <example>
 This sample shows how to call SpreadAliasWithSpreadAlias with required parameters.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
-var result = client.SpreadAliasWithSpreadAlias("<id>", 1234, "<name>", 1234);
+var result = client.SpreadAliasWithSpreadAlias("<id>", 1234, 1234, "<name>");
 ]]></code>
 </example>
     </member>
     <member name="SpreadAliasWithSpreadAliasAsync(string,int,RequestContent,RequestContext)">
 <example>
-This sample shows how to call SpreadAliasWithSpreadAliasAsync with required parameters and request content.
+This sample shows how to call SpreadAliasWithSpreadAliasAsync with required parameters.
+<code><![CDATA[
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new SpreadTypeSpecClient(endpoint);
+
+var data = new {};
+
+Response response = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, RequestContent.Create(data));
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call SpreadAliasWithSpreadAliasAsync with all parameters and request content.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
 var data = new {
-    name = "<name>",
     age = 1234,
+    name = "<name>",
 };
 
 Response response = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, RequestContent.Create(data));
@@ -270,14 +300,24 @@ Console.WriteLine(response.Status);
     </member>
     <member name="SpreadAliasWithSpreadAlias(string,int,RequestContent,RequestContext)">
 <example>
-This sample shows how to call SpreadAliasWithSpreadAlias with required parameters and request content.
+This sample shows how to call SpreadAliasWithSpreadAlias with required parameters.
+<code><![CDATA[
+var endpoint = new Uri("<https://my-service.azure.com>");
+var client = new SpreadTypeSpecClient(endpoint);
+
+var data = new {};
+
+Response response = client.SpreadAliasWithSpreadAlias("<id>", 1234, RequestContent.Create(data));
+Console.WriteLine(response.Status);
+]]></code>
+This sample shows how to call SpreadAliasWithSpreadAlias with all parameters and request content.
 <code><![CDATA[
 var endpoint = new Uri("<https://my-service.azure.com>");
 var client = new SpreadTypeSpecClient(endpoint);
 
 var data = new {
-    name = "<name>",
     age = 1234,
+    name = "<name>",
 };
 
 Response response = client.SpreadAliasWithSpreadAlias("<id>", 1234, RequestContent.Create(data));

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasRequest.Serialization.cs
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasRequest.Serialization.cs
@@ -15,10 +15,16 @@ namespace SpreadTypeSpec.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name);
-            writer.WritePropertyName("age"u8);
-            writer.WriteNumberValue(Age);
+            if (Optional.IsDefined(Age))
+            {
+                writer.WritePropertyName("age"u8);
+                writer.WriteNumberValue(Age.Value);
+            }
+            if (Optional.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name);
+            }
             writer.WriteEndObject();
         }
 

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasRequest.cs
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasRequest.cs
@@ -5,29 +5,28 @@
 
 #nullable disable
 
-using System;
-using Azure.Core;
-
 namespace SpreadTypeSpec.Models
 {
     /// <summary> The SpreadAliasRequest. </summary>
     internal partial class SpreadAliasRequest
     {
         /// <summary> Initializes a new instance of SpreadAliasRequest. </summary>
-        /// <param name="name"> name of the Thing. </param>
-        /// <param name="age"> age of the Thing. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
-        public SpreadAliasRequest(string name, int age)
+        public SpreadAliasRequest()
         {
-            Argument.AssertNotNull(name, nameof(name));
-
-            Name = name;
-            Age = age;
         }
 
-        /// <summary> name of the Thing. </summary>
-        public string Name { get; }
+        /// <summary> Initializes a new instance of SpreadAliasRequest. </summary>
+        /// <param name="age"> age of the Thing. </param>
+        /// <param name="name"> name of the Thing. </param>
+        internal SpreadAliasRequest(int? age, string name)
+        {
+            Age = age;
+            Name = name;
+        }
+
         /// <summary> age of the Thing. </summary>
-        public int Age { get; }
+        public int? Age { get; set; }
+        /// <summary> name of the Thing. </summary>
+        public string Name { get; set; }
     }
 }

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasWithSpreadAliasRequest.Serialization.cs
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasWithSpreadAliasRequest.Serialization.cs
@@ -15,10 +15,16 @@ namespace SpreadTypeSpec.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name);
-            writer.WritePropertyName("age"u8);
-            writer.WriteNumberValue(Age);
+            if (Optional.IsDefined(Age))
+            {
+                writer.WritePropertyName("age"u8);
+                writer.WriteNumberValue(Age.Value);
+            }
+            if (Optional.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name);
+            }
             writer.WriteEndObject();
         }
 

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasWithSpreadAliasRequest.cs
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/Models/SpreadAliasWithSpreadAliasRequest.cs
@@ -5,29 +5,28 @@
 
 #nullable disable
 
-using System;
-using Azure.Core;
-
 namespace SpreadTypeSpec.Models
 {
     /// <summary> The SpreadAliasWithSpreadAliasRequest. </summary>
     internal partial class SpreadAliasWithSpreadAliasRequest
     {
         /// <summary> Initializes a new instance of SpreadAliasWithSpreadAliasRequest. </summary>
-        /// <param name="name"> name of the Thing. </param>
-        /// <param name="age"> age of the Thing. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
-        public SpreadAliasWithSpreadAliasRequest(string name, int age)
+        public SpreadAliasWithSpreadAliasRequest()
         {
-            Argument.AssertNotNull(name, nameof(name));
-
-            Name = name;
-            Age = age;
         }
 
-        /// <summary> name of the Thing. </summary>
-        public string Name { get; }
+        /// <summary> Initializes a new instance of SpreadAliasWithSpreadAliasRequest. </summary>
+        /// <param name="age"> age of the Thing. </param>
+        /// <param name="name"> name of the Thing. </param>
+        internal SpreadAliasWithSpreadAliasRequest(int? age, string name)
+        {
+            Age = age;
+            Name = name;
+        }
+
         /// <summary> age of the Thing. </summary>
-        public int Age { get; }
+        public int? Age { get; set; }
+        /// <summary> name of the Thing. </summary>
+        public string Name { get; set; }
     }
 }

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/SpreadTypeSpecClient.cs
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/SpreadTypeSpecClient.cs
@@ -165,33 +165,35 @@ namespace SpreadTypeSpec
         }
 
         /// <summary> spread an alias as body. </summary>
-        /// <param name="name"> name of the Thing. </param>
         /// <param name="age"> age of the Thing. </param>
+        /// <param name="name"> name of the Thing. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
-        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAliasAsync(string,int,CancellationToken)']/*" />
-        public virtual async Task<Response> SpreadAliasAsync(string name, int age, CancellationToken cancellationToken = default)
+        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAliasAsync(int?,string,CancellationToken)']/*" />
+        public virtual async Task<Response> SpreadAliasAsync(int? age = null, string name = null, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
-
             RequestContext context = FromCancellationToken(cancellationToken);
-            SpreadAliasRequest spreadAliasRequest = new SpreadAliasRequest(name, age);
+            SpreadAliasRequest spreadAliasRequest = new SpreadAliasRequest()
+            {
+                Age = age,
+                Name = name
+            };
             Response response = await SpreadAliasAsync(spreadAliasRequest.ToRequestContent(), context).ConfigureAwait(false);
             return response;
         }
 
         /// <summary> spread an alias as body. </summary>
-        /// <param name="name"> name of the Thing. </param>
         /// <param name="age"> age of the Thing. </param>
+        /// <param name="name"> name of the Thing. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
-        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAlias(string,int,CancellationToken)']/*" />
-        public virtual Response SpreadAlias(string name, int age, CancellationToken cancellationToken = default)
+        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAlias(int?,string,CancellationToken)']/*" />
+        public virtual Response SpreadAlias(int? age = null, string name = null, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(name, nameof(name));
-
             RequestContext context = FromCancellationToken(cancellationToken);
-            SpreadAliasRequest spreadAliasRequest = new SpreadAliasRequest(name, age);
+            SpreadAliasRequest spreadAliasRequest = new SpreadAliasRequest()
+            {
+                Age = age,
+                Name = name
+            };
             Response response = SpreadAlias(spreadAliasRequest.ToRequestContent(), context);
             return response;
         }
@@ -206,7 +208,7 @@ namespace SpreadTypeSpec
         /// </item>
         /// <item>
         /// <description>
-        /// Please try the simpler <see cref="SpreadAliasAsync(string,int,CancellationToken)"/> convenience overload with strongly typed models first.
+        /// Please try the simpler <see cref="SpreadAliasAsync(int?,string,CancellationToken)"/> convenience overload with strongly typed models first.
         /// </description>
         /// </item>
         /// </list>
@@ -245,7 +247,7 @@ namespace SpreadTypeSpec
         /// </item>
         /// <item>
         /// <description>
-        /// Please try the simpler <see cref="SpreadAlias(string,int,CancellationToken)"/> convenience overload with strongly typed models first.
+        /// Please try the simpler <see cref="SpreadAlias(int?,string,CancellationToken)"/> convenience overload with strongly typed models first.
         /// </description>
         /// </item>
         /// </list>
@@ -525,19 +527,22 @@ namespace SpreadTypeSpec
         /// <summary> spread an alias with contains another alias property as body. </summary>
         /// <param name="id"> The String to use. </param>
         /// <param name="top"> The Int32 to use. </param>
-        /// <param name="name"> name of the Thing. </param>
         /// <param name="age"> age of the Thing. </param>
+        /// <param name="name"> name of the Thing. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="id"/> or <paramref name="name"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="id"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAliasWithSpreadAliasAsync(string,int,string,int,CancellationToken)']/*" />
-        public virtual async Task<Response> SpreadAliasWithSpreadAliasAsync(string id, int top, string name, int age, CancellationToken cancellationToken = default)
+        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAliasWithSpreadAliasAsync(string,int,int?,string,CancellationToken)']/*" />
+        public virtual async Task<Response> SpreadAliasWithSpreadAliasAsync(string id, int top, int? age = null, string name = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(id, nameof(id));
-            Argument.AssertNotNull(name, nameof(name));
 
             RequestContext context = FromCancellationToken(cancellationToken);
-            SpreadAliasWithSpreadAliasRequest spreadAliasWithSpreadAliasRequest = new SpreadAliasWithSpreadAliasRequest(name, age);
+            SpreadAliasWithSpreadAliasRequest spreadAliasWithSpreadAliasRequest = new SpreadAliasWithSpreadAliasRequest()
+            {
+                Age = age,
+                Name = name
+            };
             Response response = await SpreadAliasWithSpreadAliasAsync(id, top, spreadAliasWithSpreadAliasRequest.ToRequestContent(), context).ConfigureAwait(false);
             return response;
         }
@@ -545,19 +550,22 @@ namespace SpreadTypeSpec
         /// <summary> spread an alias with contains another alias property as body. </summary>
         /// <param name="id"> The String to use. </param>
         /// <param name="top"> The Int32 to use. </param>
-        /// <param name="name"> name of the Thing. </param>
         /// <param name="age"> age of the Thing. </param>
+        /// <param name="name"> name of the Thing. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="id"/> or <paramref name="name"/> is null. </exception>
+        /// <exception cref="ArgumentNullException"> <paramref name="id"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="id"/> is an empty string, and was expected to be non-empty. </exception>
-        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAliasWithSpreadAlias(string,int,string,int,CancellationToken)']/*" />
-        public virtual Response SpreadAliasWithSpreadAlias(string id, int top, string name, int age, CancellationToken cancellationToken = default)
+        /// <include file="Docs/SpreadTypeSpecClient.xml" path="doc/members/member[@name='SpreadAliasWithSpreadAlias(string,int,int?,string,CancellationToken)']/*" />
+        public virtual Response SpreadAliasWithSpreadAlias(string id, int top, int? age = null, string name = null, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(id, nameof(id));
-            Argument.AssertNotNull(name, nameof(name));
 
             RequestContext context = FromCancellationToken(cancellationToken);
-            SpreadAliasWithSpreadAliasRequest spreadAliasWithSpreadAliasRequest = new SpreadAliasWithSpreadAliasRequest(name, age);
+            SpreadAliasWithSpreadAliasRequest spreadAliasWithSpreadAliasRequest = new SpreadAliasWithSpreadAliasRequest()
+            {
+                Age = age,
+                Name = name
+            };
             Response response = SpreadAliasWithSpreadAlias(id, top, spreadAliasWithSpreadAliasRequest.ToRequestContent(), context);
             return response;
         }
@@ -572,7 +580,7 @@ namespace SpreadTypeSpec
         /// </item>
         /// <item>
         /// <description>
-        /// Please try the simpler <see cref="SpreadAliasWithSpreadAliasAsync(string,int,string,int,CancellationToken)"/> convenience overload with strongly typed models first.
+        /// Please try the simpler <see cref="SpreadAliasWithSpreadAliasAsync(string,int,int?,string,CancellationToken)"/> convenience overload with strongly typed models first.
         /// </description>
         /// </item>
         /// </list>
@@ -615,7 +623,7 @@ namespace SpreadTypeSpec
         /// </item>
         /// <item>
         /// <description>
-        /// Please try the simpler <see cref="SpreadAliasWithSpreadAlias(string,int,string,int,CancellationToken)"/> convenience overload with strongly typed models first.
+        /// Please try the simpler <see cref="SpreadAliasWithSpreadAlias(string,int,int?,string,CancellationToken)"/> convenience overload with strongly typed models first.
         /// </description>
         /// </item>
         /// </list>

--- a/test/TestProjects/Spread-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/Spread-TypeSpec/src/Generated/tspCodeModel.json
@@ -53,30 +53,30 @@
    "Properties": [
     {
      "$id": "8",
-     "Name": "name",
-     "SerializedName": "name",
-     "Description": "name of the Thing",
-     "Type": {
-      "$id": "9",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "10",
      "Name": "age",
      "SerializedName": "age",
      "Description": "age of the Thing",
      "Type": {
-      "$id": "11",
+      "$id": "9",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
      },
-     "IsRequired": true,
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "10",
+     "Name": "name",
+     "SerializedName": "name",
+     "Description": "name of the Thing",
+     "Type": {
+      "$id": "11",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": false,
      "IsReadOnly": false
     }
    ]
@@ -127,30 +127,30 @@
    "Properties": [
     {
      "$id": "18",
-     "Name": "name",
-     "SerializedName": "name",
-     "Description": "name of the Thing",
-     "Type": {
-      "$id": "19",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "20",
      "Name": "age",
      "SerializedName": "age",
      "Description": "age of the Thing",
      "Type": {
-      "$id": "21",
+      "$id": "19",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
      },
-     "IsRequired": true,
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "20",
+     "Name": "name",
+     "SerializedName": "name",
+     "Description": "name of the Thing",
+     "Type": {
+      "$id": "21",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": false,
      "IsReadOnly": false
     }
    ]

--- a/test/TestProjects/Spread-TypeSpec/tests/Generated/Samples/Samples_SpreadTypeSpecClient.cs
+++ b/test/TestProjects/Spread-TypeSpec/tests/Generated/Samples/Samples_SpreadTypeSpecClient.cs
@@ -106,11 +106,7 @@ namespace SpreadTypeSpec.Samples
             var endpoint = new Uri("<https://my-service.azure.com>");
             var client = new SpreadTypeSpecClient(endpoint);
 
-            var data = new
-            {
-                name = "<name>",
-                age = 1234,
-            };
+            var data = new { };
 
             Response response = client.SpreadAlias(RequestContent.Create(data));
             Console.WriteLine(response.Status);
@@ -125,8 +121,8 @@ namespace SpreadTypeSpec.Samples
 
             var data = new
             {
-                name = "<name>",
                 age = 1234,
+                name = "<name>",
             };
 
             Response response = client.SpreadAlias(RequestContent.Create(data));
@@ -140,11 +136,7 @@ namespace SpreadTypeSpec.Samples
             var endpoint = new Uri("<https://my-service.azure.com>");
             var client = new SpreadTypeSpecClient(endpoint);
 
-            var data = new
-            {
-                name = "<name>",
-                age = 1234,
-            };
+            var data = new { };
 
             Response response = await client.SpreadAliasAsync(RequestContent.Create(data));
             Console.WriteLine(response.Status);
@@ -159,8 +151,8 @@ namespace SpreadTypeSpec.Samples
 
             var data = new
             {
-                name = "<name>",
                 age = 1234,
+                name = "<name>",
             };
 
             Response response = await client.SpreadAliasAsync(RequestContent.Create(data));
@@ -174,7 +166,7 @@ namespace SpreadTypeSpec.Samples
             var endpoint = new Uri("<https://my-service.azure.com>");
             var client = new SpreadTypeSpecClient(endpoint);
 
-            var result = await client.SpreadAliasAsync("<name>", 1234);
+            var result = await client.SpreadAliasAsync(1234, "<name>");
         }
 
         [Test]
@@ -341,11 +333,7 @@ namespace SpreadTypeSpec.Samples
             var endpoint = new Uri("<https://my-service.azure.com>");
             var client = new SpreadTypeSpecClient(endpoint);
 
-            var data = new
-            {
-                name = "<name>",
-                age = 1234,
-            };
+            var data = new { };
 
             Response response = client.SpreadAliasWithSpreadAlias("<id>", 1234, RequestContent.Create(data));
             Console.WriteLine(response.Status);
@@ -360,8 +348,8 @@ namespace SpreadTypeSpec.Samples
 
             var data = new
             {
-                name = "<name>",
                 age = 1234,
+                name = "<name>",
             };
 
             Response response = client.SpreadAliasWithSpreadAlias("<id>", 1234, RequestContent.Create(data));
@@ -375,11 +363,7 @@ namespace SpreadTypeSpec.Samples
             var endpoint = new Uri("<https://my-service.azure.com>");
             var client = new SpreadTypeSpecClient(endpoint);
 
-            var data = new
-            {
-                name = "<name>",
-                age = 1234,
-            };
+            var data = new { };
 
             Response response = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, RequestContent.Create(data));
             Console.WriteLine(response.Status);
@@ -394,8 +378,8 @@ namespace SpreadTypeSpec.Samples
 
             var data = new
             {
-                name = "<name>",
                 age = 1234,
+                name = "<name>",
             };
 
             Response response = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, RequestContent.Create(data));
@@ -409,7 +393,7 @@ namespace SpreadTypeSpec.Samples
             var endpoint = new Uri("<https://my-service.azure.com>");
             var client = new SpreadTypeSpecClient(endpoint);
 
-            var result = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, "<name>", 1234);
+            var result = await client.SpreadAliasWithSpreadAliasAsync("<id>", 1234, 1234, "<name>");
         }
 
         [Test]


### PR DESCRIPTION
Example of possible ambiguous call.
```
alias ThingAlias = {
  @doc("name of the Thing")
  name: string;
  @doc("age of the Thing")
  age: int32;
};
```
is changed to
```
alias ThingAlias = {
  @doc("age of the Thing")
  age?: int32;
  @doc("name of the Thing")
  name?: string;
};
```

Resulting convenience method signature would be:
```cs
Response SpreadAlias(int? age = null, string name = null, CancellationToken cancellationToken = default)
```

Call `SpreadAlias(null)` is ambiguous