### PR TITLE
refactor `CreateResourceIdentifier` method in MPG

### DIFF
--- a/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/AvailabilitySetResource.cs
@@ -29,6 +29,9 @@ namespace Azure.ResourceManager.Sample
     public partial class AvailabilitySetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AvailabilitySetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="availabilitySetName"> The availabilitySetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string availabilitySetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostGroupResource.cs
@@ -28,6 +28,9 @@ namespace Azure.ResourceManager.Sample
     public partial class DedicatedHostGroupResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DedicatedHostGroupResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="hostGroupName"> The hostGroupName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string hostGroupName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/DedicatedHostResource.cs
@@ -27,6 +27,10 @@ namespace Azure.ResourceManager.Sample
     public partial class DedicatedHostResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DedicatedHostResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="hostGroupName"> The hostGroupName. </param>
+        /// <param name="hostName"> The hostName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string hostGroupName, string hostName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/ImageResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ImageResource.cs
@@ -28,6 +28,9 @@ namespace Azure.ResourceManager.Sample
     public partial class ImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ImageResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="imageName"> The imageName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string imageName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/ProximityPlacementGroupResource.cs
@@ -28,6 +28,9 @@ namespace Azure.ResourceManager.Sample
     public partial class ProximityPlacementGroupResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ProximityPlacementGroupResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="proximityPlacementGroupName"> The proximityPlacementGroupName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string proximityPlacementGroupName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups/{proximityPlacementGroupName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/SshPublicKeyResource.cs
@@ -28,6 +28,9 @@ namespace Azure.ResourceManager.Sample
     public partial class SshPublicKeyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SshPublicKeyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="sshPublicKeyName"> The sshPublicKeyName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string sshPublicKeyName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{sshPublicKeyName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionImageResource.cs
@@ -26,6 +26,11 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="publisherName"> The publisherName. </param>
+        /// <param name="type"> The type. </param>
+        /// <param name="version"> The version. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineExtensionResource.cs
@@ -27,6 +27,10 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineExtensionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
+        /// <param name="vmExtensionName"> The vmExtensionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName, string vmExtensionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineResource.cs
@@ -29,6 +29,9 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetExtensionResource.cs
@@ -26,6 +26,10 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineScaleSetExtensionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetExtensionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
+        /// <param name="vmssExtensionName"> The vmssExtensionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName, string vmssExtensionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetResource.cs
@@ -29,6 +29,9 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineScaleSetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetRollingUpgradeResource.cs
@@ -25,6 +25,9 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineScaleSetRollingUpgradeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetRollingUpgradeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/latest";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVirtualMachineExtensionResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVirtualMachineExtensionResource.cs
@@ -27,6 +27,11 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineScaleSetVirtualMachineExtensionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetVirtualMachineExtensionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
+        /// <param name="instanceId"> The instanceId. </param>
+        /// <param name="vmExtensionName"> The vmExtensionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName, string instanceId, string vmExtensionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}";

--- a/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVmResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/VirtualMachineScaleSetVmResource.cs
@@ -27,6 +27,10 @@ namespace Azure.ResourceManager.Sample
     public partial class VirtualMachineScaleSetVmResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetVmResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
+        /// <param name="instanceId"> The instanceId. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName, string instanceId)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}";

--- a/samples/Azure.ResourceManager.Storage/Generated/BlobContainerResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/BlobContainerResource.cs
@@ -26,6 +26,10 @@ namespace Azure.ResourceManager.Storage
     public partial class BlobContainerResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BlobContainerResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="containerName"> The containerName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string containerName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/BlobInventoryPolicyResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/BlobInventoryPolicyResource.cs
@@ -26,6 +26,10 @@ namespace Azure.ResourceManager.Storage
     public partial class BlobInventoryPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BlobInventoryPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="blobInventoryPolicyName"> The blobInventoryPolicyName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, BlobInventoryPolicyName blobInventoryPolicyName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies/{blobInventoryPolicyName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/BlobServiceResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/BlobServiceResource.cs
@@ -25,6 +25,9 @@ namespace Azure.ResourceManager.Storage
     public partial class BlobServiceResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BlobServiceResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default";

--- a/samples/Azure.ResourceManager.Storage/Generated/DeletedAccountResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/DeletedAccountResource.cs
@@ -26,6 +26,9 @@ namespace Azure.ResourceManager.Storage
     public partial class DeletedAccountResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeletedAccountResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="deletedAccountName"> The deletedAccountName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string deletedAccountName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/deletedAccounts/{deletedAccountName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/EncryptionScopeResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/EncryptionScopeResource.cs
@@ -25,6 +25,10 @@ namespace Azure.ResourceManager.Storage
     public partial class EncryptionScopeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="EncryptionScopeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="encryptionScopeName"> The encryptionScopeName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string encryptionScopeName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes/{encryptionScopeName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/FileServiceResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/FileServiceResource.cs
@@ -25,6 +25,9 @@ namespace Azure.ResourceManager.Storage
     public partial class FileServiceResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FileServiceResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default";

--- a/samples/Azure.ResourceManager.Storage/Generated/FileShareResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/FileShareResource.cs
@@ -26,6 +26,10 @@ namespace Azure.ResourceManager.Storage
     public partial class FileShareResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FileShareResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="shareName"> The shareName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string shareName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/ImmutabilityPolicyResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/ImmutabilityPolicyResource.cs
@@ -25,6 +25,10 @@ namespace Azure.ResourceManager.Storage
     public partial class ImmutabilityPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ImmutabilityPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="containerName"> The containerName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string containerName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default";

--- a/samples/Azure.ResourceManager.Storage/Generated/ManagementPolicyResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/ManagementPolicyResource.cs
@@ -26,6 +26,10 @@ namespace Azure.ResourceManager.Storage
     public partial class ManagementPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ManagementPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="managementPolicyName"> The managementPolicyName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, ManagementPolicyName managementPolicyName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/ObjectReplicationPolicyResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/ObjectReplicationPolicyResource.cs
@@ -25,6 +25,10 @@ namespace Azure.ResourceManager.Storage
     public partial class ObjectReplicationPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ObjectReplicationPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="objectReplicationPolicyId"> The objectReplicationPolicyId. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string objectReplicationPolicyId)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies/{objectReplicationPolicyId}";

--- a/samples/Azure.ResourceManager.Storage/Generated/StorageAccountResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/StorageAccountResource.cs
@@ -29,6 +29,9 @@ namespace Azure.ResourceManager.Storage
     public partial class StorageAccountResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="StorageAccountResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}";

--- a/samples/Azure.ResourceManager.Storage/Generated/StoragePrivateEndpointConnectionResource.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/StoragePrivateEndpointConnectionResource.cs
@@ -25,6 +25,10 @@ namespace Azure.ResourceManager.Storage
     public partial class StoragePrivateEndpointConnectionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="StoragePrivateEndpointConnectionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="accountName"> The accountName. </param>
+        /// <param name="privateEndpointConnectionName"> The privateEndpointConnectionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string accountName, string privateEndpointConnectionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}";

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
@@ -10,6 +10,7 @@ using AutoRest.CSharp.Common.Output.Expressions.Statements;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 using AutoRest.CSharp.Common.Output.Models;
 using AutoRest.CSharp.Generation.Types;
+using AutoRest.CSharp.Utilities;
 using Azure.ResourceManager.Models;
 using SwitchExpression = AutoRest.CSharp.Common.Output.Expressions.ValueExpressions.SwitchExpression;
 
@@ -590,6 +591,27 @@ namespace AutoRest.CSharp.Generation.Writers
                     break;
                 case StringLiteralExpression(var literal, false):
                     writer.Literal(literal);
+                    break;
+                case FormattableStringExpression(var formattable):
+                    writer.AppendRaw("$\"");
+                    var argumentCount = 0;
+                    foreach ((var span, bool isLiteral) in StringExtensions.GetPathParts(formattable.Format))
+                    {
+                        if (isLiteral)
+                        {
+                            writer.AppendRaw(span.ToString());
+                            continue;
+                        }
+
+                        var arg = formattable.GetArgument(argumentCount);
+                        argumentCount++;
+                        // append the argument. The argument must be something assignable to ValueExpression here
+                        var a = (ValueExpression)arg!;
+                        writer.AppendRaw("{");
+                        writer.WriteValueExpression(a);
+                        writer.AppendRaw("}");
+                    }
+                    writer.AppendRaw("\"");
                     break;
             }
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
@@ -592,10 +592,10 @@ namespace AutoRest.CSharp.Generation.Writers
                 case StringLiteralExpression(var literal, false):
                     writer.Literal(literal);
                     break;
-                case FormattableStringExpression(var formattable):
+                case FormattableStringExpression(var format, var args):
                     writer.AppendRaw("$\"");
                     var argumentCount = 0;
-                    foreach ((var span, bool isLiteral) in StringExtensions.GetPathParts(formattable.Format))
+                    foreach ((var span, bool isLiteral) in StringExtensions.GetPathParts(format))
                     {
                         if (isLiteral)
                         {
@@ -603,12 +603,11 @@ namespace AutoRest.CSharp.Generation.Writers
                             continue;
                         }
 
-                        var arg = formattable.GetArgument(argumentCount);
+                        var arg = args[argumentCount];
                         argumentCount++;
-                        // append the argument. The argument must be something assignable to ValueExpression here
-                        var a = (ValueExpression)arg!;
+                        // append the argument
                         writer.AppendRaw("{");
-                        writer.WriteValueExpression(a);
+                        writer.WriteValueExpression(arg);
                         writer.AppendRaw("}");
                     }
                     writer.AppendRaw("\"");

--- a/src/AutoRest.CSharp/Common/Output/Expressions/KnownValueExpressions/StringExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/KnownValueExpressions/StringExpression.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 using static AutoRest.CSharp.Common.Output.Models.Snippets;
 
@@ -13,5 +15,8 @@ namespace AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions
 
         public static BoolExpression Equals(StringExpression left, StringExpression right, StringComparison comparisonType)
             => new(InvokeStatic(nameof(string.Equals), new[] { left, right, FrameworkEnumValue(comparisonType) }));
+
+        public static StringExpression Format(StringExpression format, params ValueExpression[] args)
+            => new(new InvokeStaticMethodExpression(typeof(string), nameof(string.Format), args.Prepend(format).ToArray()));
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.New.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.New.cs
@@ -50,7 +50,7 @@ namespace AutoRest.CSharp.Common.Output.Models
 
             public static ValueExpression RequestFailedException(BaseResponseExpression response) => Instance(Configuration.ApiTypes.RequestFailedExceptionType, response);
 
-            public static ResourceIdentifierExpression ResourceIdentifier(ValueExpression resourceData) => new(Instance(typeof(ResourceIdentifier), new MemberExpression(resourceData, "Id")));
+            public static ResourceIdentifierExpression ResourceIdentifier(ValueExpression id) => new(Instance(typeof(ResourceIdentifier), id));
 
             public static StreamReaderExpression StreamReader(ValueExpression stream) => new(Instance(typeof(StreamReader), stream));
 

--- a/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/FormattableStringExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/FormattableStringExpression.cs
@@ -6,6 +6,12 @@ using AutoRest.CSharp.Utilities;
 
 namespace AutoRest.CSharp.Common.Output.Expressions.ValueExpressions
 {
+    /// <summary>
+    /// Represents a FormattableString literal expression such as $"foo{bar}"
+    /// Constructed by a format string which should look like "foo{0}"
+    /// and a list of arguments of ValueExpressions
+    /// The constructor throws IndexOutOfRangeException when the count of arguments does not match in the format string and argument list.
+    /// </summary>
     internal sealed record FormattableStringExpression : ValueExpression
     {
         public FormattableStringExpression(string format, IReadOnlyList<ValueExpression> args)

--- a/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/FormattableStringExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/FormattableStringExpression.cs
@@ -1,9 +1,41 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
+using System.Collections.Generic;
+using AutoRest.CSharp.Utilities;
 
 namespace AutoRest.CSharp.Common.Output.Expressions.ValueExpressions
 {
-    internal sealed record FormattableStringExpression(FormattableString literal) : ValueExpression;
+    internal sealed record FormattableStringExpression : ValueExpression
+    {
+        public FormattableStringExpression(string format, IReadOnlyList<ValueExpression> args)
+        {
+#if DEBUG
+            Validate(format, args);
+#endif
+            Format = format;
+            Args = args;
+        }
+        public string Format { get; init; }
+        public IReadOnlyList<ValueExpression> Args { get; init; }
+
+        public void Deconstruct(out string format,  out IReadOnlyList<ValueExpression> args)
+        {
+            format = Format;
+            args = Args;
+        }
+
+        private static void Validate(string format, IReadOnlyList<ValueExpression> args)
+        {
+            var count = 0;
+            foreach (var (_, isLiteral) in StringExtensions.GetPathParts(format))
+            {
+                if (!isLiteral)
+                    count++;
+            }
+
+            if (count != args.Count)
+                throw new System.IndexOutOfRangeException($"The count of arguments in format {format} does not match with the arguments provided");
+        }
+    }
 }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/FormattableStringExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/FormattableStringExpression.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace AutoRest.CSharp.Common.Output.Expressions.ValueExpressions
+{
+    internal sealed record FormattableStringExpression(FormattableString literal) : ValueExpression;
+}

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtConfiguration.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtConfiguration.cs
@@ -46,7 +46,7 @@ namespace AutoRest.CSharp.Input
                 SkipCodeGen = Configuration.DeserializeBoolean(skipCodeGen, false);
                 GenerateReport = Configuration.DeserializeBoolean(generateReport, true);
                 ReportOnly = Configuration.DeserializeBoolean(reportOnly, false);
-                ReportFormat = reportFormat?.GetString() ?? "yaml";
+                ReportFormat = Configuration.IsValidJsonElement(reportFormat) ? reportFormat?.GetString() ?? "yaml" : "yaml";
             }
 
             internal static MgmtDebugConfiguration LoadConfiguration(JsonElement root)

--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -617,7 +617,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
         protected FormattableString CreateResourceIdentifierExpression(Resource resource, RequestPath requestPath, IEnumerable<ParameterMapping> parameterMappings, FormattableString dataExpression)
         {
-            var methodWithLeastParameters = resource.CreateResourceIdentifierMethodSignature;
+            var methodWithLeastParameters = resource.CreateResourceIdentifierMethod.Signature;
             var cache = new List<ParameterMapping>(parameterMappings);
 
             var parameterInvocations = new List<FormattableString>();

--- a/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/OperationSourceWriter.cs
@@ -85,7 +85,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
                             _writer.Line($"return data;");
                             _writer.Line();
                             _writer.Append($"var newId = {resourceType}.CreateResourceIdentifier(");
-                            var createIdMethod = resource.CreateResourceIdentifierMethodSignature;
+                            var createIdMethod = resource.CreateResourceIdentifierMethod.Signature;
                             foreach (var param in createIdMethod.Parameters)
                             {
                                 _writer.Line();

--- a/src/AutoRest.CSharp/Mgmt/Generation/ResourceWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ResourceWriter.cs
@@ -49,38 +49,9 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
         private void WriteCreateResourceIdentifierMethods()
         {
-            var requestPath = This.RequestPath;
-            var method = This.CreateResourceIdentifierMethodSignature;
-            _writer.WriteXmlDocumentationSummary($"{method.Description}");
-            using (_writer.WriteMethodDeclaration(method))
-            {
-                // Storage has inconsistent definitions:
-                // - https://github.com/Azure/azure-rest-api-specs/blob/719b74f77b92eb1ec3814be6c4488bcf6b651733/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json#L58
-                // - https://github.com/Azure/azure-rest-api-specs/blob/719b74f77b92eb1ec3814be6c4488bcf6b651733/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json#L146
-                // so here we have to use `Seqment.BuildSerializedSegments` instead of `RequestPath.SerializedPath` which could be from `RestClientMethod.Operation.GetHttpPath`
-                var resourceId = new CodeWriterDeclaration("resourceId");
-                _writer.Append($"var {resourceId:D} = ");
-                _writer.AppendRaw("$\"");
-                var first = true;
-                foreach (var segment in requestPath)
-                {
-                    if (first)
-                    {
-                        first = false;
-                        // If first segment is "{var}", then we should not add leading "/". Instead, we should let callers to specify, e.g. "{scope}/providers/Microsoft.Resources/..." v.s. "/subscriptions/{subscriptionId}/..."
-                        if (!requestPath.Any() || requestPath.First().IsConstant)
-                            _writer.AppendRaw("/");
-                    }
-                    else
-                        _writer.AppendRaw("/");
-                    if (segment.IsConstant)
-                        _writer.AppendRaw(segment.ConstantValue);
-                    else
-                        _writer.Append($"{{{segment.ReferenceName:I}}}");
-                }
-                _writer.LineRaw("\";");
-                _writer.Line($"return new {method.ReturnType?.Name}({resourceId:I});");
-            }
+            var method = This.CreateResourceIdentifierMethod;
+            _writer.WriteMethodDocumentation(method.Signature);
+            _writer.WriteMethod(method);
         }
 
         protected override void WriteProperties()

--- a/src/AutoRest.CSharp/Mgmt/Output/PartialResource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/PartialResource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using AutoRest.CSharp.Common.Output.Models;
 using AutoRest.CSharp.Generation.Writers;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
@@ -45,11 +46,16 @@ internal class PartialResource : Resource
         return null;
     }
 
-    private MethodSignature? _createResourceIdentifierSignature;
-    public override MethodSignature CreateResourceIdentifierMethodSignature => _createResourceIdentifierSignature ??= base.CreateResourceIdentifierMethodSignature with
+    protected override Method BuildCreateResourceIdentifierMethod()
     {
-        Modifiers = MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static
-    };
+        var original = base.BuildCreateResourceIdentifierMethod();
+
+        return new(
+            original.Signature with
+            {
+                Modifiers = MethodSignatureModifiers.Internal | MethodSignatureModifiers.Static
+            }, original.Body!);
+    }
 
     protected override IEnumerable<FieldDeclaration> GetAdditionalFields()
     {

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -492,16 +492,18 @@ namespace AutoRest.CSharp.Mgmt.Output
                 {
                     first = false;
                     // If first segment is "{var}", then we should not add leading "/". Instead, we should let callers to specify, e.g. "{scope}/providers/Microsoft.Resources/..." v.s. "/subscriptions/{subscriptionId}/..."
-                    if (!RequestPath.Any() || RequestPath.First().IsConstant)
-                        formatBuilder.Append("/");
+                    if (RequestPath.Count == 0 || RequestPath[0].IsConstant)
+                        formatBuilder.Append('/');
                 }
                 else
-                    formatBuilder.Append("/");
+                    formatBuilder.Append('/');
                 if (segment.IsConstant)
                     formatBuilder.Append(segment.ConstantValue);
                 else
                 {
-                    formatBuilder.Append($"{{{refCount}}}");
+                    formatBuilder.Append('{')
+                        .Append(refCount)
+                        .Append('}');
                     refCount++;
                 }
             }

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using AutoRest.CSharp.Common.Input;
 using AutoRest.CSharp.Common.Output.Expressions.Statements;
@@ -22,11 +23,9 @@ using AutoRest.CSharp.Output.Models.Shared;
 using AutoRest.CSharp.Output.Models.Types;
 using Azure.Core;
 using Azure.ResourceManager;
+using static AutoRest.CSharp.Common.Output.Models.Snippets;
 using static AutoRest.CSharp.Mgmt.Decorator.ParameterMappingBuilder;
 using static AutoRest.CSharp.Output.Models.MethodSignatureModifiers;
-using static AutoRest.CSharp.Common.Output.Models.Snippets;
-using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions;
-using System.Runtime.CompilerServices;
 
 namespace AutoRest.CSharp.Mgmt.Output
 {

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -4,7 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using AutoRest.CSharp.Common.Input;
+using AutoRest.CSharp.Common.Output.Expressions.Statements;
+using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
+using AutoRest.CSharp.Common.Output.Models;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Generation.Writers;
 using AutoRest.CSharp.Input;
@@ -13,12 +17,16 @@ using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Mgmt.Models;
 using AutoRest.CSharp.Mgmt.Report;
 using AutoRest.CSharp.Output.Models;
+using AutoRest.CSharp.Output.Models.Requests;
 using AutoRest.CSharp.Output.Models.Shared;
 using AutoRest.CSharp.Output.Models.Types;
 using Azure.Core;
 using Azure.ResourceManager;
 using static AutoRest.CSharp.Mgmt.Decorator.ParameterMappingBuilder;
 using static AutoRest.CSharp.Output.Models.MethodSignatureModifiers;
+using static AutoRest.CSharp.Common.Output.Models.Snippets;
+using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions;
+using System.Runtime.CompilerServices;
 
 namespace AutoRest.CSharp.Mgmt.Output
 {
@@ -451,31 +459,64 @@ namespace AutoRest.CSharp.Mgmt.Output
             _ => FormattableStringHelpers.Join(parentTypes.Select(type => (FormattableString)$"<see cref=\"{type}\" />").ToList(), ", ", " or "),
         };
 
-        private static Type? ToFormatTypeByName(string? name) => name switch
-        {
-            "location" => typeof(AzureLocation),
-            _ => null
-        };
+        private static CSharpType GetReferenceType(Reference reference)
+            => reference.Name switch
+            {
+                "location" when reference.Type.EqualsIgnoreNullable(typeof(string)) => typeof(AzureLocation),
+                _ => reference.Type
+            };
 
         private Parameter CreateResourceIdentifierParameter(Segment segment)
-        {
-            CSharpType ctype = ToFormatTypeByName(segment.Reference.Name) is Type type ? new CSharpType(type, false) : segment.Reference.Type;
-            return new Parameter(segment.Reference.Name, null, ctype, null, ValidationType.AssertNotNull, null);
-        }
+            => new Parameter(segment.Reference.Name, $"The {segment.Reference.Name}", GetReferenceType(segment.Reference), null, ValidationType.None, null);
 
-        private MethodSignature? _createResourceIdentifierMethodSignature;
-        /// <summary>
-        /// Returns the different method signature for different base path of this resource
-        /// </summary>
-        /// <returns></returns>
-        public virtual MethodSignature CreateResourceIdentifierMethodSignature => _createResourceIdentifierMethodSignature ??= new MethodSignature(
-            Name: "CreateResourceIdentifier",
-            null,
-            Description: $"Generate the resource identifier of a <see cref=\"{Type.Name}\"/> instance.",
-            Modifiers: Public | Static,
-            ReturnType: typeof(ResourceIdentifier),
-            ReturnDescription: null,
-            Parameters: RequestPath.Where(segment => segment.IsReference).Select(segment => CreateResourceIdentifierParameter(segment)).ToArray());
+        public Method? _createResourceIdentifierMethod;
+        public Method CreateResourceIdentifierMethod => _createResourceIdentifierMethod ??= BuildCreateResourceIdentifierMethod();
+
+        protected virtual Method BuildCreateResourceIdentifierMethod()
+        {
+            var signature = new MethodSignature(
+                Name: "CreateResourceIdentifier",
+                null,
+                Description: $"Generate the resource identifier of a <see cref=\"{Type.ToStringForDocs()}\"/> instance.",
+                Modifiers: Public | Static,
+                ReturnType: typeof(ResourceIdentifier),
+                ReturnDescription: null,
+                Parameters: RequestPath.Where(segment => segment.IsReference).Select(CreateResourceIdentifierParameter).ToArray());
+
+            // build the format string of the id
+            var formatBuilder = new StringBuilder();
+            var first = true;
+            var refCount = 0;
+            foreach (var segment in RequestPath)
+            {
+                if (first)
+                {
+                    first = false;
+                    // If first segment is "{var}", then we should not add leading "/". Instead, we should let callers to specify, e.g. "{scope}/providers/Microsoft.Resources/..." v.s. "/subscriptions/{subscriptionId}/..."
+                    if (!RequestPath.Any() || RequestPath.First().IsConstant)
+                        formatBuilder.Append("/");
+                }
+                else
+                    formatBuilder.Append("/");
+                if (segment.IsConstant)
+                    formatBuilder.Append(segment.ConstantValue);
+                else
+                {
+                    formatBuilder.Append($"{{{refCount}}}");
+                    refCount++;
+                }
+            }
+
+            var formattable = FormattableStringFactory.Create(formatBuilder.ToString(), signature.Parameters.Select(p => (ValueExpression)p).ToArray());
+
+            var resourceId = new VariableReference(typeof(ResourceIdentifier), "resourceId");
+            var methodBody = new MethodBodyStatement[]
+            {
+                Var(resourceId, new FormattableStringExpression(formattable)),
+                Return(Snippets.New.ResourceIdentifier(resourceId))
+            };
+            return new Method(signature, methodBody);
+        }
 
         public FormattableString ResourceDataIdExpression(FormattableString dataExpression)
         {

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -506,12 +506,10 @@ namespace AutoRest.CSharp.Mgmt.Output
                 }
             }
 
-            var formattable = FormattableStringFactory.Create(formatBuilder.ToString(), signature.Parameters.Select(p => (ValueExpression)p).ToArray());
-
             var resourceId = new VariableReference(typeof(ResourceIdentifier), "resourceId");
             var methodBody = new MethodBodyStatement[]
             {
-                Var(resourceId, new FormattableStringExpression(formattable)),
+                Var(resourceId, new FormattableStringExpression(formatBuilder.ToString(), signature.Parameters.Select(p => (ValueExpression)p).ToArray())),
                 Return(Snippets.New.ResourceIdentifier(resourceId))
             };
             return new Method(signature, methodBody);

--- a/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ResourceCollection.cs
@@ -271,8 +271,6 @@ namespace AutoRest.CSharp.Mgmt.Output
             }
         }
 
-        public override MethodSignature CreateResourceIdentifierMethodSignature => throw new InvalidOperationException("Resource collections will never have CreateResourceIdentifier method");
-
         private IDictionary<RequestPath, ISet<ResourceTypeSegment>>? _resourceTypes;
         public IDictionary<RequestPath, ISet<ResourceTypeSegment>> ResourceTypes => _resourceTypes ??= EnsureResourceTypes();
 

--- a/test/TestProjects/MgmtAcronymMapping/Generated/ImageResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/ImageResource.cs
@@ -28,6 +28,9 @@ namespace MgmtAcronymMapping
     public partial class ImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ImageResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="imageName"> The imageName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string imageName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}";

--- a/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineResource.cs
@@ -29,6 +29,9 @@ namespace MgmtAcronymMapping
     public partial class VirtualMachineResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}";

--- a/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetExtensionResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetExtensionResource.cs
@@ -26,6 +26,10 @@ namespace MgmtAcronymMapping
     public partial class VirtualMachineScaleSetExtensionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetExtensionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
+        /// <param name="vmssExtensionName"> The vmssExtensionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName, string vmssExtensionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}";

--- a/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetResource.cs
@@ -29,6 +29,9 @@ namespace MgmtAcronymMapping
     public partial class VirtualMachineScaleSetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}";

--- a/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetRollingUpgradeResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetRollingUpgradeResource.cs
@@ -25,6 +25,9 @@ namespace MgmtAcronymMapping
     public partial class VirtualMachineScaleSetRollingUpgradeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetRollingUpgradeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/latest";

--- a/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetVmResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/VirtualMachineScaleSetVmResource.cs
@@ -27,6 +27,10 @@ namespace MgmtAcronymMapping
     public partial class VirtualMachineScaleSetVmResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetVmResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
+        /// <param name="instanceId"> The instanceId. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName, string instanceId)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}";

--- a/test/TestProjects/MgmtCollectionParent/Generated/OrderResource.cs
+++ b/test/TestProjects/MgmtCollectionParent/Generated/OrderResource.cs
@@ -26,6 +26,10 @@ namespace MgmtCollectionParent
     public partial class OrderResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="OrderResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="orderName"> The orderName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, AzureLocation location, string orderName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/locations/{location}/orders/{orderName}";

--- a/test/TestProjects/MgmtConstants/Generated/OptionalMachineResource.cs
+++ b/test/TestProjects/MgmtConstants/Generated/OptionalMachineResource.cs
@@ -28,6 +28,9 @@ namespace MgmtConstants
     public partial class OptionalMachineResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="OptionalMachineResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Constant/optionalMachines/{name}";

--- a/test/TestProjects/MgmtCustomizations/Generated/PetStoreResource.cs
+++ b/test/TestProjects/MgmtCustomizations/Generated/PetStoreResource.cs
@@ -26,6 +26,9 @@ namespace MgmtCustomizations
     public partial class PetStoreResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PetStoreResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Pets/petStore/{name}";

--- a/test/TestProjects/MgmtDiscriminator/Generated/DeliveryRuleResource.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/DeliveryRuleResource.cs
@@ -27,6 +27,9 @@ namespace MgmtDiscriminator
     public partial class DeliveryRuleResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeliveryRuleResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/deliveryRules/{name}";

--- a/test/TestProjects/MgmtExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel1Resource.cs
+++ b/test/TestProjects/MgmtExactMatchFlattenInheritance/Generated/AzureResourceFlattenModel1Resource.cs
@@ -27,6 +27,9 @@ namespace MgmtExactMatchFlattenInheritance
     public partial class AzureResourceFlattenModel1Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AzureResourceFlattenModel1Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/azureResourceFlattenModel1s/{name}";

--- a/test/TestProjects/MgmtExactMatchFlattenInheritance/Generated/CustomModel2Resource.cs
+++ b/test/TestProjects/MgmtExactMatchFlattenInheritance/Generated/CustomModel2Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtExactMatchFlattenInheritance
     public partial class CustomModel2Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="CustomModel2Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/customModel2s/{name}";

--- a/test/TestProjects/MgmtExactMatchFlattenInheritance/Generated/CustomModel3Resource.cs
+++ b/test/TestProjects/MgmtExactMatchFlattenInheritance/Generated/CustomModel3Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtExactMatchFlattenInheritance
     public partial class CustomModel3Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="CustomModel3Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/customModel3s/{name}";

--- a/test/TestProjects/MgmtExactMatchInheritance/Generated/ExactMatchModel1Resource.cs
+++ b/test/TestProjects/MgmtExactMatchInheritance/Generated/ExactMatchModel1Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtExactMatchInheritance
     public partial class ExactMatchModel1Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ExactMatchModel1Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="exactMatchModel1SName"> The exactMatchModel1SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string exactMatchModel1SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/exactMatchModel1s/{exactMatchModel1SName}";

--- a/test/TestProjects/MgmtExactMatchInheritance/Generated/ExactMatchModel5Resource.cs
+++ b/test/TestProjects/MgmtExactMatchInheritance/Generated/ExactMatchModel5Resource.cs
@@ -27,6 +27,9 @@ namespace MgmtExactMatchInheritance
     public partial class ExactMatchModel5Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ExactMatchModel5Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="exactMatchModel5SName"> The exactMatchModel5SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string exactMatchModel5SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/exactMatchModel5s/{exactMatchModel5SName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetAResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetAResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetAResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetAResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/A/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetAaaaResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetAaaaResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetAaaaResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetAaaaResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/AAAA/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetCNameResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetCNameResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetCNameResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetCNameResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/CNAME/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetCaaResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetCaaResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetCaaResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetCaaResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/CAA/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetMxResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetMxResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetMxResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetMxResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/MX/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetNsResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetNsResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetNsResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetNsResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/NS/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetPtrResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetPtrResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetPtrResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetPtrResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/PTR/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetSoaResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetSoaResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetSoaResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetSoaResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/SOA/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetSrvResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetSrvResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetSrvResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetSrvResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/SRV/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetTxtResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/RecordSetTxtResource.cs
@@ -26,6 +26,10 @@ namespace MgmtExpandResourceTypes
     public partial class RecordSetTxtResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RecordSetTxtResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
+        /// <param name="relativeRecordSetName"> The relativeRecordSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName, string relativeRecordSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/TXT/{relativeRecordSetName}";

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/ZoneResource.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/ZoneResource.cs
@@ -29,6 +29,9 @@ namespace MgmtExpandResourceTypes
     public partial class ZoneResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ZoneResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="zoneName"> The zoneName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string zoneName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}";

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/TypeOneResource.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/TypeOneResource.cs
@@ -27,6 +27,9 @@ namespace MgmtExtensionCommonRestOperation
     public partial class TypeOneResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TypeOneResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="typeOneName"> The typeOneName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string typeOneName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TypeOne/typeOnes/{typeOneName}";

--- a/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/TypeTwoResource.cs
+++ b/test/TestProjects/MgmtExtensionCommonRestOperation/Generated/TypeTwoResource.cs
@@ -27,6 +27,9 @@ namespace MgmtExtensionCommonRestOperation
     public partial class TypeTwoResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TypeTwoResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="typeTwoName"> The typeTwoName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string typeTwoName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TypeTwo/typeTwos/{typeTwoName}";

--- a/test/TestProjects/MgmtExtensionResource/Generated/BuiltInPolicyDefinitionResource.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/BuiltInPolicyDefinitionResource.cs
@@ -26,6 +26,7 @@ namespace MgmtExtensionResource
     public partial class BuiltInPolicyDefinitionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BuiltInPolicyDefinitionResource"/> instance. </summary>
+        /// <param name="policyDefinitionName"> The policyDefinitionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string policyDefinitionName)
         {
             var resourceId = $"/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}";

--- a/test/TestProjects/MgmtExtensionResource/Generated/ManagementGroupPolicyDefinitionResource.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/ManagementGroupPolicyDefinitionResource.cs
@@ -26,6 +26,8 @@ namespace MgmtExtensionResource
     public partial class ManagementGroupPolicyDefinitionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ManagementGroupPolicyDefinitionResource"/> instance. </summary>
+        /// <param name="managementGroupId"> The managementGroupId. </param>
+        /// <param name="policyDefinitionName"> The policyDefinitionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string managementGroupId, string policyDefinitionName)
         {
             var resourceId = $"/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}";

--- a/test/TestProjects/MgmtExtensionResource/Generated/SubSingletonResource.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/SubSingletonResource.cs
@@ -26,6 +26,7 @@ namespace MgmtExtensionResource
     public partial class SubSingletonResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubSingletonResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Singleton/subSingletons/default";

--- a/test/TestProjects/MgmtExtensionResource/Generated/SubscriptionPolicyDefinitionResource.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/SubscriptionPolicyDefinitionResource.cs
@@ -26,6 +26,8 @@ namespace MgmtExtensionResource
     public partial class SubscriptionPolicyDefinitionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubscriptionPolicyDefinitionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="policyDefinitionName"> The policyDefinitionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string policyDefinitionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}";

--- a/test/TestProjects/MgmtHierarchicalNonResource/Generated/SharedGalleryResource.cs
+++ b/test/TestProjects/MgmtHierarchicalNonResource/Generated/SharedGalleryResource.cs
@@ -28,6 +28,9 @@ namespace MgmtHierarchicalNonResource
     public partial class SharedGalleryResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SharedGalleryResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="galleryUniqueName"> The galleryUniqueName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string galleryUniqueName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/sharedGalleries/{galleryUniqueName}";

--- a/test/TestProjects/MgmtLRO/Generated/BarResource.cs
+++ b/test/TestProjects/MgmtLRO/Generated/BarResource.cs
@@ -28,6 +28,9 @@ namespace MgmtLRO
     public partial class BarResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BarResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="barName"> The barName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string barName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/bars/{barName}";

--- a/test/TestProjects/MgmtLRO/Generated/FakeResource.cs
+++ b/test/TestProjects/MgmtLRO/Generated/FakeResource.cs
@@ -28,6 +28,9 @@ namespace MgmtLRO
     public partial class FakeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="fakeName"> The fakeName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string fakeName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/fakes/{fakeName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeConfigurationResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeConfigurationResource.cs
@@ -26,6 +26,9 @@ namespace MgmtListMethods
     public partial class FakeConfigurationResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeConfigurationResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="configurationName"> The configurationName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string configurationName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/configurations/{configurationName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeParentResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeParentResource.cs
@@ -26,6 +26,9 @@ namespace MgmtListMethods
     public partial class FakeParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="fakeParentName"> The fakeParentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string fakeParentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/fakeParents/{fakeParentName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorResource.cs
@@ -26,6 +26,9 @@ namespace MgmtListMethods
     public partial class FakeParentWithAncestorResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeParentWithAncestorResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="fakeParentWithAncestorName"> The fakeParentWithAncestorName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string fakeParentWithAncestorName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/fakeParentWithAncestors/{fakeParentWithAncestorName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorWithLocResource.cs
@@ -26,6 +26,9 @@ namespace MgmtListMethods
     public partial class FakeParentWithAncestorWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeParentWithAncestorWithLocResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="fakeParentWithAncestorWithLocName"> The fakeParentWithAncestorWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string fakeParentWithAncestorWithLocName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/fakeParentWithAncestorWithLocs/{fakeParentWithAncestorWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorWithNonResChResource.cs
@@ -28,6 +28,9 @@ namespace MgmtListMethods
     public partial class FakeParentWithAncestorWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeParentWithAncestorWithNonResChResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="fakeParentWithAncestorWithNonResChName"> The fakeParentWithAncestorWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string fakeParentWithAncestorWithNonResChName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/fakeParentWithAncestorWithNonResChes/{fakeParentWithAncestorWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorWithNonResChWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeParentWithAncestorWithNonResChWithLocResource.cs
@@ -28,6 +28,9 @@ namespace MgmtListMethods
     public partial class FakeParentWithAncestorWithNonResChWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeParentWithAncestorWithNonResChWithLocResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="fakeParentWithAncestorWithNonResChWithLocName"> The fakeParentWithAncestorWithNonResChWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string fakeParentWithAncestorWithNonResChWithLocName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/fakeParentWithAncestorWithNonResChWithLocs/{fakeParentWithAncestorWithNonResChWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeParentWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeParentWithNonResChResource.cs
@@ -28,6 +28,9 @@ namespace MgmtListMethods
     public partial class FakeParentWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeParentWithNonResChResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
+        /// <param name="fakeParentWithNonResChName"> The fakeParentWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName, string fakeParentWithNonResChName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}/fakeParentWithNonResChes/{fakeParentWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/FakeResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/FakeResource.cs
@@ -29,6 +29,8 @@ namespace MgmtListMethods
     public partial class FakeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="fakeName"> The fakeName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string fakeName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Fake/fakes/{fakeName}";

--- a/test/TestProjects/MgmtListMethods/Generated/MgmtGroupParentResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/MgmtGroupParentResource.cs
@@ -27,6 +27,8 @@ namespace MgmtListMethods
     public partial class MgmtGroupParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MgmtGroupParentResource"/> instance. </summary>
+        /// <param name="groupId"> The groupId. </param>
+        /// <param name="mgmtGroupParentName"> The mgmtGroupParentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string groupId, string mgmtGroupParentName)
         {
             var resourceId = $"/providers/Microsoft.Management/managementGroups/{groupId}/mgmtGroupParents/{mgmtGroupParentName}";

--- a/test/TestProjects/MgmtListMethods/Generated/MgmtGrpParentWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/MgmtGrpParentWithLocResource.cs
@@ -27,6 +27,8 @@ namespace MgmtListMethods
     public partial class MgmtGrpParentWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MgmtGrpParentWithLocResource"/> instance. </summary>
+        /// <param name="groupId"> The groupId. </param>
+        /// <param name="mgmtGrpParentWithLocName"> The mgmtGrpParentWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string groupId, string mgmtGrpParentWithLocName)
         {
             var resourceId = $"/providers/Microsoft.Management/managementGroups/{groupId}/mgmtGrpParentWithLocs/{mgmtGrpParentWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/MgmtGrpParentWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/MgmtGrpParentWithNonResChResource.cs
@@ -29,6 +29,8 @@ namespace MgmtListMethods
     public partial class MgmtGrpParentWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MgmtGrpParentWithNonResChResource"/> instance. </summary>
+        /// <param name="groupId"> The groupId. </param>
+        /// <param name="mgmtGrpParentWithNonResChName"> The mgmtGrpParentWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string groupId, string mgmtGrpParentWithNonResChName)
         {
             var resourceId = $"/providers/Microsoft.Management/managementGroups/{groupId}/mgmtGrpParentWithNonResChes/{mgmtGrpParentWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/MgmtGrpParentWithNonResChWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/MgmtGrpParentWithNonResChWithLocResource.cs
@@ -29,6 +29,8 @@ namespace MgmtListMethods
     public partial class MgmtGrpParentWithNonResChWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MgmtGrpParentWithNonResChWithLocResource"/> instance. </summary>
+        /// <param name="groupId"> The groupId. </param>
+        /// <param name="mgmtGrpParentWithNonResChWithLocName"> The mgmtGrpParentWithNonResChWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string groupId, string mgmtGrpParentWithNonResChWithLocName)
         {
             var resourceId = $"/providers/Microsoft.Management/managementGroups/{groupId}/mgmtGrpParentWithNonResChWithLocs/{mgmtGrpParentWithNonResChWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/ResGrpParentResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/ResGrpParentResource.cs
@@ -27,6 +27,9 @@ namespace MgmtListMethods
     public partial class ResGrpParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResGrpParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resGrpParentName"> The resGrpParentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resGrpParentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MgmtListMethods/resGrpParents/{resGrpParentName}";

--- a/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorResource.cs
@@ -27,6 +27,9 @@ namespace MgmtListMethods
     public partial class ResGrpParentWithAncestorResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResGrpParentWithAncestorResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resGrpParentWithAncestorName"> The resGrpParentWithAncestorName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resGrpParentWithAncestorName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MgmtListMethods/resGrpParentWithAncestors/{resGrpParentWithAncestorName}";

--- a/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorWithLocResource.cs
@@ -27,6 +27,9 @@ namespace MgmtListMethods
     public partial class ResGrpParentWithAncestorWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResGrpParentWithAncestorWithLocResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resGrpParentWithAncestorWithLocName"> The resGrpParentWithAncestorWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resGrpParentWithAncestorWithLocName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MgmtListMethods/resGrpParentWithAncestorWithLocs/{resGrpParentWithAncestorWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorWithNonResChResource.cs
@@ -29,6 +29,9 @@ namespace MgmtListMethods
     public partial class ResGrpParentWithAncestorWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResGrpParentWithAncestorWithNonResChResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resGrpParentWithAncestorWithNonResChName"> The resGrpParentWithAncestorWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resGrpParentWithAncestorWithNonResChName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MgmtListMethods/resGrpParentWithAncestorWithNonResChes/{resGrpParentWithAncestorWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorWithNonResChWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithAncestorWithNonResChWithLocResource.cs
@@ -29,6 +29,9 @@ namespace MgmtListMethods
     public partial class ResGrpParentWithAncestorWithNonResChWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResGrpParentWithAncestorWithNonResChWithLocResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resGrpParentWithAncestorWithNonResChWithLocName"> The resGrpParentWithAncestorWithNonResChWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resGrpParentWithAncestorWithNonResChWithLocName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MgmtListMethods/resGrpParentWithAncestorWithNonResChWithLocs/{resGrpParentWithAncestorWithNonResChWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/ResGrpParentWithNonResChResource.cs
@@ -29,6 +29,9 @@ namespace MgmtListMethods
     public partial class ResGrpParentWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResGrpParentWithNonResChResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resGrpParentWithNonResChName"> The resGrpParentWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resGrpParentWithNonResChName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MgmtListMethods/resGrpParentWithNonResChes/{resGrpParentWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/SubParentResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/SubParentResource.cs
@@ -27,6 +27,8 @@ namespace MgmtListMethods
     public partial class SubParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="subParentName"> The subParentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string subParentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.MgmtListMethods/subParents/{subParentName}";

--- a/test/TestProjects/MgmtListMethods/Generated/SubParentWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/SubParentWithLocResource.cs
@@ -27,6 +27,8 @@ namespace MgmtListMethods
     public partial class SubParentWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubParentWithLocResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="subParentWithLocName"> The subParentWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string subParentWithLocName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.MgmtListMethods/subParentWithLocs/{subParentWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/SubParentWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/SubParentWithNonResChResource.cs
@@ -29,6 +29,8 @@ namespace MgmtListMethods
     public partial class SubParentWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubParentWithNonResChResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="subParentWithNonResChName"> The subParentWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string subParentWithNonResChName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.MgmtListMethods/subParentWithNonResChes/{subParentWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/SubParentWithNonResChWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/SubParentWithNonResChWithLocResource.cs
@@ -29,6 +29,8 @@ namespace MgmtListMethods
     public partial class SubParentWithNonResChWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubParentWithNonResChWithLocResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="subParentWithNonResChWithLocName"> The subParentWithNonResChWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string subParentWithNonResChWithLocName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.MgmtListMethods/subParentWithNonResChWithLocs/{subParentWithNonResChWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/TenantParentResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/TenantParentResource.cs
@@ -26,6 +26,8 @@ namespace MgmtListMethods
     public partial class TenantParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TenantParentResource"/> instance. </summary>
+        /// <param name="tenantTestName"> The tenantTestName. </param>
+        /// <param name="tenantParentName"> The tenantParentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string tenantTestName, string tenantParentName)
         {
             var resourceId = $"/providers/Microsoft.Tenant/tenantTests/{tenantTestName}/tenantParents/{tenantParentName}";

--- a/test/TestProjects/MgmtListMethods/Generated/TenantParentWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/TenantParentWithLocResource.cs
@@ -26,6 +26,8 @@ namespace MgmtListMethods
     public partial class TenantParentWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TenantParentWithLocResource"/> instance. </summary>
+        /// <param name="tenantTestName"> The tenantTestName. </param>
+        /// <param name="tenantParentWithLocName"> The tenantParentWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string tenantTestName, string tenantParentWithLocName)
         {
             var resourceId = $"/providers/Microsoft.Tenant/tenantTests/{tenantTestName}/tenantParentWithLocs/{tenantParentWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/TenantParentWithNonResChResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/TenantParentWithNonResChResource.cs
@@ -28,6 +28,8 @@ namespace MgmtListMethods
     public partial class TenantParentWithNonResChResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TenantParentWithNonResChResource"/> instance. </summary>
+        /// <param name="tenantTestName"> The tenantTestName. </param>
+        /// <param name="tenantParentWithNonResChName"> The tenantParentWithNonResChName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string tenantTestName, string tenantParentWithNonResChName)
         {
             var resourceId = $"/providers/Microsoft.Tenant/tenantTests/{tenantTestName}/tenantParentWithNonResChes/{tenantParentWithNonResChName}";

--- a/test/TestProjects/MgmtListMethods/Generated/TenantParentWithNonResChWithLocResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/TenantParentWithNonResChWithLocResource.cs
@@ -28,6 +28,8 @@ namespace MgmtListMethods
     public partial class TenantParentWithNonResChWithLocResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TenantParentWithNonResChWithLocResource"/> instance. </summary>
+        /// <param name="tenantTestName"> The tenantTestName. </param>
+        /// <param name="tenantParentWithNonResChWithLocName"> The tenantParentWithNonResChWithLocName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string tenantTestName, string tenantParentWithNonResChWithLocName)
         {
             var resourceId = $"/providers/Microsoft.Tenant/tenantTests/{tenantTestName}/tenantParentWithNonResChWithLocs/{tenantParentWithNonResChWithLocName}";

--- a/test/TestProjects/MgmtListMethods/Generated/TenantTestResource.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/TenantTestResource.cs
@@ -27,6 +27,7 @@ namespace MgmtListMethods
     public partial class TenantTestResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TenantTestResource"/> instance. </summary>
+        /// <param name="tenantTestName"> The tenantTestName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string tenantTestName)
         {
             var resourceId = $"/providers/Microsoft.Tenant/tenantTests/{tenantTestName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/DeletedManagedHsmResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/DeletedManagedHsmResource.cs
@@ -26,6 +26,9 @@ namespace MgmtMockAndSample
     public partial class DeletedManagedHsmResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeletedManagedHsmResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedManagedHSMs/{name}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/DeletedVaultResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/DeletedVaultResource.cs
@@ -26,6 +26,9 @@ namespace MgmtMockAndSample
     public partial class DeletedVaultResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeletedVaultResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="vaultName"> The vaultName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string vaultName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/DiskEncryptionSetResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/DiskEncryptionSetResource.cs
@@ -27,6 +27,9 @@ namespace MgmtMockAndSample
     public partial class DiskEncryptionSetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DiskEncryptionSetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="diskEncryptionSetName"> The diskEncryptionSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string diskEncryptionSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/FirewallPolicyResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/FirewallPolicyResource.cs
@@ -27,6 +27,9 @@ namespace MgmtMockAndSample
     public partial class FirewallPolicyResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FirewallPolicyResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="firewallPolicyName"> The firewallPolicyName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string firewallPolicyName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/FirewallPolicyRuleCollectionGroupResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/FirewallPolicyRuleCollectionGroupResource.cs
@@ -25,6 +25,10 @@ namespace MgmtMockAndSample
     public partial class FirewallPolicyRuleCollectionGroupResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FirewallPolicyRuleCollectionGroupResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="firewallPolicyName"> The firewallPolicyName. </param>
+        /// <param name="ruleCollectionGroupName"> The ruleCollectionGroupName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string firewallPolicyName, string ruleCollectionGroupName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups/{ruleCollectionGroupName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/GuestConfigurationAssignmentResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/GuestConfigurationAssignmentResource.cs
@@ -25,6 +25,10 @@ namespace MgmtMockAndSample
     public partial class GuestConfigurationAssignmentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="GuestConfigurationAssignmentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
+        /// <param name="guestConfigurationAssignmentName"> The guestConfigurationAssignmentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName, string guestConfigurationAssignmentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/ManagedHsmResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/ManagedHsmResource.cs
@@ -29,6 +29,9 @@ namespace MgmtMockAndSample
     public partial class ManagedHsmResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ManagedHsmResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/MgmtMockAndSamplePrivateEndpointConnectionResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/MgmtMockAndSamplePrivateEndpointConnectionResource.cs
@@ -25,6 +25,10 @@ namespace MgmtMockAndSample
     public partial class MgmtMockAndSamplePrivateEndpointConnectionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MgmtMockAndSamplePrivateEndpointConnectionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vaultName"> The vaultName. </param>
+        /// <param name="privateEndpointConnectionName"> The privateEndpointConnectionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vaultName, string privateEndpointConnectionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/MhsmPrivateEndpointConnectionResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/MhsmPrivateEndpointConnectionResource.cs
@@ -26,6 +26,10 @@ namespace MgmtMockAndSample
     public partial class MhsmPrivateEndpointConnectionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MhsmPrivateEndpointConnectionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
+        /// <param name="privateEndpointConnectionName"> The privateEndpointConnectionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name, string privateEndpointConnectionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/privateEndpointConnections/{privateEndpointConnectionName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/RoleAssignmentResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/RoleAssignmentResource.cs
@@ -26,6 +26,8 @@ namespace MgmtMockAndSample
     public partial class RoleAssignmentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="RoleAssignmentResource"/> instance. </summary>
+        /// <param name="scope"> The scope. </param>
+        /// <param name="roleAssignmentName"> The roleAssignmentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string scope, string roleAssignmentName)
         {
             var resourceId = $"{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/VaultResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/VaultResource.cs
@@ -29,6 +29,9 @@ namespace MgmtMockAndSample
     public partial class VaultResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VaultResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vaultName"> The vaultName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vaultName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}";

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/VirtualMachineExtensionImageResource.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/VirtualMachineExtensionImageResource.cs
@@ -26,6 +26,11 @@ namespace MgmtMockAndSample
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="publisherName"> The publisherName. </param>
+        /// <param name="type"> The type. </param>
+        /// <param name="version"> The version. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/AnotherParentChildResource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/AnotherParentChildResource.cs
@@ -27,6 +27,10 @@ namespace MgmtMultipleParentResource
     public partial class AnotherParentChildResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AnotherParentChildResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="anotherName"> The anotherName. </param>
+        /// <param name="childName"> The childName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string anotherName, string childName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/anotherParents/{anotherName}/children/{childName}";

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/AnotherParentResource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/AnotherParentResource.cs
@@ -28,6 +28,9 @@ namespace MgmtMultipleParentResource
     public partial class AnotherParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AnotherParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="anotherName"> The anotherName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string anotherName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/anotherParents/{anotherName}";

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/SubParentResource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/SubParentResource.cs
@@ -27,6 +27,10 @@ namespace MgmtMultipleParentResource
     public partial class SubParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SubParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="theParentName"> The theParentName. </param>
+        /// <param name="instanceId"> The instanceId. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string theParentName, string instanceId)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/theParents/{theParentName}/subParents/{instanceId}";

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/TheParentResource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/TheParentResource.cs
@@ -28,6 +28,9 @@ namespace MgmtMultipleParentResource
     public partial class TheParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TheParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="theParentName"> The theParentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string theParentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/theParents/{theParentName}";

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/TheParentSubParentChildResource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/TheParentSubParentChildResource.cs
@@ -27,6 +27,11 @@ namespace MgmtMultipleParentResource
     public partial class TheParentSubParentChildResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TheParentSubParentChildResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="theParentName"> The theParentName. </param>
+        /// <param name="instanceId"> The instanceId. </param>
+        /// <param name="childName"> The childName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string theParentName, string instanceId, string childName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/theParents/{theParentName}/subParents/{instanceId}/children/{childName}";

--- a/test/TestProjects/MgmtNoTypeReplacement/Generated/NoTypeReplacementModel1Resource.cs
+++ b/test/TestProjects/MgmtNoTypeReplacement/Generated/NoTypeReplacementModel1Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtNoTypeReplacement
     public partial class NoTypeReplacementModel1Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="NoTypeReplacementModel1Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="noTypeReplacementModel1SName"> The noTypeReplacementModel1SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string noTypeReplacementModel1SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/noTypeReplacementModel1s/{noTypeReplacementModel1SName}";

--- a/test/TestProjects/MgmtNoTypeReplacement/Generated/NoTypeReplacementModel2Resource.cs
+++ b/test/TestProjects/MgmtNoTypeReplacement/Generated/NoTypeReplacementModel2Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtNoTypeReplacement
     public partial class NoTypeReplacementModel2Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="NoTypeReplacementModel2Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="noTypeReplacementModel2SName"> The noTypeReplacementModel2SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string noTypeReplacementModel2SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/noTypeReplacementModel2s/{noTypeReplacementModel2SName}";

--- a/test/TestProjects/MgmtNoTypeReplacement/Generated/NoTypeReplacementModel3Resource.cs
+++ b/test/TestProjects/MgmtNoTypeReplacement/Generated/NoTypeReplacementModel3Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtNoTypeReplacement
     public partial class NoTypeReplacementModel3Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="NoTypeReplacementModel3Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="noTypeReplacementModel3SName"> The noTypeReplacementModel3SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string noTypeReplacementModel3SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/noTypeReplacementModel3s/{noTypeReplacementModel3SName}";

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/BarResource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/BarResource.cs
@@ -28,6 +28,9 @@ namespace MgmtNonStringPathVariable
     public partial class BarResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BarResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="barName"> The barName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, int barName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/bars/{barName}";

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/FakeResource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/FakeResource.cs
@@ -28,6 +28,9 @@ namespace MgmtNonStringPathVariable
     public partial class FakeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="fakeName"> The fakeName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, FakeNameAsEnum fakeName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/fakes/{fakeName}";

--- a/test/TestProjects/MgmtOmitOperationGroups/Generated/Model2Resource.cs
+++ b/test/TestProjects/MgmtOmitOperationGroups/Generated/Model2Resource.cs
@@ -27,6 +27,9 @@ namespace MgmtOmitOperationGroups
     public partial class Model2Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="Model2Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="model2SName"> The model2SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string model2SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/model2s/{model2SName}";

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetChildResource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetChildResource.cs
@@ -26,6 +26,10 @@ namespace MgmtOperations
     public partial class AvailabilitySetChildResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AvailabilitySetChildResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="availabilitySetName"> The availabilitySetName. </param>
+        /// <param name="availabilitySetChildName"> The availabilitySetChildName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string availabilitySetName, string availabilitySetChildName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}/availabilitySetChildren/{availabilitySetChildName}";

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetGrandChildResource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetGrandChildResource.cs
@@ -26,6 +26,11 @@ namespace MgmtOperations
     public partial class AvailabilitySetGrandChildResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AvailabilitySetGrandChildResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="availabilitySetName"> The availabilitySetName. </param>
+        /// <param name="availabilitySetChildName"> The availabilitySetChildName. </param>
+        /// <param name="availabilitySetGrandChildName"> The availabilitySetGrandChildName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string availabilitySetName, string availabilitySetChildName, string availabilitySetGrandChildName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}/availabilitySetChildren/{availabilitySetChildName}/availabilitySetGrandChildren/{availabilitySetGrandChildName}";

--- a/test/TestProjects/MgmtOperations/Generated/AvailabilitySetResource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/AvailabilitySetResource.cs
@@ -28,6 +28,9 @@ namespace MgmtOperations
     public partial class AvailabilitySetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AvailabilitySetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="availabilitySetName"> The availabilitySetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string availabilitySetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}";

--- a/test/TestProjects/MgmtOperations/Generated/UnpatchableResource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/UnpatchableResource.cs
@@ -28,6 +28,9 @@ namespace MgmtOperations
     public partial class UnpatchableResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="UnpatchableResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/unpatchableResources/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeDecimalModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeDecimalModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeDecimalModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeDecimalModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeDecimalModel/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeDoubleModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeDoubleModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeDoubleModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeDoubleModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeDoubleModel/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeFloatModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeFloatModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeFloatModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeFloatModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeFloatModel/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeInt32ModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeInt32ModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeInt32ModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeInt32ModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeInt32Model/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeInt64ModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeInt64ModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeInt64ModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeInt64ModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeInt64Model/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeIntegerModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeIntegerModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeIntegerModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeIntegerModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeIntegerModel/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeNumericModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeNumericModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeNumericModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeNumericModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeNumericModel/{name}";

--- a/test/TestProjects/MgmtPagination/Generated/PageSizeStringModelResource.cs
+++ b/test/TestProjects/MgmtPagination/Generated/PageSizeStringModelResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPagination
     public partial class PageSizeStringModelResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PageSizeStringModelResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/pageSizeStringModel/{name}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/AvailabilitySetResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/AvailabilitySetResource.cs
@@ -28,6 +28,9 @@ namespace MgmtParamOrdering
     public partial class AvailabilitySetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AvailabilitySetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="availabilitySetName"> The availabilitySetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string availabilitySetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/DedicatedHostGroupResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/DedicatedHostGroupResource.cs
@@ -28,6 +28,9 @@ namespace MgmtParamOrdering
     public partial class DedicatedHostGroupResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DedicatedHostGroupResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="hostGroupName"> The hostGroupName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string hostGroupName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/DedicatedHostResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/DedicatedHostResource.cs
@@ -27,6 +27,10 @@ namespace MgmtParamOrdering
     public partial class DedicatedHostResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DedicatedHostResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="hostGroupName"> The hostGroupName. </param>
+        /// <param name="hostName"> The hostName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string hostGroupName, string hostName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/EnvironmentContainerResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/EnvironmentContainerResource.cs
@@ -26,6 +26,10 @@ namespace MgmtParamOrdering
     public partial class EnvironmentContainerResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="EnvironmentContainerResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="workspaceName"> The workspaceName. </param>
+        /// <param name="name"> The name. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string workspaceName, string name)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/environments/{name}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/VirtualMachineExtensionImageResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/VirtualMachineExtensionImageResource.cs
@@ -26,6 +26,11 @@ namespace MgmtParamOrdering
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="publisherName"> The publisherName. </param>
+        /// <param name="type"> The type. </param>
+        /// <param name="version"> The version. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/VirtualMachineScaleSetResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/VirtualMachineScaleSetResource.cs
@@ -28,6 +28,9 @@ namespace MgmtParamOrdering
     public partial class VirtualMachineScaleSetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineScaleSetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmScaleSetName"> The vmScaleSetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmScaleSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}";

--- a/test/TestProjects/MgmtParamOrdering/Generated/WorkspaceResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/WorkspaceResource.cs
@@ -28,6 +28,9 @@ namespace MgmtParamOrdering
     public partial class WorkspaceResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="WorkspaceResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="workspaceName"> The workspaceName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string workspaceName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}";

--- a/test/TestProjects/MgmtParent/Generated/AvailabilitySetResource.cs
+++ b/test/TestProjects/MgmtParent/Generated/AvailabilitySetResource.cs
@@ -28,6 +28,9 @@ namespace MgmtParent
     public partial class AvailabilitySetResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="AvailabilitySetResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="availabilitySetName"> The availabilitySetName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string availabilitySetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}";

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupResource.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostGroupResource.cs
@@ -28,6 +28,9 @@ namespace MgmtParent
     public partial class DedicatedHostGroupResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DedicatedHostGroupResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="hostGroupName"> The hostGroupName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string hostGroupName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}";

--- a/test/TestProjects/MgmtParent/Generated/DedicatedHostResource.cs
+++ b/test/TestProjects/MgmtParent/Generated/DedicatedHostResource.cs
@@ -27,6 +27,10 @@ namespace MgmtParent
     public partial class DedicatedHostResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DedicatedHostResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="hostGroupName"> The hostGroupName. </param>
+        /// <param name="hostName"> The hostName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string hostGroupName, string hostName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}";

--- a/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageResource.cs
+++ b/test/TestProjects/MgmtParent/Generated/VirtualMachineExtensionImageResource.cs
@@ -26,6 +26,11 @@ namespace MgmtParent
     public partial class VirtualMachineExtensionImageResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineExtensionImageResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="location"> The location. </param>
+        /// <param name="publisherName"> The publisherName. </param>
+        /// <param name="type"> The type. </param>
+        /// <param name="version"> The version. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, AzureLocation location, string publisherName, string type, string version)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}";

--- a/test/TestProjects/MgmtPartialResource/Generated/ConfigurationProfileAssignmentResource.cs
+++ b/test/TestProjects/MgmtPartialResource/Generated/ConfigurationProfileAssignmentResource.cs
@@ -26,6 +26,10 @@ namespace MgmtPartialResource
     public partial class ConfigurationProfileAssignmentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ConfigurationProfileAssignmentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
+        /// <param name="configurationProfileAssignmentName"> The configurationProfileAssignmentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName, string configurationProfileAssignmentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.Automanage/configurationProfileAssignments/{configurationProfileAssignmentName}";

--- a/test/TestProjects/MgmtPartialResource/Generated/PartialVmssResource.cs
+++ b/test/TestProjects/MgmtPartialResource/Generated/PartialVmssResource.cs
@@ -23,6 +23,9 @@ namespace MgmtPartialResource
     public partial class PartialVmssResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PartialVmssResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="virtualMachineScaleSetName"> The virtualMachineScaleSetName. </param>
         internal static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string virtualMachineScaleSetName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}";

--- a/test/TestProjects/MgmtPartialResource/Generated/PublicIPAddressResource.cs
+++ b/test/TestProjects/MgmtPartialResource/Generated/PublicIPAddressResource.cs
@@ -26,6 +26,9 @@ namespace MgmtPartialResource
     public partial class PublicIPAddressResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="PublicIPAddressResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="publicIpAddressName"> The publicIpAddressName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string publicIpAddressName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}";

--- a/test/TestProjects/MgmtPartialResource/Generated/VirtualMachineMgmtPartialResource.cs
+++ b/test/TestProjects/MgmtPartialResource/Generated/VirtualMachineMgmtPartialResource.cs
@@ -22,6 +22,9 @@ namespace MgmtPartialResource
     public partial class VirtualMachineMgmtPartialResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineMgmtPartialResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
         internal static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}";

--- a/test/TestProjects/MgmtPropertyBag/Generated/BarResource.cs
+++ b/test/TestProjects/MgmtPropertyBag/Generated/BarResource.cs
@@ -27,6 +27,9 @@ namespace MgmtPropertyBag
     public partial class BarResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BarResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="barName"> The barName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string barName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/bars/{barName}";

--- a/test/TestProjects/MgmtPropertyBag/Generated/FooResource.cs
+++ b/test/TestProjects/MgmtPropertyBag/Generated/FooResource.cs
@@ -27,6 +27,9 @@ namespace MgmtPropertyBag
     public partial class FooResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FooResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="fooName"> The fooName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string fooName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fake/foos/{fooName}";

--- a/test/TestProjects/MgmtPropertyChooser/Generated/VirtualMachineResource.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/VirtualMachineResource.cs
@@ -28,6 +28,9 @@ namespace MgmtPropertyChooser
     public partial class VirtualMachineResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VirtualMachineResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}";

--- a/test/TestProjects/MgmtResourceName/Generated/Disk.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/Disk.cs
@@ -26,6 +26,9 @@ namespace MgmtResourceName
     public partial class Disk : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="Disk"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="diskResourceName"> The diskResourceName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string diskResourceName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskResources/{diskResourceName}";

--- a/test/TestProjects/MgmtResourceName/Generated/DisplayResource.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/DisplayResource.cs
@@ -26,6 +26,9 @@ namespace MgmtResourceName
     public partial class DisplayResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DisplayResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="displayResourceName"> The displayResourceName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string displayResourceName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/displayResources/{displayResourceName}";

--- a/test/TestProjects/MgmtResourceName/Generated/MachineResource.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/MachineResource.cs
@@ -26,6 +26,9 @@ namespace MgmtResourceName
     public partial class MachineResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="MachineResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="machineName"> The machineName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string machineName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/machines/{machineName}";

--- a/test/TestProjects/MgmtResourceName/Generated/Memory.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/Memory.cs
@@ -26,6 +26,9 @@ namespace MgmtResourceName
     public partial class Memory : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="Memory"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="memoryResourceName"> The memoryResourceName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string memoryResourceName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/memoryResources/{memoryResourceName}";

--- a/test/TestProjects/MgmtResourceName/Generated/NetworkResource.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/NetworkResource.cs
@@ -26,6 +26,9 @@ namespace MgmtResourceName
     public partial class NetworkResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="NetworkResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="networkResourceName"> The networkResourceName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string networkResourceName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/networkResources/{networkResourceName}";

--- a/test/TestProjects/MgmtResourceName/Generated/ProviderOperationResource.cs
+++ b/test/TestProjects/MgmtResourceName/Generated/ProviderOperationResource.cs
@@ -26,6 +26,7 @@ namespace MgmtResourceName
     public partial class ProviderOperationResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ProviderOperationResource"/> instance. </summary>
+        /// <param name="resourceProviderNamespace"> The resourceProviderNamespace. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string resourceProviderNamespace)
         {
             var resourceId = $"/providers/Microsoft.Authorization/providerOperations/{resourceProviderNamespace}";

--- a/test/TestProjects/MgmtSafeFlatten/Generated/TypeOneResource.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/TypeOneResource.cs
@@ -27,6 +27,9 @@ namespace MgmtSafeFlatten
     public partial class TypeOneResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TypeOneResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="typeOneName"> The typeOneName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string typeOneName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TypeOne/typeOnes/{typeOneName}";

--- a/test/TestProjects/MgmtSafeFlatten/Generated/TypeTwoResource.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/TypeTwoResource.cs
@@ -27,6 +27,9 @@ namespace MgmtSafeFlatten
     public partial class TypeTwoResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TypeTwoResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="typeTwoName"> The typeTwoName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string typeTwoName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TypeTwo/typeTwos/{typeTwoName}";

--- a/test/TestProjects/MgmtScopeResource/Generated/DeploymentExtendedResource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/DeploymentExtendedResource.cs
@@ -30,6 +30,8 @@ namespace MgmtScopeResource
     public partial class DeploymentExtendedResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="DeploymentExtendedResource"/> instance. </summary>
+        /// <param name="scope"> The scope. </param>
+        /// <param name="deploymentName"> The deploymentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string scope, string deploymentName)
         {
             var resourceId = $"{scope}/providers/Microsoft.Resources/deployments/{deploymentName}";

--- a/test/TestProjects/MgmtScopeResource/Generated/FakePolicyAssignmentResource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/FakePolicyAssignmentResource.cs
@@ -25,6 +25,8 @@ namespace MgmtScopeResource
     public partial class FakePolicyAssignmentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="FakePolicyAssignmentResource"/> instance. </summary>
+        /// <param name="scope"> The scope. </param>
+        /// <param name="policyAssignmentName"> The policyAssignmentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string scope, string policyAssignmentName)
         {
             var resourceId = $"{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}";

--- a/test/TestProjects/MgmtScopeResource/Generated/GuestConfigurationAssignmentResource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/GuestConfigurationAssignmentResource.cs
@@ -25,6 +25,10 @@ namespace MgmtScopeResource
     public partial class GuestConfigurationAssignmentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="GuestConfigurationAssignmentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="vmName"> The vmName. </param>
+        /// <param name="guestConfigurationAssignmentName"> The guestConfigurationAssignmentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string vmName, string guestConfigurationAssignmentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}";

--- a/test/TestProjects/MgmtScopeResource/Generated/ResourceLinkResource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/ResourceLinkResource.cs
@@ -26,6 +26,7 @@ namespace MgmtScopeResource
     public partial class ResourceLinkResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResourceLinkResource"/> instance. </summary>
+        /// <param name="linkId"> The linkId. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string linkId)
         {
             var resourceId = $"{linkId}";

--- a/test/TestProjects/MgmtScopeResource/Generated/VMInsightsOnboardingStatusResource.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/VMInsightsOnboardingStatusResource.cs
@@ -25,6 +25,7 @@ namespace MgmtScopeResource
     public partial class VMInsightsOnboardingStatusResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="VMInsightsOnboardingStatusResource"/> instance. </summary>
+        /// <param name="resourceUri"> The resourceUri. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string resourceUri)
         {
             var resourceId = $"{resourceUri}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses/default";

--- a/test/TestProjects/MgmtSingletonResource/Generated/BrakeResource.cs
+++ b/test/TestProjects/MgmtSingletonResource/Generated/BrakeResource.cs
@@ -26,6 +26,10 @@ namespace MgmtSingletonResource
     public partial class BrakeResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="BrakeResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="carName"> The carName. </param>
+        /// <param name="default"> The default. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string carName, BrakeName @default)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/cars/{carName}/brakes/{@default}";

--- a/test/TestProjects/MgmtSingletonResource/Generated/CarResource.cs
+++ b/test/TestProjects/MgmtSingletonResource/Generated/CarResource.cs
@@ -26,6 +26,9 @@ namespace MgmtSingletonResource
     public partial class CarResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="CarResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="carName"> The carName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string carName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/cars/{carName}";

--- a/test/TestProjects/MgmtSingletonResource/Generated/IgnitionResource.cs
+++ b/test/TestProjects/MgmtSingletonResource/Generated/IgnitionResource.cs
@@ -25,6 +25,9 @@ namespace MgmtSingletonResource
     public partial class IgnitionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="IgnitionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="carName"> The carName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string carName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/cars/{carName}/ignitions/default";

--- a/test/TestProjects/MgmtSingletonResource/Generated/ParentResource.cs
+++ b/test/TestProjects/MgmtSingletonResource/Generated/ParentResource.cs
@@ -27,6 +27,9 @@ namespace MgmtSingletonResource
     public partial class ParentResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ParentResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="parentName"> The parentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string parentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Billing/parentResources/{parentName}";

--- a/test/TestProjects/MgmtSingletonResource/Generated/SingletonResource.cs
+++ b/test/TestProjects/MgmtSingletonResource/Generated/SingletonResource.cs
@@ -25,6 +25,9 @@ namespace MgmtSingletonResource
     public partial class SingletonResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SingletonResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="parentName"> The parentName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string parentName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Billing/parentResources/{parentName}/singletonResources/current";

--- a/test/TestProjects/MgmtSubscriptionNameParameter/Generated/SBSubscriptionResource.cs
+++ b/test/TestProjects/MgmtSubscriptionNameParameter/Generated/SBSubscriptionResource.cs
@@ -26,6 +26,9 @@ namespace MgmtSubscriptionNameParameter
     public partial class SBSubscriptionResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SBSubscriptionResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="subscriptionName"> The subscriptionName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string subscriptionName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/subscriptions/{subscriptionName}";

--- a/test/TestProjects/MgmtSupersetFlattenInheritance/Generated/ResourceModel1Resource.cs
+++ b/test/TestProjects/MgmtSupersetFlattenInheritance/Generated/ResourceModel1Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtSupersetFlattenInheritance
     public partial class ResourceModel1Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="ResourceModel1Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="resourceModel1SName"> The resourceModel1SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string resourceModel1SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/resourceModel1s/{resourceModel1SName}";

--- a/test/TestProjects/MgmtSupersetFlattenInheritance/Generated/TrackedResourceModel1Resource.cs
+++ b/test/TestProjects/MgmtSupersetFlattenInheritance/Generated/TrackedResourceModel1Resource.cs
@@ -27,6 +27,9 @@ namespace MgmtSupersetFlattenInheritance
     public partial class TrackedResourceModel1Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="TrackedResourceModel1Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="trackedResourceModel1SName"> The trackedResourceModel1SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string trackedResourceModel1SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/trackedResourceModel1s/{trackedResourceModel1SName}";

--- a/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel1Resource.cs
+++ b/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel1Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtSupersetInheritance
     public partial class SupersetModel1Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SupersetModel1Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="supersetModel1SName"> The supersetModel1SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string supersetModel1SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/supersetModel1s/{supersetModel1SName}";

--- a/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel4Resource.cs
+++ b/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel4Resource.cs
@@ -27,6 +27,9 @@ namespace MgmtSupersetInheritance
     public partial class SupersetModel4Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SupersetModel4Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="supersetModel4SName"> The supersetModel4SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string supersetModel4SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/supersetModel4s/{supersetModel4SName}";

--- a/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel6Resource.cs
+++ b/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel6Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtSupersetInheritance
     public partial class SupersetModel6Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SupersetModel6Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="supersetModel6SName"> The supersetModel6SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string supersetModel6SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/supersetModel6s/{supersetModel6SName}";

--- a/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel7Resource.cs
+++ b/test/TestProjects/MgmtSupersetInheritance/Generated/SupersetModel7Resource.cs
@@ -26,6 +26,9 @@ namespace MgmtSupersetInheritance
     public partial class SupersetModel7Resource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="SupersetModel7Resource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="supersetModel7SName"> The supersetModel7SName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string supersetModel7SName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/supersetModel7s/{supersetModel7SName}";

--- a/test/TestProjects/MgmtXmlDeserialization/Generated/XmlInstanceResource.cs
+++ b/test/TestProjects/MgmtXmlDeserialization/Generated/XmlInstanceResource.cs
@@ -26,6 +26,9 @@ namespace MgmtXmlDeserialization
     public partial class XmlInstanceResource : ArmResource
     {
         /// <summary> Generate the resource identifier of a <see cref="XmlInstanceResource"/> instance. </summary>
+        /// <param name="subscriptionId"> The subscriptionId. </param>
+        /// <param name="resourceGroupName"> The resourceGroupName. </param>
+        /// <param name="xmlName"> The xmlName. </param>
         public static ResourceIdentifier CreateResourceIdentifier(string subscriptionId, string resourceGroupName, string xmlName)
         {
             var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.XmlDeserialization/xmls/{xmlName}";


### PR DESCRIPTION
# Description

This PR refactors the code to use expressions to write the `CreateResourceIdentifier` method.
To do this, a `FormattableStringExpression` is introduced, using this new expression you could just use a `FormattableString` instance built from other expressions and it will just turns out to be the way you constructed it
```csharp
var writer = new CodeWriter();
var a = new VariableReference(typeof(bool), "a");
var b = new VariableReference(typeof(bool), "b");
var expression = And(a, b);
writer.WriteValueExpression(new FormattableStringExpression("the result is {0}", new[] {expression}));
// this will write:
// $"the result is {a && b}"
```

One side effect of this change is that now the `CreateResourceIdentifier` method will have some extra parameter documentation.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first