### PR TITLE
fix(common): random error due to repetitive loading configuration

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
@@ -108,7 +108,6 @@ namespace AutoRest.CSharp.Input
                 {
                     return;
                 }
-                IsInitialized = true;
 
                 _outputFolder = outputFolder;
                 _namespace = ns;
@@ -176,6 +175,8 @@ namespace AutoRest.CSharp.Input
                 _modelsToTreatEmptyStringAsNull = new HashSet<string>(modelsToTreatEmptyStringAsNull);
                 _intrinsicTypesToTreatEmptyStringAsNull.UnionWith(additionalIntrinsicTypesToTreatEmptyStringAsNull);
                 _methodsToKeepClientDefaultValue = methodsToKeepClientDefaultValue ?? Array.Empty<string>();
+
+                IsInitialized = true;
             }
         }
 

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/Configuration.cs
@@ -19,8 +19,6 @@ namespace AutoRest.CSharp.Input
 
         private static readonly object InitLock = new object();
 
-        private static bool IsInitialized = false;
-
         public static class Options
         {
             public const string OutputFolder = "output-folder";
@@ -98,17 +96,8 @@ namespace AutoRest.CSharp.Input
             MgmtConfiguration mgmtConfiguration,
             MgmtTestConfiguration? mgmtTestConfiguration)
         {
-            if (IsInitialized)
-            {
-                return;
-            }
             lock (InitLock)
             {
-                if (IsInitialized)
-                {
-                    return;
-                }
-
                 _outputFolder = outputFolder;
                 _namespace = ns;
                 _libraryName = libraryName;
@@ -175,8 +164,6 @@ namespace AutoRest.CSharp.Input
                 _modelsToTreatEmptyStringAsNull = new HashSet<string>(modelsToTreatEmptyStringAsNull);
                 _intrinsicTypesToTreatEmptyStringAsNull.UnionWith(additionalIntrinsicTypesToTreatEmptyStringAsNull);
                 _methodsToKeepClientDefaultValue = methodsToKeepClientDefaultValue ?? Array.Empty<string>();
-
-                IsInitialized = true;
             }
         }
 


### PR DESCRIPTION
# Description

We have mulitple `IPlugin` which could load configuration multiple times. For example, in `src/AutoRest.CSharp/readme.md`, we load plugins `csharpgen` and `csharpproj`. The bad thing is that plugin invocation is async, so loading configuration could be concurrent. And unfortunately the configuration loading is not concurrency safe. For example, `_intrinsicTypesToTreatEmptyStringAsNull.UnionWith(additionalIntrinsicTypesToTreatEmptyStringAsNull);` is not thread-safe.

To fix that, we should make sure the configuration is loaded only once. This commit uses a flag `IsInitialized` and a lock `InitLock` to make sure the configuration initialization is executed only once and exclusively.

fix #3697

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first