### PR TITLE
Fix the spelling of the commitish parameter

### DIFF
--- a/eng/pipelines/generate-sdk-job-matrix-files.yml
+++ b/eng/pipelines/generate-sdk-job-matrix-files.yml
@@ -28,7 +28,7 @@ jobs:
       Repositories:
       - Name: Azure/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
-        Committish: refs/heads/${{ parameters.BranchName}}
+        Commitish: refs/heads/${{ parameters.BranchName}}
       SkipCheckoutNone: true
   - pwsh: ./eng/GenerateSdkForNetCodeGenerationMatrix.ps1 -SdkForNetPath $(Build.SourcesDirectory)/azure-sdk-for-net -GroupCount ${{ parameters.JobCount }} -OutputFolder $(System.DefaultWorkingDirectory)/output
     displayName: "Generate Matrix Files"

--- a/eng/pipelines/generate-sdk-job-matrix-files.yml
+++ b/eng/pipelines/generate-sdk-job-matrix-files.yml
@@ -26,7 +26,7 @@ jobs:
       - "/*"
       - "!SessionRecords"
       Repositories:
-      - Name: Azure/azure-sdk-for-net
+      - Name: azure-sdk/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
         Commitish: refs/heads/${{ parameters.BranchName}}
       SkipCheckoutNone: true

--- a/eng/pipelines/sdk-update.yml
+++ b/eng/pipelines/sdk-update.yml
@@ -4,6 +4,9 @@ parameters:
   - name: UseTypeSpecNext
     type: boolean
     default: false
+  - name: RunTests
+    type: boolean
+    default: true
 
 variables:
   nugetMultiFeedWarnLevel: 'none'
@@ -67,44 +70,47 @@ stages:
               npm ls -a
             displayName: "List packages"
             workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-          - script: |
-              npm run prettier
-            displayName: "Emitter format check"
-            workingDirectory: $(Build.SourcesDirectory)/autorest.csharp/src/TypeSpec.Extension/Emitter.Csharp
+          - ${{ if eq(parameters.RunTests, 'true') }}:
+            - script: |
+                npm run prettier
+              displayName: "Emitter format check"
+              workingDirectory: $(Build.SourcesDirectory)/autorest.csharp/src/TypeSpec.Extension/Emitter.Csharp
           - pwsh: ./eng/PackArtifacts.ps1 -BuildNumber $(Build.BuildNumber) -StagingDirectory $(Build.ArtifactStagingDirectory)/packages
             name: Package
             displayName: "Pack Artifacts"
             workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-          - task: Npm@1
-            displayName: 'Build CADL Ranch Mock Api project'
-            inputs:
-              command: custom
-              customCommand: run build
-              workingDir: $(Build.SourcesDirectory)/autorest.csharp/test/CadlRanchMockApis
-          - script: |
-              dotnet test AutoRest.CSharp.sln -v:q
-            displayName: "Test"
-            env:
-              DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-              DOTNET_CLI_TELEMETRY_OPTOUT: 1
-              DOTNET_MULTILEVEL_LOOKUP: 0
-            workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-            continueOnError: ${{ parameters.UseTypeSpecNext }}
+          - ${{ if eq(parameters.RunTests, 'true') }}:
+            - task: Npm@1
+              displayName: 'Build CADL Ranch Mock Api project'
+              inputs:
+                command: custom
+                customCommand: run build
+                workingDir: $(Build.SourcesDirectory)/autorest.csharp/test/CadlRanchMockApis
+            - script: |
+                dotnet test AutoRest.CSharp.sln -v:q
+              displayName: "Test"
+              env:
+                DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+                DOTNET_CLI_TELEMETRY_OPTOUT: 1
+                DOTNET_MULTILEVEL_LOOKUP: 0
+              workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
+              continueOnError: ${{ parameters.UseTypeSpecNext }}
           - task: Npm@1
             displayName: 'Build TypeSpec csharp emitter'
             inputs:
               command: custom
               customCommand: run build
               workingDir: $(Build.SourcesDirectory)/autorest.csharp/src/TypeSpec.Extension/Emitter.Csharp
-          - pwsh: ./eng/ExecuteTypespecEmitterUnitTests.ps1
-            displayName: 'E2E Test for TypeSpec emitter'
-            workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-            continueOnError: ${{ parameters.UseTypeSpecNext }}
-          - script: |
-              npm run test --prefix src/TypeSpec.Extension/Emitter.Csharp
-            displayName: 'Unit Test'
-            workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-            continueOnError: ${{ parameters.UseTypeSpecNext }}
+          - ${{ if eq(parameters.RunTests, 'true') }}:
+            - pwsh: ./eng/ExecuteTypespecEmitterUnitTests.ps1
+              displayName: 'E2E Test for TypeSpec emitter'
+              workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
+              continueOnError: ${{ parameters.UseTypeSpecNext }}
+            - script: |
+                npm run test --prefix src/TypeSpec.Extension/Emitter.Csharp
+              displayName: 'Unit Test'
+              workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
+              continueOnError: ${{ parameters.UseTypeSpecNext }}
           - task: NuGetCommand@2
             displayName: 'Publish NugetPackage'
             inputs:
@@ -142,7 +148,7 @@ stages:
             artifact: build_artifacts
             condition: succeededOrFailed()
             displayName: "Publish build artifacts"
-  - ${{ if eq(parameters.UseTypeSpecNext, 'true') }}:
+  - ${{ if and(eq(parameters.UseTypeSpecNext, 'true'), eq(parameters.RunTests, 'true')) }}:
     - stage: 'Check_Code_Generation'
       dependsOn:
         - Build_and_Test

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -32,7 +32,7 @@ jobs:
       - "/*"
       - "!SessionRecords"
       Repositories:
-      - Name: Azure/azure-sdk-for-net
+      - Name: azure-sdk/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
         Commitish: refs/heads/${{ parameters.BranchName }}}
       SkipCheckoutNone: true

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -34,7 +34,7 @@ jobs:
       Repositories:
       - Name: Azure/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
-        Committish: refs/heads/${{ parameters.BranchName }}}
+        Commitish: refs/heads/${{ parameters.BranchName }}}
       SkipCheckoutNone: true
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -64,7 +64,7 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
   - template: /eng/common/pipelines/templates/steps/git-push-changes.yml@azure-sdk-tools
     parameters:
-      BaseRepoBranch: ${{ parameters.BranchName }}}
+      BaseRepoBranch: ${{ parameters.BranchName }}
       BaseRepoOwner: azure-sdk
       CommitMsg: Update SDK codes $(JobKey)
       TargetRepoOwner: Azure

--- a/eng/pipelines/update-azure-sdk-for-net-codes.yml
+++ b/eng/pipelines/update-azure-sdk-for-net-codes.yml
@@ -34,7 +34,7 @@ jobs:
       Repositories:
       - Name: azure-sdk/azure-sdk-for-net
         WorkingDirectory: $(Build.SourcesDirectory)/azure-sdk-for-net
-        Commitish: refs/heads/${{ parameters.BranchName }}}
+        Commitish: refs/heads/${{ parameters.BranchName }}
       SkipCheckoutNone: true
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'


### PR DESCRIPTION
- Add the RunTests parameter to allow sdk-update runners to skip tests
- Fix the spelling of the commitish parameter name (it should have 2 Ts, but it's misspelled in azure-sdk-tools)
- Pull from the azure-sdk repo instead of the azure repo after pushing the branch with updated metadata 