### PR TITLE
Revert "update generate target to run export api if exists (#3717)"

### DIFF
--- a/src/AutoRest.CSharp/build/CodeGeneration.targets
+++ b/src/AutoRest.CSharp/build/CodeGeneration.targets
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <PowerShellExe Condition="'$(PowerShellExe)' == ''">pwsh</PowerShellExe>
-    <EngRoot>$(MSBuildProjectDirectory)/../../../../eng</EngRoot>
-    <TypeSpecProjectSyncScriptPath Condition="'$(TypeSpecProjectSyncScriptPath)' == ''">$(EngRoot)/common/scripts/TypeSpec-Project-Sync.ps1</TypeSpecProjectSyncScriptPath>
-    <TypeSpecProjectGenerateScriptPath Condition="'$(TypeSpecProjectGenerateScriptPath)' == ''">$(EngRoot)/common/scripts/TypeSpec-Project-Generate.ps1</TypeSpecProjectGenerateScriptPath>
+    <TypeSpecProjectSyncScriptPath Condition="'$(TypeSpecProjectSyncScriptPath)' == ''">$(MSBuildProjectDirectory)/../../../../eng/common/scripts/TypeSpec-Project-Sync.ps1</TypeSpecProjectSyncScriptPath>
+    <TypeSpecProjectGenerateScriptPath Condition="'$(TypeSpecProjectGenerateScriptPath)' == ''">$(MSBuildProjectDirectory)/../../../../eng/common/scripts/TypeSpec-Project-Generate.ps1</TypeSpecProjectGenerateScriptPath>
     <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <TypeSpecInput Condition="Exists('$(MSBuildProjectDirectory)/../tsp-location.yaml') and $(MSBuildProjectDirectory.EndsWith('src'))">$(MSBuildProjectDirectory)/../tsp-location.yaml</TypeSpecInput>
     <AutoRestInput Condition="'$(AutoRestInput)' == ''">$(_DefaultInputName)</AutoRestInput>
@@ -36,20 +35,9 @@
     <_SaveInputs Condition="'$(SaveInputs)' == 'true'">-SaveInputs</_SaveInputs>
     <_TypespecAdditionalOptions Condition="'$(TypespecAdditionalOptions)' != ''">-TypespecAdditionalOptions "$(TypespecAdditionalOptions)"</_TypespecAdditionalOptions>
     <_SpecRepoRoot Condition="'$(SpecRepoRoot)' != ''">"$(SpecRepoRoot)"</_SpecRepoRoot>
-
-    <ServiceDirectoryPath>$(MSBuildProjectDirectory)/../..</ServiceDirectoryPath>
-    <ServiceDirectory>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetFullPath($(ServiceDirectoryPath)))))</ServiceDirectory>
-    <ExportApiScript>$(EngRoot)/scripts/Export-API.ps1</ExportApiScript>
-    <ExportApiCommand>$(PowerShellExe) -NoProfile -NonInteractive -executionpolicy Unrestricted -File $(ExportApiScript) $(ServiceDirectory)</ExportApiCommand>
   </PropertyGroup>
 
-  <Target Name="GenerateCode" DependsOnTargets="_ExportApi"/>
-
-  <Target Name="_ExportApi" DependsOnTargets="_GenerateCodeForAutorest;_GenerateCodeForTypeSpec">
-    <Message Condition="'$(_GenerateCode)' == 'true' AND Exists('$(ExportApiScript)')" Text="----- Running '$(ExportApiCommand)' -----" />
-    <Exec Condition="'$(_GenerateCode)' == 'true' AND Exists('$(ExportApiScript)')" Command="$(ExportApiCommand)" />
-  </Target>
-
+  <Target Name="GenerateCode" DependsOnTargets="_GenerateCodeForAutorest;_GenerateCodeForTypeSpec"/>
   <Target Name="_GenerateCodeForAutorest" Condition="'$(_GenerateCode)' == 'true' AND Exists('$(AutoRestInput)')">
     <ReadLinesFromFile File="$(AutoRestInput)">
       <Output TaskParameter="Lines" ItemName="AutoRestInputLines"/>


### PR DESCRIPTION
This reverts commit c7c69fee6bfecf6f14ca561453bc56c30e05384d.

The regen preview wasn't run and there were issues in regenerating azure-sdk-for-net

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first