### PR TITLE
Turn `dfe-object` into `DataFactoryElement<object>` instead of `DataFactoryElement<BinaryData>`

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -287,7 +287,7 @@ namespace AutoRest.CSharp.Generation.Types
             XMsFormat.DataFactoryElementOfDateTime => typeof(DataFactoryElement<DateTimeOffset>),
             XMsFormat.DataFactoryElementOfDuration => typeof(DataFactoryElement<TimeSpan>),
             XMsFormat.DataFactoryElementOfUri => typeof(DataFactoryElement<Uri>),
-            XMsFormat.DataFactoryElementOfObject => typeof(DataFactoryElement<BinaryData>),
+            XMsFormat.DataFactoryElementOfObject => typeof(DataFactoryElement<object>),
             XMsFormat.DataFactoryElementOfListOfString => typeof(DataFactoryElement<IList<string>>),
             XMsFormat.DataFactoryElementOfKeyValuePairs => typeof(DataFactoryElement<IDictionary<string, string>>),
             _ => null


### PR DESCRIPTION
# Description
To be honest I'm not sure what BinaryData is supposed to represent, but ADF SetVariable accepts any JSON value either `123` or `"some String"`, so it seems better to use `DataFactoryElement<object>`, because `DataFactoryElement<BinaryData>` throws exception when it sees raw `123`... This depends on https://github.com/Azure/azure-sdk-for-net/pull/39436 being merged first...

# Checklist

To ensure a quick review and merge, please ensure:
- [x] The PR has a understandable title and description explaining the _why_ and _what_.
- [x] The PR is opened in draft if not ready for review yet.
   - Well I want someone with better understanding of things to look into this and say I talk nonsense or that, yes this should be merged...
- [x] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first