### PR TITLE
Prevent race condition by pre-caching npx/npm

### DIFF
--- a/eng/UpdateAzureSdkCodes.ps1
+++ b/eng/UpdateAzureSdkCodes.ps1
@@ -16,19 +16,15 @@ Write-Host "Generating Azure SDK Codes..."
 
 if($ProjectListOverrideFile) {
     Write-Host "Initializing npm and npx cache"
-    Push-Location $SdkRepoRoot/sdk/template/Azure.Template
-    try {
-        dotnet build /t:GenerateCode
-        git restore .
-        git clean . -f
-    }
-    finally {
-        Pop-Location
-    }
+
+    $templatePath = "$SdkRepoRoot/sdk/template/Azure.Template"
+    Invoke "dotnet build /t:GenerateCode" -ExecutePath $templatePath
+    Invoke "git restore ." -ExecutePath $templatePath
+    Invoke "git clean . --force" -ExecutePath $templatePath
 
     $tempFolder = New-TemporaryFile
     $tempFolder | Remove-Item -Force
-    New-Item $tempFolder -ItemType Directory -Force -Verbose | Out-Null
+    New-Item $tempFolder -ItemType Directory -Force | Out-Null
 
     Push-Location $tempFolder
     try {

--- a/eng/UpdateAzureSdkCodes.ps1
+++ b/eng/UpdateAzureSdkCodes.ps1
@@ -16,7 +16,7 @@ Write-Host "Generating Azure SDK Codes..."
 
 if($ProjectListOverrideFile) {
     Write-Host "Initializing npm and npx cache"
-    Push-Location $SdkRepoRoot/sdk/template/Azure.template
+    Push-Location $SdkRepoRoot/sdk/template/Azure.Template
     try {
         dotnet build /t:GenerateCode
         git restore .

--- a/eng/UpdateAzureSdkCodes.ps1
+++ b/eng/UpdateAzureSdkCodes.ps1
@@ -10,8 +10,32 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Import-Module "$PSScriptRoot\Generation.psm1" -DisableNameChecking -Force;
 
 Write-Host "Generating Azure SDK Codes..."
+
+Write-Host "Initializing npm and npx cache"
+$tempFolder = New-TemporaryFile
+$tempFolder | Remove-Item -Force
+New-Item $tempFolder -ItemType Directory -Force -Verbose | Out-Null
+
+Push-Location $tempFolder
+try {
+    Copy-Item "$SdkRepoRoot/eng/emitter-package.json" "package.json"
+    if(Test-Path "$SdkRepoRoot/eng/emitter-package-lock.json") {
+        Copy-Item "$SdkRepoRoot/eng/emitter-package-lock.json" "package-lock.json"
+        Invoke "npm ci" -ExecutePath $PWD
+    } else {
+        Invoke "npm install" -ExecutePath $PWD
+    }
+    Invoke "npx autorest --latest" -ExecutePath $PWD
+    Invoke "npx autorest --info" -ExecutePath $PWD
+}
+finally {
+    Pop-Location
+    $tempFolder | Remove-Item -Force -Recurse
+}
+
 if($ProjectListOverrideFile) {
     Write-Host 'Generating projects in override file ' -ForegroundColor Green -NoNewline
     Write-Host "$ProjectListOverrideFile" -ForegroundColor Yellow


### PR DESCRIPTION
When msbuild fans out code generation into the projects in the override props file, a race condition in concurrent npx install commands causes build failures.  To prevent the race condition, before calling `dotnet msbuild`, we call `npm install` and `npx autorest` to prepopulate the appropriate caches.