### PR TITLE
Provide a way to keep _ in Name

### DIFF
--- a/src/AutoRest.CSharp/Common/Utilities/StringExtensions.cs
+++ b/src/AutoRest.CSharp/Common/Utilities/StringExtensions.cs
@@ -57,6 +57,9 @@ namespace AutoRest.CSharp.Utilities
                 if (IsWordSeparator(c))
                 {
                     upperCase = true;
+                    // for continuous _, we just eat the first one so that people can still have a way to keep _ in the name if they want
+                    if (i > 0 && name[i - 1] == '_' && name[i] == '_')
+                        nameBuilder.Append('_');
                     continue;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/3812

Provide a way (double '_') to keep the '_' in the ToCleanName() method explicitly when we do need to have the '_' in the name 

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first