### PR TITLE
RequestMethod does not have an implicit to string so needs an explicit call

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Writers/JsonCodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/JsonCodeWriterExtensions.cs
@@ -124,7 +124,6 @@ namespace AutoRest.CSharp.Generation.Writers
                                  frameworkType == typeof(Guid) ||
                                  frameworkType == typeof(Azure.Core.ResourceIdentifier) ||
                                  frameworkType == typeof(Azure.Core.ResourceType) ||
-                                 frameworkType == typeof(Azure.Core.RequestMethod) ||
                                  frameworkType == typeof(Azure.Core.AzureLocation))
                         {
                             writer.AppendRaw("WriteStringValue");
@@ -156,7 +155,8 @@ namespace AutoRest.CSharp.Generation.Writers
                         }
                         else if (frameworkType == typeof(ETag) ||
                             frameworkType == typeof(Azure.Core.ContentType) ||
-                            frameworkType == typeof(IPAddress))
+                            frameworkType == typeof(IPAddress) ||
+                            frameworkType == typeof(Azure.Core.RequestMethod))
                         {
                             writer.Line($"WriteStringValue({name:I}.ToString());");
                             return;


### PR DESCRIPTION
Found while working on https://github.com/Azure/autorest.csharp/pull/3434

If a class doesn't have an implicit to string we need to add `.ToString()` at the end of the call.  [RequestMethod](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/RequestMethod.cs) does not have this.

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first