### PR TITLE
update to use testmodeler2.6.1 (support DataFactoryElement's example) to generate example's model

### DIFF
--- a/src/AutoRest.CSharp/readme.md
+++ b/src/AutoRest.CSharp/readme.md
@@ -36,7 +36,7 @@ pipeline:
 
 ```yaml $(testgen)
 use-extension:
-  "@autorest/testmodeler": "2.6.0"
+  "@autorest/testmodeler": "2.6.1"
 
 pipeline:
   test-modeler:


### PR DESCRIPTION
update to use testmodeler2.6.1 (support DataFactoryElement's example) to generate example's model