### PR TITLE
Adding ReadOnlyMemory support

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -116,6 +116,7 @@ namespace AutoRest.CSharp.Generation.Types
                 {
                     return new CSharpType(type.Arguments[0].FrameworkType.MakeArrayType());
                 }
+
                 if (IsList(type))
                 {
                     return new CSharpType(typeof(List<>), type.Arguments);
@@ -134,6 +135,11 @@ namespace AutoRest.CSharp.Generation.Types
         {
             if (type.IsFrameworkType)
             {
+                if (IsReadOnlyMemory(type))
+                {
+                    return new CSharpType(typeof(ReadOnlyMemory<>), type.Arguments);
+                }
+
                 if (IsList(type))
                 {
                     return new CSharpType(Configuration.ApiTypes.ChangeTrackingListType, type.Arguments);
@@ -335,6 +341,11 @@ namespace AutoRest.CSharp.Generation.Types
         {
             if (type.IsFrameworkType)
             {
+                if (IsReadOnlyMemory(type))
+                {
+                    return new CSharpType(typeof(ReadOnlyMemory<>), isNullable: type.IsNullable, type.Arguments);
+                }
+
                 if (IsList(type))
                 {
                     return new CSharpType(
@@ -351,6 +362,11 @@ namespace AutoRest.CSharp.Generation.Types
         {
             if (type.IsFrameworkType)
             {
+                if (IsReadOnlyMemory(type))
+                {
+                    return new CSharpType(typeof(ReadOnlyMemory<>), isNullable: type.IsNullable, type.Arguments);
+                }
+
                 if (IsList(type))
                 {
                     return new CSharpType(

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
@@ -248,6 +248,9 @@ namespace AutoRest.CSharp.Generation.Writers
                     writer.AppendRaw(") => ");
                     writer.WriteValueExpression(localFunction.Body);
                     break;
+                case UnaryOperatorStatement unaryOperatorStatement:
+                    writer.WriteValueExpression(unaryOperatorStatement.Value);
+                    break;
             }
 
             writer.LineRaw(";");
@@ -509,8 +512,16 @@ namespace AutoRest.CSharp.Generation.Writers
                     }
                     break;
 
-                case NewArrayExpression(var type, var items):
-                    if (items is { Elements.Count: > 0 })
+                case NewArrayExpression(var type, var items, var size):
+                    if (size is not null)
+                    {
+                        writer.Append($"new {type?.FrameworkType.GetElementType()}");
+                        writer.AppendRaw("[");
+                        writer.WriteValueExpression(size);
+                        writer.AppendRaw("]");
+                        break;
+                    }
+                    else if (items is { Elements.Count: > 0 })
                     {
                         if (type is null)
                         {
@@ -590,6 +601,12 @@ namespace AutoRest.CSharp.Generation.Writers
                     break;
                 case StringLiteralExpression(var literal, false):
                     writer.Literal(literal);
+                    break;
+                case ArrayElementExpression(var array, var index):
+                    writer.WriteValueExpression(array);
+                    writer.AppendRaw("[");
+                    writer.WriteValueExpression(index);
+                    writer.AppendRaw("]");
                     break;
             }
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
@@ -249,7 +249,7 @@ namespace AutoRest.CSharp.Generation.Writers
                     writer.WriteValueExpression(localFunction.Body);
                     break;
                 case UnaryOperatorStatement unaryOperatorStatement:
-                    writer.WriteValueExpression(unaryOperatorStatement.Value);
+                    writer.WriteValueExpression(unaryOperatorStatement.Expression);
                     break;
             }
 

--- a/src/AutoRest.CSharp/Common/Generation/Writers/FormattableStringHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/FormattableStringHelpers.cs
@@ -75,6 +75,9 @@ namespace AutoRest.CSharp.Generation.Writers
 
         public static FormattableString? GetParameterInitializer(this CSharpType parameterType, Constant? defaultValue)
         {
+            if (parameterType.IsValueType)
+                return null;
+
             if (TypeFactory.IsCollectionType(parameterType) && (defaultValue == null || TypeFactory.IsCollectionType(defaultValue.Value.Type)))
             {
                 defaultValue = Constant.NewInstanceOf(TypeFactory.GetImplementationType(parameterType).WithNullable(false));

--- a/src/AutoRest.CSharp/Common/Generation/Writers/FormattableStringHelpers.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/FormattableStringHelpers.cs
@@ -76,7 +76,9 @@ namespace AutoRest.CSharp.Generation.Writers
         public static FormattableString? GetParameterInitializer(this CSharpType parameterType, Constant? defaultValue)
         {
             if (parameterType.IsValueType)
+            {
                 return null;
+            }
 
             if (TypeFactory.IsCollectionType(parameterType) && (defaultValue == null || TypeFactory.IsCollectionType(defaultValue.Value.Type)))
             {

--- a/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelPartials.cs
@@ -117,6 +117,8 @@ namespace AutoRest.CSharp.Input
         public string? Namespace => TryGetValue("x-namespace", out object? value) ? value?.ToString() : null;
         public string? Usage => TryGetValue("x-csharp-usage", out object? value) ? value?.ToString() : null;
 
+        public bool IsEmbeddingsVector => TryGetValue("x-ms-embedding-vector", out var value) && Convert.ToBoolean(value);
+
         public string[] Formats
         {
             get

--- a/src/AutoRest.CSharp/Common/Output/Builders/JsonSerializationMethodsBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/JsonSerializationMethodsBuilder.cs
@@ -113,7 +113,7 @@ namespace AutoRest.CSharp.Common.Output.Builders
                 utf8JsonWriter.WritePropertyName(serialization.SerializedName),
                 serialization.CustomSerializationMethodName is {} serializationMethodName
                     ? InvokeCustomSerializationMethod(serializationMethodName, utf8JsonWriter)
-                    : SerializeExpression(utf8JsonWriter, serialization.ValueSerialization, serialization.EnumerableValue) // EnumerableValue is equal to Value if its not an array
+                    : SerializeExpression(utf8JsonWriter, serialization.ValueSerialization, serialization.EnumerableValue ?? serialization.Value)
             };
         }
 

--- a/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
@@ -278,8 +278,8 @@ namespace AutoRest.CSharp.Output.Builders
                 if (property.SchemaProperty is not null && property.SchemaProperty.Extensions is not null && property.SchemaProperty.Extensions.IsEmbeddingsVector)
                 {
                     enumerableExpression = property.Declaration.Type.IsNullable
-                    ? new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(Nullable<ReadOnlyMemory<object>>.Value)}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType))
-                    : new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType));
+                        ? new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(Nullable<ReadOnlyMemory<object>>.Value)}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType))
+                        : new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType));
                 }
                 yield return new JsonPropertySerialization(
                     parameter.Name,

--- a/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
@@ -273,9 +273,12 @@ namespace AutoRest.CSharp.Output.Builders
                 var isReadOnly = schemaProperty.IsReadOnly;
                 var serialization = BuildSerialization(schemaProperty.Schema, property.Declaration.Type, false);
 
+                var memberExpression = property.SchemaProperty is not null && property.SchemaProperty.Extensions is not null && property.SchemaProperty.Extensions.IsEmbeddingsVector
+                    ? new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType))
+                    : new TypedMemberExpression(null, property.Declaration.Name, property.Declaration.Type);
                 yield return new JsonPropertySerialization(
                     parameter.Name,
-                    new TypedMemberExpression(null, property.Declaration.Name, property.Declaration.Type),
+                    memberExpression,
                     serializedName,
                     property.ValueType,
                     serialization,

--- a/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
@@ -273,12 +273,17 @@ namespace AutoRest.CSharp.Output.Builders
                 var isReadOnly = schemaProperty.IsReadOnly;
                 var serialization = BuildSerialization(schemaProperty.Schema, property.Declaration.Type, false);
 
-                var memberExpression = property.SchemaProperty is not null && property.SchemaProperty.Extensions is not null && property.SchemaProperty.Extensions.IsEmbeddingsVector
-                    ? new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType))
-                    : new TypedMemberExpression(null, property.Declaration.Name, property.Declaration.Type);
+                var memberValueExpression = new TypedMemberExpression(null, property.Declaration.Name, property.Declaration.Type);
+                TypedMemberExpression? enumerableExpression = null;
+                if (property.SchemaProperty is not null && property.SchemaProperty.Extensions is not null && property.SchemaProperty.Extensions.IsEmbeddingsVector)
+                {
+                    enumerableExpression = property.Declaration.Type.IsNullable
+                    ? new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(Nullable<ReadOnlyMemory<object>>.Value)}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType))
+                    : new TypedMemberExpression(null, $"{property.Declaration.Name}.{nameof(ReadOnlyMemory<object>.Span)}", typeof(ReadOnlySpan<>).MakeGenericType(property.Declaration.Type.Arguments[0].FrameworkType));
+                }
                 yield return new JsonPropertySerialization(
                     parameter.Name,
-                    memberExpression,
+                    memberValueExpression,
                     serializedName,
                     property.ValueType,
                     serialization,
@@ -286,7 +291,8 @@ namespace AutoRest.CSharp.Output.Builders
                     isReadOnly,
                     false,
                     customSerializationMethodName: property.SerializationMapping?.SerializationValueHook,
-                    customDeserializationMethodName: property.SerializationMapping?.DeserializationValueHook);
+                    customDeserializationMethodName: property.SerializationMapping?.DeserializationValueHook,
+                    enumerableExpression: enumerableExpression);
             }
 
             foreach ((string name, SerializationPropertyBag innerBag) in propertyBag.Bag)

--- a/src/AutoRest.CSharp/Common/Output/Expressions/KnownValueExpressions/JsonElementExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/KnownValueExpressions/JsonElementExpression.cs
@@ -34,6 +34,7 @@ namespace AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions
         public ValueExpression GetSingle() => Untyped.Invoke(nameof(JsonElement.GetSingle));
         public StringExpression GetString() => new(Untyped.Invoke(nameof(JsonElement.GetString)));
         public ValueExpression GetTimeSpan(string? format) => InvokeExtension(Configuration.ApiTypes.JsonElementExtensionsType, nameof(JsonElementExtensions.GetTimeSpan), Literal(format));
+        public ValueExpression GetArrayLength() => Invoke(nameof(JsonElement.GetArrayLength));
 
         public BoolExpression ValueKindEqualsNull()
             => new(new BinaryOperatorExpression("==", Property(nameof(JsonElement.ValueKind)), FrameworkEnumValue(JsonValueKind.Null)));

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Convert.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Convert.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions;
+using AutoRest.CSharp.Common.Output.Expressions.Statements;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 using AutoRest.CSharp.Generation.Types;
 
@@ -22,6 +23,8 @@ namespace AutoRest.CSharp.Common.Output.Models
 
             return expression;
         }
+
+        internal static MethodBodyStatement Increment(VariableReference value) => new UnaryOperatorStatement(new UnaryOperatorExpression("++", value, true));
 
         public static class InvokeConvert
         {

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.DeclarationStatements.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.DeclarationStatements.cs
@@ -4,7 +4,6 @@
 using System;
 using AutoRest.CSharp.Common.Input;
 using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions;
-using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions.Azure;
 using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions.Base;
 using AutoRest.CSharp.Common.Output.Expressions.Statements;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.New.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.New.cs
@@ -30,6 +30,7 @@ namespace AutoRest.CSharp.Common.Output.Models
             public static EnumerableExpression Array(CSharpType? elementType) => new(elementType ?? typeof(object), new NewArrayExpression(elementType));
             public static EnumerableExpression Array(CSharpType? elementType, params ValueExpression[] items) => new(elementType ?? typeof(object), new NewArrayExpression(elementType, new ArrayInitializerExpression(items)));
             public static EnumerableExpression Array(CSharpType? elementType, bool isInline, params ValueExpression[] items) => new(elementType ?? typeof(object), new NewArrayExpression(elementType, new ArrayInitializerExpression(items, isInline)));
+            public static EnumerableExpression Array(CSharpType? elementType, ValueExpression size) => new(elementType ?? typeof(object), new NewArrayExpression(elementType, Size: size));
 
             public static DictionaryExpression Dictionary(CSharpType dictionaryType) => new(TypeFactory.GetElementType(dictionaryType), new NewDictionaryExpression(dictionaryType));
             public static DictionaryExpression Dictionary(CSharpType keyType, CSharpType valueType) => Dictionary(new CSharpType(typeof(Dictionary<,>), keyType, valueType));

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
@@ -22,7 +22,7 @@ namespace AutoRest.CSharp.Common.Output.Models
 
             public static MethodBodyStatement WrapInIsDefined(PropertySerialization serialization, MethodBodyStatement statement)
             {
-                if (serialization.IsRequired || (serialization.Value.Type.IsFrameworkType && serialization.Value.Type.FrameworkType.IsValueType))
+                if (serialization.IsRequired || TypeFactory.IsReadOnlyMemory(serialization.Value.Type))
                 {
                     return statement;
                 }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
@@ -14,22 +14,22 @@ namespace AutoRest.CSharp.Common.Output.Models
     {
         public static class InvokeOptional
         {
-            public static BoolExpression IsCollectionDefined(ValueExpression collection) => new(new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalIsCollectionDefinedName, new[]{collection}));
-            public static BoolExpression IsDefined(ValueExpression value) => new(new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalIsDefinedName, new[]{value}));
-            public static ValueExpression ToDictionary(ValueExpression dictionary) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToDictionaryName, new[]{dictionary});
-            public static ValueExpression ToList(ValueExpression collection) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToListName, new[]{collection});
-            public static ValueExpression ToNullable(ValueExpression optional) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToNullableName, new[]{optional});
+            public static BoolExpression IsCollectionDefined(ValueExpression collection) => new(new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalIsCollectionDefinedName, new[] { collection }));
+            public static BoolExpression IsDefined(ValueExpression value) => new(new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalIsDefinedName, new[] { value }));
+            public static ValueExpression ToDictionary(ValueExpression dictionary) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToDictionaryName, new[] { dictionary });
+            public static ValueExpression ToList(ValueExpression collection) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToListName, new[] { collection });
+            public static ValueExpression ToNullable(ValueExpression optional) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToNullableName, new[] { optional });
 
             public static MethodBodyStatement WrapInIsDefined(PropertySerialization serialization, MethodBodyStatement statement)
             {
-                if (serialization.IsRequired)
+                if (serialization.IsRequired || (serialization.Value.Type.IsFrameworkType && serialization.Value.Type.FrameworkType.IsValueType))
                 {
                     return statement;
                 }
 
                 return TypeFactory.IsCollectionType(serialization.Value.Type)
-                    ? new IfStatement(IsCollectionDefined(serialization.Value)) {statement}
-                    : new IfStatement(IsDefined(serialization.Value)) {statement};
+                    ? new IfStatement(IsCollectionDefined(serialization.Value)) { statement }
+                    : new IfStatement(IsDefined(serialization.Value)) { statement };
             }
         }
     }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Statements/UnaryOperatorStatement.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Statements/UnaryOperatorStatement.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
+
+namespace AutoRest.CSharp.Common.Output.Expressions.Statements
+{
+    internal record UnaryOperatorStatement(ValueExpression Value) : DeclarationStatement;
+}

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Statements/UnaryOperatorStatement.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Statements/UnaryOperatorStatement.cs
@@ -5,5 +5,5 @@ using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 
 namespace AutoRest.CSharp.Common.Output.Expressions.Statements
 {
-    internal record UnaryOperatorStatement(ValueExpression Value) : DeclarationStatement;
+    internal record UnaryOperatorStatement(UnaryOperatorExpression Expression) : DeclarationStatement;
 }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/ArrayElementExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/ArrayElementExpression.cs
@@ -1,0 +1,7 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+namespace AutoRest.CSharp.Common.Output.Expressions.ValueExpressions
+{
+    internal record ArrayElementExpression(ValueExpression array, ValueExpression index) : ValueExpression;
+}

--- a/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/NewArrayExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/NewArrayExpression.cs
@@ -5,5 +5,5 @@ using AutoRest.CSharp.Generation.Types;
 
 namespace AutoRest.CSharp.Common.Output.Expressions.ValueExpressions
 {
-    internal record NewArrayExpression(CSharpType? Type, ArrayInitializerExpression? Items = null) : ValueExpression;
+    internal record NewArrayExpression(CSharpType? Type, ArrayInitializerExpression? Items = null, ValueExpression? Size = null) : ValueExpression;
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Serialization/Json/JsonPropertySerialization.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Serialization/Json/JsonPropertySerialization.cs
@@ -8,8 +8,19 @@ namespace AutoRest.CSharp.Output.Models.Serialization.Json
 {
     internal class JsonPropertySerialization : PropertySerialization
     {
-        public JsonPropertySerialization(string parameterName, TypedValueExpression value, string serializedName, CSharpType? serializedType, JsonSerialization valueSerialization, bool isRequired, bool shouldSkipSerialization, bool shouldSkipDeserialization, string? customSerializationMethodName = null, string? customDeserializationMethodName = null)
-            : base(parameterName, value, serializedName, serializedType, isRequired, shouldSkipSerialization, shouldSkipDeserialization)
+        public JsonPropertySerialization(
+            string parameterName,
+            TypedValueExpression value,
+            string serializedName,
+            CSharpType? serializedType,
+            JsonSerialization valueSerialization,
+            bool isRequired,
+            bool shouldSkipSerialization,
+            bool shouldSkipDeserialization,
+            string? customSerializationMethodName = null,
+            string? customDeserializationMethodName = null,
+            TypedValueExpression? enumerableExpression = null)
+            : base(parameterName, value, serializedName, serializedType, isRequired, shouldSkipSerialization, shouldSkipDeserialization, enumerableExpression)
         {
             ValueSerialization = valueSerialization;
             CustomSerializationMethodName = customSerializationMethodName;

--- a/src/AutoRest.CSharp/Common/Output/Models/Serialization/PropertySerialization.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Serialization/PropertySerialization.cs
@@ -19,6 +19,11 @@ namespace AutoRest.CSharp.Output.Models.Serialization
         public TypedValueExpression Value { get; }
 
         /// <summary>
+        /// Value expression to be enumerated over. Used in serialization logic only.
+        /// </summary>
+        public TypedValueExpression EnumerableValue { get; }
+
+        /// <summary>
         /// Name of the property in serialized string
         /// </summary>
         public string SerializedName { get; }
@@ -36,7 +41,7 @@ namespace AutoRest.CSharp.Output.Models.Serialization
         {
         }
 
-        protected PropertySerialization(string parameterName, TypedValueExpression value, string serializedName, CSharpType? serializedType, bool isRequired, bool shouldSkipSerialization, bool shouldSkipDeserialization)
+        protected PropertySerialization(string parameterName, TypedValueExpression value, string serializedName, CSharpType? serializedType, bool isRequired, bool shouldSkipSerialization, bool shouldSkipDeserialization, TypedValueExpression? enumerableValue = null)
         {
             SerializationConstructorParameterName = parameterName;
             Value = value;
@@ -45,6 +50,7 @@ namespace AutoRest.CSharp.Output.Models.Serialization
             IsRequired = isRequired;
             ShouldSkipSerialization = shouldSkipSerialization;
             ShouldSkipDeserialization = shouldSkipDeserialization;
+            EnumerableValue = enumerableValue ?? value;
         }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Serialization/PropertySerialization.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Serialization/PropertySerialization.cs
@@ -21,7 +21,7 @@ namespace AutoRest.CSharp.Output.Models.Serialization
         /// <summary>
         /// Value expression to be enumerated over. Used in serialization logic only.
         /// </summary>
-        public TypedValueExpression EnumerableValue { get; }
+        public TypedValueExpression? EnumerableValue { get; }
 
         /// <summary>
         /// Name of the property in serialized string
@@ -50,7 +50,7 @@ namespace AutoRest.CSharp.Output.Models.Serialization
             IsRequired = isRequired;
             ShouldSkipSerialization = shouldSkipSerialization;
             ShouldSkipDeserialization = shouldSkipDeserialization;
-            EnumerableValue = enumerableValue ?? value;
+            EnumerableValue = enumerableValue;
         }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProvider.cs
@@ -281,7 +281,14 @@ namespace AutoRest.CSharp.Output.Models.Types
                 {
                     if (initializationValue == null && TypeFactory.IsCollectionType(propertyType))
                     {
-                        initializationValue = Constant.NewInstanceOf(TypeFactory.GetPropertyImplementationType(propertyType));
+                        if (TypeFactory.IsReadOnlyMemory(propertyType))
+                        {
+                            initializationValue = propertyType.IsNullable ? null : Constant.FromExpression($"{propertyType}.{nameof(ReadOnlyMemory<object>.Empty)}", propertyType);
+                        }
+                        else
+                        {
+                            initializationValue = Constant.NewInstanceOf(TypeFactory.GetPropertyImplementationType(propertyType));
+                        }
                     }
                 }
 

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -261,7 +261,14 @@ namespace AutoRest.CSharp.Output.Models.Types
 
                     if (initializationValue == null && TypeFactory.IsCollectionType(propertyType))
                     {
-                        initializationValue = Constant.NewInstanceOf(TypeFactory.GetPropertyImplementationType(propertyType));
+                        if (TypeFactory.IsReadOnlyMemory(propertyType))
+                        {
+                            initializationValue = propertyType.IsNullable ? null : Constant.FromExpression($"{propertyType}.{nameof(ReadOnlyMemory<object>.Empty)}", propertyType);
+                        }
+                        else
+                        {
+                            initializationValue = Constant.NewInstanceOf(TypeFactory.GetPropertyImplementationType(propertyType));
+                        }
                     }
                 }
 
@@ -405,7 +412,6 @@ namespace AutoRest.CSharp.Output.Models.Types
                         continue;
                     }
 
-
                     yield return CreateProperty(property);
                 }
             }
@@ -453,7 +459,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                 valueType = valueType.WithNullable(false);
             }
 
-            bool isCollection = TypeFactory.IsCollectionType(type);
+            bool isCollection = TypeFactory.IsCollectionType(type) && !TypeFactory.IsReadOnlyMemory(type);
 
             bool propertyShouldOmitSetter = IsStruct ||
                               !_usage.HasFlag(SchemaTypeUsage.Input) ||

--- a/src/AutoRest.CSharp/LowLevel/Extensions/Snippets.ExampleValues.cs
+++ b/src/AutoRest.CSharp/LowLevel/Extensions/Snippets.ExampleValues.cs
@@ -27,6 +27,9 @@ namespace AutoRest.CSharp.LowLevel.Extensions
     {
         private static ValueExpression GetExpression(CSharpType type, InputExampleValue exampleValue, SerializationFormat serializationFormat, bool includeCollectionInitialization = true)
         {
+            // handle ReadOnlyMemory
+            if (TypeFactory.IsReadOnlyMemory(type))
+                return GetExpressionForList(type, exampleValue, serializationFormat, true);
             // handle list
             if (TypeFactory.IsList(type))
                 return GetExpressionForList(type, exampleValue, serializationFormat, includeCollectionInitialization);

--- a/src/AutoRest.CSharp/Properties/launchSettings.json
+++ b/src/AutoRest.CSharp/Properties/launchSettings.json
@@ -73,8 +73,8 @@
       "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestProjects\\sdk\\newprojecttypespec\\Azure.NewProject.TypeSpec\\src\\Generated -n"
     },
     "Azure.ResourceManager.Sample": {
-      "commandName": "Project",
-      "commandLineArgs": "--standalone $(SolutionDir)\\samples\\Azure.ResourceManager.Sample\\Generated"
+        "commandName": "Project",
+        "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestProjects\\ModelShapes\\Generated"
     },
     "Azure.ResourceManager.Storage": {
       "commandName": "Project",

--- a/src/AutoRest.CSharp/Properties/launchSettings.json
+++ b/src/AutoRest.CSharp/Properties/launchSettings.json
@@ -73,8 +73,8 @@
       "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestProjects\\sdk\\newprojecttypespec\\Azure.NewProject.TypeSpec\\src\\Generated -n"
     },
     "Azure.ResourceManager.Sample": {
-        "commandName": "Project",
-        "commandLineArgs": "--standalone $(SolutionDir)\\test\\TestProjects\\ModelShapes\\Generated"
+      "commandName": "Project",
+      "commandLineArgs": "--standalone $(SolutionDir)\\samples\\Azure.ResourceManager.Sample\\Generated"
     },
     "Azure.ResourceManager.Storage": {
       "commandName": "Project",

--- a/test/AutoRest.TestServer.Tests/ModelShapeTests.cs
+++ b/test/AutoRest.TestServer.Tests/ModelShapeTests.cs
@@ -190,6 +190,10 @@ namespace AutoRest.TestServer.Tests
                 null,
                 null,
                 null,
+                null,
+                ReadOnlyMemory<float>.Empty,
+                ReadOnlyMemory<float>.Empty,
+                null,
                 null
             );
 
@@ -209,6 +213,10 @@ namespace AutoRest.TestServer.Tests
                 Array.Empty<int>(),
                 null,
                 null,
+                null,
+                null,
+                ReadOnlyMemory<float>.Empty,
+                ReadOnlyMemory<float>.Empty,
                 null,
                 null
             );
@@ -231,7 +239,12 @@ namespace AutoRest.TestServer.Tests
                 "string",
                 1,
                 Array.Empty<string>(),
-                Array.Empty<int>()
+                Array.Empty<int>(),
+                ReadOnlyMemory<float>.Empty,
+                ReadOnlyMemory<float>.Empty,
+                null,
+                null
+
             );
 
             var element = JsonAsserts.AssertSerializes(inputModel);
@@ -381,7 +394,12 @@ namespace AutoRest.TestServer.Tests
                 null,
                 null,
                 Array.Empty<string>(),
-                Array.Empty<int>()
+                Array.Empty<int>(),
+                ReadOnlyMemory<float>.Empty,
+                ReadOnlyMemory<float>.Empty,
+                null,
+                null
+
             );
         }
 
@@ -396,7 +414,12 @@ namespace AutoRest.TestServer.Tests
                 "string",
                 1,
                 Array.Empty<string>(),
-                Array.Empty<int>()
+                Array.Empty<int>(),
+                ReadOnlyMemory<float>.Empty,
+                ReadOnlyMemory<float>.Empty,
+                null,
+                null
+
             );
 
             inputModel.RequiredIntList.Add(1);

--- a/test/TestProjects/Customizations-TypeSpec/Customizations-TypeSpec.tsp
+++ b/test/TestProjects/Customizations-TypeSpec/Customizations-TypeSpec.tsp
@@ -90,6 +90,34 @@ model ModelWithCustomizedProperties {
 
   @doc("Property renamed that is listofdictionary")
   badListOfDictionaryName: Record<string>[];
+
+  @doc("Property type changed to ReadOnlyMemory<float>")
+  vector: float32[];
+
+  @doc("Property type changed to ReadOnlyMemory<float>?")
+  vectorOptional?: float32[];
+
+  @doc("Property type changed to ReadOnlyMemory<float>?")
+  vectorNullable: float32[] | null;
+
+  @doc("Property type changed to ReadOnlyMemory<float>?")
+  vectorOptionalNullable?: float32[] | null;
+
+  @doc("Property type changed to ReadOnlyMemory<float>")
+  @visibility("read")
+  vectorReadOnly: float32[];
+
+  @doc("Property type changed to ReadOnlyMemory<float>?")
+  @visibility("read")
+  vectorOptionalReadOnly?: float32[];
+
+  @doc("Property type changed to ReadOnlyMemory<float>?")
+  @visibility("read")
+  vectorNullableReadOnly: float32[] | null;
+
+  @doc("Property type changed to ReadOnlyMemory<float>?")
+  @visibility("read")
+  vectorOptionalNullableReadOnly?: float32[] | null;
 }
 
 @doc("Renamed enum (original name: EnumToRename)")

--- a/test/TestProjects/Customizations-TypeSpec/src/Customizations/ModelWithCustomizedProperties.cs
+++ b/test/TestProjects/Customizations-TypeSpec/src/Customizations/ModelWithCustomizedProperties.cs
@@ -75,5 +75,29 @@ namespace CustomizationsInTsp.Models
         /// </summary>
         [CodeGenMember("BadListOfDictionaryName")]
         public IList<IDictionary<string, string>> GoodListOfDictionaryName { get; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float> Vector { get; set; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float>? VectorOptional { get; set; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float>? VectorNullable { get; set; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float>? VectorOptionalNullable { get; set; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float> VectorReadOnly { get; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float>? VectorOptionalReadOnly { get; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float>? VectorNullableReadOnly { get; }
+
+        /// <summary> Property type changed to ReadOnlyMemory&lt;float&gt;. </summary>
+        public ReadOnlyMemory<float>? VectorOptionalNullableReadOnly { get; }
     }
 }

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/Docs/CustomizationsInTspClient.xml
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/Docs/CustomizationsInTspClient.xml
@@ -34,7 +34,11 @@ RootModel input = new RootModel
         {
             ["key"] = "<badListOfDictionaryName>"
         }
-    }),
+    }, new float[] { 123.45F }, new float[] { 123.45F })
+    {
+        VectorOptional = new float[] { 123.45F },
+        VectorOptionalNullable = new float[] { 123.45F },
+    },
     PropertyEnumToRename = RenamedEnum.One,
     PropertyEnumWithValueToRename = EnumWithValueToRename.One,
     PropertyEnumToBeMadeExtensible = EnumToBeMadeExtensible.ExOne,
@@ -77,7 +81,11 @@ RootModel input = new RootModel
         {
             ["key"] = "<badListOfDictionaryName>"
         }
-    }),
+    }, new float[] { 123.45F }, new float[] { 123.45F })
+    {
+        VectorOptional = new float[] { 123.45F },
+        VectorOptionalNullable = new float[] { 123.45F },
+    },
     PropertyEnumToRename = RenamedEnum.One,
     PropertyEnumWithValueToRename = EnumWithValueToRename.One,
     PropertyEnumToBeMadeExtensible = EnumToBeMadeExtensible.ExOne,
@@ -151,6 +159,22 @@ using RequestContent content = RequestContent.Create(new
                 key = "<badListOfDictionaryName>",
             }
         },
+        vector = new object[]
+        {
+            123.45F
+        },
+        vectorOptional = new object[]
+        {
+            123.45F
+        },
+        vectorNullable = new object[]
+        {
+            123.45F
+        },
+        vectorOptionalNullable = new object[]
+        {
+            123.45F
+        },
     },
     propertyEnumToRename = "1",
     propertyEnumWithValueToRename = "1",
@@ -181,6 +205,14 @@ Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").Ge
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badDictionaryName").GetProperty("<key>").ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfListName")[0][0].ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfDictionaryName")[0].GetProperty("<key>").ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vector")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptional")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullable")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullable")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorReadOnly")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalReadOnly")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullableReadOnly")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullableReadOnly")[0].ToString());
 Console.WriteLine(result.GetProperty("propertyEnumToRename").ToString());
 Console.WriteLine(result.GetProperty("propertyEnumWithValueToRename").ToString());
 Console.WriteLine(result.GetProperty("propertyEnumToBeMadeExtensible").ToString());
@@ -252,6 +284,22 @@ using RequestContent content = RequestContent.Create(new
                 key = "<badListOfDictionaryName>",
             }
         },
+        vector = new object[]
+        {
+            123.45F
+        },
+        vectorOptional = new object[]
+        {
+            123.45F
+        },
+        vectorNullable = new object[]
+        {
+            123.45F
+        },
+        vectorOptionalNullable = new object[]
+        {
+            123.45F
+        },
     },
     propertyEnumToRename = "1",
     propertyEnumWithValueToRename = "1",
@@ -282,6 +330,14 @@ Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").Ge
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badDictionaryName").GetProperty("<key>").ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfListName")[0][0].ToString());
 Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfDictionaryName")[0].GetProperty("<key>").ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vector")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptional")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullable")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullable")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorReadOnly")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalReadOnly")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullableReadOnly")[0].ToString());
+Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullableReadOnly")[0].ToString());
 Console.WriteLine(result.GetProperty("propertyEnumToRename").ToString());
 Console.WriteLine(result.GetProperty("propertyEnumWithValueToRename").ToString());
 Console.WriteLine(result.GetProperty("propertyEnumToBeMadeExtensible").ToString());

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/ModelWithCustomizedProperties.Serialization.cs
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/ModelWithCustomizedProperties.Serialization.cs
@@ -84,6 +84,55 @@ namespace CustomizationsInTsp.Models
                 writer.WriteEndObject();
             }
             writer.WriteEndArray();
+            writer.WritePropertyName("vector"u8);
+            writer.WriteStartArray();
+            foreach (var item in Vector.Span)
+            {
+                writer.WriteNumberValue(item);
+            }
+            writer.WriteEndArray();
+            if (VectorOptional != null)
+            {
+                writer.WritePropertyName("vectorOptional"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorOptional.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorOptional");
+            }
+            if (VectorNullable != null)
+            {
+                writer.WritePropertyName("vectorNullable"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorNullable.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorNullable");
+            }
+            if (VectorOptionalNullable != null)
+            {
+                writer.WritePropertyName("vectorOptionalNullable"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorOptionalNullable.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorOptionalNullable");
+            }
             writer.WriteEndObject();
         }
 
@@ -105,6 +154,14 @@ namespace CustomizationsInTsp.Models
             IDictionary<string, string> badDictionaryName = default;
             IList<IList<string>> badListOfListName = default;
             IList<IDictionary<string, string>> badListOfDictionaryName = default;
+            ReadOnlyMemory<float> vector = default;
+            Optional<ReadOnlyMemory<float>?> vectorOptional = default;
+            ReadOnlyMemory<float>? vectorNullable = default;
+            Optional<ReadOnlyMemory<float>?> vectorOptionalNullable = default;
+            ReadOnlyMemory<float> vectorReadOnly = default;
+            Optional<ReadOnlyMemory<float>?> vectorOptionalReadOnly = default;
+            ReadOnlyMemory<float>? vectorNullableReadOnly = default;
+            Optional<ReadOnlyMemory<float>?> vectorOptionalNullableReadOnly = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("propertyToMakeInternal"u8))
@@ -211,8 +268,136 @@ namespace CustomizationsInTsp.Models
                     badListOfDictionaryName = array;
                     continue;
                 }
+                if (property.NameEquals("vector"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vector = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorOptional"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorOptional = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorOptionalNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorOptionalNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnly"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnly = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorOptionalReadOnly"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorOptionalReadOnly = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorNullableReadOnly"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorNullableReadOnly = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorOptionalNullableReadOnly"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorOptionalNullableReadOnly = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
             }
-            return new ModelWithCustomizedProperties(propertyToMakeInternal, propertyToRename, propertyToMakeFloat, propertyToMakeInt, propertyToMakeDuration, propertyToMakeString, propertyToMakeJsonElement, propertyToField, badListName, badDictionaryName, badListOfListName, badListOfDictionaryName);
+            return new ModelWithCustomizedProperties(propertyToMakeInternal, propertyToRename, propertyToMakeFloat, propertyToMakeInt, propertyToMakeDuration, propertyToMakeString, propertyToMakeJsonElement, propertyToField, badListName, badDictionaryName, badListOfListName, badListOfDictionaryName, vector, Optional.ToNullable(vectorOptional), vectorNullable, Optional.ToNullable(vectorOptionalNullable), vectorReadOnly, Optional.ToNullable(vectorOptionalReadOnly), vectorNullableReadOnly, Optional.ToNullable(vectorOptionalNullableReadOnly));
         }
 
         /// <summary> Deserializes the model from a raw response. </summary>

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/ModelWithCustomizedProperties.cs
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/Models/ModelWithCustomizedProperties.cs
@@ -29,8 +29,10 @@ namespace CustomizationsInTsp.Models
         /// <param name="goodDictionaryName"> Property renamed that is dictionary. </param>
         /// <param name="goodListOfListName"> Property renamed that is listoflist. </param>
         /// <param name="goodListOfDictionaryName"> Property renamed that is listofdictionary. </param>
+        /// <param name="vector"> Property type changed to ReadOnlyMemory&lt;float&gt;. </param>
+        /// <param name="vectorNullable"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="propertyToMakeString"/>, <paramref name="propertyToField"/>, <paramref name="goodListName"/>, <paramref name="goodDictionaryName"/>, <paramref name="goodListOfListName"/> or <paramref name="goodListOfDictionaryName"/> is null. </exception>
-        public ModelWithCustomizedProperties(int propertyToMakeInternal, int renamedProperty, float propertyToMakeFloat, int propertyToMakeInt, TimeSpan propertyToMakeDuration, string propertyToMakeString, JsonElement propertyToMakeJsonElement, string propertyToField, IEnumerable<string> goodListName, IDictionary<string, string> goodDictionaryName, IEnumerable<IList<string>> goodListOfListName, IEnumerable<IDictionary<string, string>> goodListOfDictionaryName)
+        public ModelWithCustomizedProperties(int propertyToMakeInternal, int renamedProperty, float propertyToMakeFloat, int propertyToMakeInt, TimeSpan propertyToMakeDuration, string propertyToMakeString, JsonElement propertyToMakeJsonElement, string propertyToField, IEnumerable<string> goodListName, IDictionary<string, string> goodDictionaryName, IEnumerable<IList<string>> goodListOfListName, IEnumerable<IDictionary<string, string>> goodListOfDictionaryName, ReadOnlyMemory<float> vector, ReadOnlyMemory<float>? vectorNullable)
         {
             Argument.AssertNotNull(propertyToMakeString, nameof(propertyToMakeString));
             Argument.AssertNotNull(propertyToField, nameof(propertyToField));
@@ -51,6 +53,9 @@ namespace CustomizationsInTsp.Models
             GoodDictionaryName = goodDictionaryName;
             GoodListOfListName = goodListOfListName.ToList();
             GoodListOfDictionaryName = goodListOfDictionaryName.ToList();
+            Vector = vector;
+            VectorNullable = vectorNullable;
+            VectorReadOnly = ReadOnlyMemory<float>.Empty;
         }
 
         /// <summary> Initializes a new instance of ModelWithCustomizedProperties. </summary>
@@ -66,7 +71,15 @@ namespace CustomizationsInTsp.Models
         /// <param name="goodDictionaryName"> Property renamed that is dictionary. </param>
         /// <param name="goodListOfListName"> Property renamed that is listoflist. </param>
         /// <param name="goodListOfDictionaryName"> Property renamed that is listofdictionary. </param>
-        internal ModelWithCustomizedProperties(int propertyToMakeInternal, int renamedProperty, float propertyToMakeFloat, int propertyToMakeInt, TimeSpan propertyToMakeDuration, string propertyToMakeString, JsonElement propertyToMakeJsonElement, string propertyToField, IList<string> goodListName, IDictionary<string, string> goodDictionaryName, IList<IList<string>> goodListOfListName, IList<IDictionary<string, string>> goodListOfDictionaryName)
+        /// <param name="vector"> Property type changed to ReadOnlyMemory&lt;float&gt;. </param>
+        /// <param name="vectorOptional"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
+        /// <param name="vectorNullable"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
+        /// <param name="vectorOptionalNullable"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
+        /// <param name="vectorReadOnly"> Property type changed to ReadOnlyMemory&lt;float&gt;. </param>
+        /// <param name="vectorOptionalReadOnly"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
+        /// <param name="vectorNullableReadOnly"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
+        /// <param name="vectorOptionalNullableReadOnly"> Property type changed to ReadOnlyMemory&lt;float&gt;?. </param>
+        internal ModelWithCustomizedProperties(int propertyToMakeInternal, int renamedProperty, float propertyToMakeFloat, int propertyToMakeInt, TimeSpan propertyToMakeDuration, string propertyToMakeString, JsonElement propertyToMakeJsonElement, string propertyToField, IList<string> goodListName, IDictionary<string, string> goodDictionaryName, IList<IList<string>> goodListOfListName, IList<IDictionary<string, string>> goodListOfDictionaryName, ReadOnlyMemory<float> vector, ReadOnlyMemory<float>? vectorOptional, ReadOnlyMemory<float>? vectorNullable, ReadOnlyMemory<float>? vectorOptionalNullable, ReadOnlyMemory<float> vectorReadOnly, ReadOnlyMemory<float>? vectorOptionalReadOnly, ReadOnlyMemory<float>? vectorNullableReadOnly, ReadOnlyMemory<float>? vectorOptionalNullableReadOnly)
         {
             PropertyToMakeInternal = propertyToMakeInternal;
             RenamedProperty = renamedProperty;
@@ -80,6 +93,14 @@ namespace CustomizationsInTsp.Models
             GoodDictionaryName = goodDictionaryName;
             GoodListOfListName = goodListOfListName;
             GoodListOfDictionaryName = goodListOfDictionaryName;
+            Vector = vector;
+            VectorOptional = vectorOptional;
+            VectorNullable = vectorNullable;
+            VectorOptionalNullable = vectorOptionalNullable;
+            VectorReadOnly = vectorReadOnly;
+            VectorOptionalReadOnly = vectorOptionalReadOnly;
+            VectorNullableReadOnly = vectorNullableReadOnly;
+            VectorOptionalNullableReadOnly = vectorOptionalNullableReadOnly;
         }
     }
 }

--- a/test/TestProjects/Customizations-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/Customizations-TypeSpec/src/Generated/tspCodeModel.json
@@ -486,6 +486,158 @@
         },
         "IsRequired": true,
         "IsReadOnly": false
+       },
+       {
+        "$id": "70",
+        "Name": "vector",
+        "SerializedName": "vector",
+        "Description": "Property type changed to ReadOnlyMemory<float>",
+        "Type": {
+         "$id": "71",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "72",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": false
+        },
+        "IsRequired": true,
+        "IsReadOnly": false
+       },
+       {
+        "$id": "73",
+        "Name": "vectorOptional",
+        "SerializedName": "vectorOptional",
+        "Description": "Property type changed to ReadOnlyMemory<float>?",
+        "Type": {
+         "$id": "74",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "75",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": false
+        },
+        "IsRequired": false,
+        "IsReadOnly": false
+       },
+       {
+        "$id": "76",
+        "Name": "vectorNullable",
+        "SerializedName": "vectorNullable",
+        "Description": "Property type changed to ReadOnlyMemory<float>?",
+        "Type": {
+         "$id": "77",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "78",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": true
+        },
+        "IsRequired": true,
+        "IsReadOnly": false
+       },
+       {
+        "$id": "79",
+        "Name": "vectorOptionalNullable",
+        "SerializedName": "vectorOptionalNullable",
+        "Description": "Property type changed to ReadOnlyMemory<float>?",
+        "Type": {
+         "$id": "80",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "81",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": true
+        },
+        "IsRequired": false,
+        "IsReadOnly": false
+       },
+       {
+        "$id": "82",
+        "Name": "vectorReadOnly",
+        "SerializedName": "vectorReadOnly",
+        "Description": "Property type changed to ReadOnlyMemory<float>",
+        "Type": {
+         "$id": "83",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "84",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": false
+        },
+        "IsRequired": true,
+        "IsReadOnly": true
+       },
+       {
+        "$id": "85",
+        "Name": "vectorOptionalReadOnly",
+        "SerializedName": "vectorOptionalReadOnly",
+        "Description": "Property type changed to ReadOnlyMemory<float>?",
+        "Type": {
+         "$id": "86",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "87",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": false
+        },
+        "IsRequired": false,
+        "IsReadOnly": true
+       },
+       {
+        "$id": "88",
+        "Name": "vectorNullableReadOnly",
+        "SerializedName": "vectorNullableReadOnly",
+        "Description": "Property type changed to ReadOnlyMemory<float>?",
+        "Type": {
+         "$id": "89",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "90",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": true
+        },
+        "IsRequired": true,
+        "IsReadOnly": true
+       },
+       {
+        "$id": "91",
+        "Name": "vectorOptionalNullableReadOnly",
+        "SerializedName": "vectorOptionalNullableReadOnly",
+        "Description": "Property type changed to ReadOnlyMemory<float>?",
+        "Type": {
+         "$id": "92",
+         "Name": "Array",
+         "ElementType": {
+          "$id": "93",
+          "Name": "float32",
+          "Kind": "Float32",
+          "IsNullable": false
+         },
+         "IsNullable": true
+        },
+        "IsRequired": false,
+        "IsReadOnly": true
        }
       ]
      },
@@ -493,7 +645,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "70",
+     "$id": "94",
      "Name": "propertyEnumToRename",
      "SerializedName": "propertyEnumToRename",
      "Description": "EnumToRename",
@@ -504,7 +656,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "71",
+     "$id": "95",
      "Name": "propertyEnumWithValueToRename",
      "SerializedName": "propertyEnumWithValueToRename",
      "Description": "EnumWithValueToRename",
@@ -515,7 +667,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "72",
+     "$id": "96",
      "Name": "propertyEnumToBeMadeExtensible",
      "SerializedName": "propertyEnumToBeMadeExtensible",
      "Description": "EnumToBeMadeExtensible",
@@ -526,12 +678,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "73",
+     "$id": "97",
      "Name": "propertyModelToAddAdditionalSerializableProperty",
      "SerializedName": "propertyModelToAddAdditionalSerializableProperty",
      "Description": "ModelToAddAdditionalSerializableProperty",
      "Type": {
-      "$id": "74",
+      "$id": "98",
       "Name": "ModelToAddAdditionalSerializableProperty",
       "Namespace": "CustomizationsInTsp",
       "Description": "Model to add additional serializable property",
@@ -539,12 +691,12 @@
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "75",
+        "$id": "99",
         "Name": "requiredInt",
         "SerializedName": "requiredInt",
         "Description": "Required int",
         "Type": {
-         "$id": "76",
+         "$id": "100",
          "Name": "int32",
          "Kind": "Int32",
          "IsNullable": false
@@ -558,7 +710,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "77",
+     "$id": "101",
      "Name": "propertyToMoveToCustomization",
      "SerializedName": "propertyToMoveToCustomization",
      "Description": "Enum type property to move to customization code",
@@ -583,23 +735,23 @@
    "$ref": "37"
   },
   {
-   "$ref": "74"
+   "$ref": "98"
   }
  ],
  "Clients": [
   {
-   "$id": "78",
+   "$id": "102",
    "Name": "CustomizationsInTspClient",
    "Description": "CADL project to test various types of models.",
    "Operations": [
     {
-     "$id": "79",
+     "$id": "103",
      "Name": "roundTrip",
      "ResourceName": "CustomizationsInTsp",
      "Description": "RoundTrip operation to make RootModel round-trip",
      "Parameters": [
       {
-       "$id": "80",
+       "$id": "104",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -616,11 +768,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "81",
+       "$id": "105",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "82",
+        "$id": "106",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -635,19 +787,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "83",
+        "$id": "107",
         "Type": {
-         "$ref": "82"
+         "$ref": "106"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "84",
+       "$id": "108",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "85",
+        "$id": "109",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -662,20 +814,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "86",
+        "$id": "110",
         "Type": {
-         "$ref": "85"
+         "$ref": "109"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "87",
+       "$id": "111",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "88",
+        "$id": "112",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -690,9 +842,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "89",
+        "$id": "113",
         "Type": {
-         "$id": "90",
+         "$id": "114",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -703,7 +855,7 @@
      ],
      "Responses": [
       {
-       "$id": "91",
+       "$id": "115",
        "StatusCodes": [
         200
        ],
@@ -728,7 +880,7 @@
     }
    ],
    "Protocol": {
-    "$id": "92"
+    "$id": "116"
    },
    "Creatable": true
   }

--- a/test/TestProjects/Customizations-TypeSpec/tests/Generated/Samples/Samples_CustomizationsInTspClient.cs
+++ b/test/TestProjects/Customizations-TypeSpec/tests/Generated/Samples/Samples_CustomizationsInTspClient.cs
@@ -121,6 +121,22 @@ new
 key = "<badListOfDictionaryName>",
 }
             },
+                    vector = new object[]
+            {
+123.45F
+            },
+                    vectorOptional = new object[]
+            {
+123.45F
+            },
+                    vectorNullable = new object[]
+            {
+123.45F
+            },
+                    vectorOptionalNullable = new object[]
+            {
+123.45F
+            },
                 },
                 propertyEnumToRename = "1",
                 propertyEnumWithValueToRename = "1",
@@ -151,6 +167,14 @@ key = "<badListOfDictionaryName>",
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badDictionaryName").GetProperty("<key>").ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfListName")[0][0].ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfDictionaryName")[0].GetProperty("<key>").ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vector")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptional")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullable")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullable")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorReadOnly")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalReadOnly")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullableReadOnly")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullableReadOnly")[0].ToString());
             Console.WriteLine(result.GetProperty("propertyEnumToRename").ToString());
             Console.WriteLine(result.GetProperty("propertyEnumWithValueToRename").ToString());
             Console.WriteLine(result.GetProperty("propertyEnumToBeMadeExtensible").ToString());
@@ -212,6 +236,22 @@ new
 key = "<badListOfDictionaryName>",
 }
             },
+                    vector = new object[]
+            {
+123.45F
+            },
+                    vectorOptional = new object[]
+            {
+123.45F
+            },
+                    vectorNullable = new object[]
+            {
+123.45F
+            },
+                    vectorOptionalNullable = new object[]
+            {
+123.45F
+            },
                 },
                 propertyEnumToRename = "1",
                 propertyEnumWithValueToRename = "1",
@@ -242,6 +282,14 @@ key = "<badListOfDictionaryName>",
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badDictionaryName").GetProperty("<key>").ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfListName")[0][0].ToString());
             Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("badListOfDictionaryName")[0].GetProperty("<key>").ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vector")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptional")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullable")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullable")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorReadOnly")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalReadOnly")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorNullableReadOnly")[0].ToString());
+            Console.WriteLine(result.GetProperty("propertyModelWithCustomizedProperties").GetProperty("vectorOptionalNullableReadOnly")[0].ToString());
             Console.WriteLine(result.GetProperty("propertyEnumToRename").ToString());
             Console.WriteLine(result.GetProperty("propertyEnumWithValueToRename").ToString());
             Console.WriteLine(result.GetProperty("propertyEnumToBeMadeExtensible").ToString());
@@ -275,7 +323,11 @@ new Dictionary<string, string>
 {
 ["key"] = "<badListOfDictionaryName>"
 }
-            }),
+            }, new float[] { 123.45F }, new float[] { 123.45F })
+                {
+                    VectorOptional = new float[] { 123.45F },
+                    VectorOptionalNullable = new float[] { 123.45F },
+                },
                 PropertyEnumToRename = RenamedEnum.One,
                 PropertyEnumWithValueToRename = EnumWithValueToRename.One,
                 PropertyEnumToBeMadeExtensible = EnumToBeMadeExtensible.ExOne,
@@ -311,7 +363,11 @@ new Dictionary<string, string>
 {
 ["key"] = "<badListOfDictionaryName>"
 }
-            }),
+            }, new float[] { 123.45F }, new float[] { 123.45F })
+                {
+                    VectorOptional = new float[] { 123.45F },
+                    VectorOptionalNullable = new float[] { 123.45F },
+                },
                 PropertyEnumToRename = RenamedEnum.One,
                 PropertyEnumWithValueToRename = EnumWithValueToRename.One,
                 PropertyEnumToBeMadeExtensible = EnumToBeMadeExtensible.ExOne,

--- a/test/TestProjects/ModelShapes/Generated/CodeModel.yaml
+++ b/test/TestProjects/ModelShapes/Generated/CodeModel.yaml
@@ -122,7 +122,15 @@ schemas: !Schemas
           name: MixedModelNonRequiredReadonlyInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_35
+    - !NumberSchema &ref_34
+      type: number
+      precision: 32
+      language: !Languages 
+        default:
+          name: ArrayItemschema
+          description: ''
+      protocol: !Protocols {}
+    - !NumberSchema &ref_36
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -133,7 +141,7 @@ schemas: !Schemas
           name: OutputModelRequiredInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_38
+    - !NumberSchema &ref_39
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -144,7 +152,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_41
+    - !NumberSchema &ref_42
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -155,7 +163,7 @@ schemas: !Schemas
           name: OutputModelRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_44
+    - !NumberSchema &ref_45
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -166,7 +174,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_46
+    - !NumberSchema &ref_47
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -177,7 +185,7 @@ schemas: !Schemas
           name: OutputModelRequiredReadonlyInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_47
+    - !NumberSchema &ref_48
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -376,7 +384,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_34
+    - !StringSchema &ref_35
       type: string
       apiVersions:
         - !ApiVersion 
@@ -386,7 +394,7 @@ schemas: !Schemas
           name: OutputModelRequiredString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_36
+    - !StringSchema &ref_37
       type: string
       apiVersions:
         - !ApiVersion 
@@ -396,7 +404,7 @@ schemas: !Schemas
           name: OutputModelRequiredStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_37
+    - !StringSchema &ref_38
       type: string
       apiVersions:
         - !ApiVersion 
@@ -406,7 +414,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_39
+    - !StringSchema &ref_40
       type: string
       apiVersions:
         - !ApiVersion 
@@ -416,7 +424,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_40
+    - !StringSchema &ref_41
       type: string
       apiVersions:
         - !ApiVersion 
@@ -426,7 +434,7 @@ schemas: !Schemas
           name: OutputModelRequiredNullableString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_42
+    - !StringSchema &ref_43
       type: string
       apiVersions:
         - !ApiVersion 
@@ -436,7 +444,7 @@ schemas: !Schemas
           name: OutputModelRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_43
+    - !StringSchema &ref_44
       type: string
       apiVersions:
         - !ApiVersion 
@@ -446,7 +454,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredNullableString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_45
+    - !StringSchema &ref_46
       type: string
       apiVersions:
         - !ApiVersion 
@@ -456,7 +464,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_48
+    - !StringSchema &ref_49
       type: string
       apiVersions:
         - !ApiVersion 
@@ -466,7 +474,7 @@ schemas: !Schemas
           name: ReadonlyModelName
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_50
+    - !StringSchema &ref_51
       type: string
       apiVersions:
         - !ApiVersion 
@@ -476,7 +484,7 @@ schemas: !Schemas
           name: ParametersModelCode
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_51
+    - !StringSchema &ref_52
       type: string
       apiVersions:
         - !ApiVersion 
@@ -486,7 +494,7 @@ schemas: !Schemas
           name: ParametersModelStatus
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_52
+    - !StringSchema &ref_53
       type: string
       apiVersions:
         - !ApiVersion 
@@ -497,7 +505,7 @@ schemas: !Schemas
           description: ''
       protocol: !Protocols {}
   constants:
-    - !ConstantSchema &ref_67
+    - !ConstantSchema &ref_69
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -507,7 +515,7 @@ schemas: !Schemas
           name: ApplicationJson
           description: Content Type 'application/json'
       protocol: !Protocols {}
-    - !ConstantSchema &ref_69
+    - !ConstantSchema &ref_71
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -518,7 +526,7 @@ schemas: !Schemas
           description: 'Accept: application/json'
       protocol: !Protocols {}
   objects:
-    - !ObjectSchema &ref_68
+    - !ObjectSchema &ref_70
       type: object
       apiVersions:
         - !ApiVersion 
@@ -543,7 +551,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_53
+          schema: !ArraySchema &ref_54
             type: array
             apiVersions:
               - !ApiVersion 
@@ -596,7 +604,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_54
+          schema: !ArraySchema &ref_55
             type: array
             apiVersions:
               - !ApiVersion 
@@ -651,7 +659,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_55
+          schema: !ArraySchema &ref_56
             type: array
             apiVersions:
               - !ApiVersion 
@@ -708,7 +716,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_56
+          schema: !ArraySchema &ref_57
             type: array
             apiVersions:
               - !ApiVersion 
@@ -754,7 +762,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_72
+    - !ObjectSchema &ref_74
       type: object
       apiVersions:
         - !ApiVersion 
@@ -786,7 +794,7 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_73
+    - !ObjectSchema &ref_75
       type: object
       apiVersions:
         - !ApiVersion 
@@ -811,7 +819,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_57
+          schema: !ArraySchema &ref_58
             type: array
             apiVersions:
               - !ApiVersion 
@@ -857,7 +865,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_58
+          schema: !ArraySchema &ref_59
             type: array
             apiVersions:
               - !ApiVersion 
@@ -905,7 +913,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_59
+          schema: !ArraySchema &ref_60
             type: array
             apiVersions:
               - !ApiVersion 
@@ -955,7 +963,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_60
+          schema: !ArraySchema &ref_61
             type: array
             apiVersions:
               - !ApiVersion 
@@ -1004,6 +1012,26 @@ schemas: !Schemas
               name: nonRequiredReadonlyInt
               description: ''
           protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_62
+            type: array
+            elementType: *ref_34
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          required: false
+          serializedName: vector
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vector
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
       serializationFormats:
         - json
       usage:
@@ -1015,14 +1043,14 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_76
+    - !ObjectSchema &ref_78
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_34
+          schema: *ref_35
           required: true
           serializedName: RequiredString
           language: !Languages 
@@ -1031,7 +1059,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_35
+          schema: *ref_36
           required: true
           serializedName: RequiredInt
           language: !Languages 
@@ -1040,12 +1068,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_61
+          schema: !ArraySchema &ref_63
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_36
+            elementType: *ref_37
             language: !Languages 
               default:
                 name: OutputModelRequiredStringList
@@ -1068,7 +1096,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_37
+          schema: *ref_38
           required: false
           serializedName: NonRequiredString
           language: !Languages 
@@ -1077,7 +1105,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_38
+          schema: *ref_39
           required: false
           serializedName: NonRequiredInt
           language: !Languages 
@@ -1086,12 +1114,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_62
+          schema: !ArraySchema &ref_64
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_39
+            elementType: *ref_40
             language: !Languages 
               default:
                 name: OutputModelNonRequiredStringList
@@ -1114,7 +1142,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_40
+          schema: *ref_41
           nullable: true
           required: true
           serializedName: RequiredNullableString
@@ -1124,7 +1152,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_41
+          schema: *ref_42
           nullable: true
           required: true
           serializedName: RequiredNullableInt
@@ -1134,12 +1162,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_63
+          schema: !ArraySchema &ref_65
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_42
+            elementType: *ref_43
             language: !Languages 
               default:
                 name: OutputModelRequiredNullableStringList
@@ -1164,7 +1192,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_43
+          schema: *ref_44
           nullable: true
           required: false
           serializedName: NonRequiredNullableString
@@ -1174,7 +1202,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_44
+          schema: *ref_45
           nullable: true
           required: false
           serializedName: NonRequiredNullableInt
@@ -1184,12 +1212,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_64
+          schema: !ArraySchema &ref_66
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_45
+            elementType: *ref_46
             language: !Languages 
               default:
                 name: OutputModelNonRequiredNullableStringList
@@ -1214,7 +1242,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_46
+          schema: *ref_47
           readOnly: true
           required: true
           serializedName: RequiredReadonlyInt
@@ -1224,7 +1252,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_47
+          schema: *ref_48
           readOnly: true
           required: false
           serializedName: NonRequiredReadonlyInt
@@ -1243,21 +1271,21 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_77
+    - !ObjectSchema &ref_79
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
         - !Property 
-          schema: !ObjectSchema &ref_49
+          schema: !ObjectSchema &ref_50
             type: object
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
             properties:
               - !Property 
-                schema: *ref_48
+                schema: *ref_49
                 serializedName: Name
                 language: !Languages 
                   default:
@@ -1283,12 +1311,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_65
+          schema: !ArraySchema &ref_67
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_49
+            elementType: *ref_50
             language: !Languages 
               default:
                 name: MixedModelWithReadonlyPropertyReadonlyListProperty
@@ -1312,23 +1340,23 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - *ref_49
-    - !ObjectSchema &ref_80
+    - *ref_50
+    - !ObjectSchema &ref_82
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
-        - !Property &ref_82
-          schema: *ref_50
+        - !Property &ref_84
+          schema: *ref_51
           serializedName: Code
           language: !Languages 
             default:
               name: code
               description: ''
           protocol: !Protocols {}
-        - !Property &ref_83
-          schema: *ref_51
+        - !Property &ref_85
+          schema: *ref_52
           serializedName: Status
           language: !Languages 
             default:
@@ -1352,7 +1380,7 @@ schemas: !Schemas
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_52
+          schema: *ref_53
           serializedName: UnusedString
           language: !Languages 
             default:
@@ -1366,15 +1394,14 @@ schemas: !Schemas
           namespace: ''
       protocol: !Protocols {}
   arrays:
-    - *ref_53
-    - *ref_19
     - *ref_54
-    - *ref_23
+    - *ref_19
     - *ref_55
-    - *ref_27
+    - *ref_23
     - *ref_56
-    - *ref_31
+    - *ref_27
     - *ref_57
+    - *ref_31
     - *ref_58
     - *ref_59
     - *ref_60
@@ -1383,8 +1410,10 @@ schemas: !Schemas
     - *ref_63
     - *ref_64
     - *ref_65
+    - *ref_66
+    - *ref_67
 globalParameters:
-  - !Parameter &ref_66
+  - !Parameter &ref_68
     schema: *ref_0
     clientDefaultValue: http://localhost:3000
     implementation: Client
@@ -1410,12 +1439,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_66
+          - *ref_68
         requestMediaTypes:
-          application/json: !Request &ref_71
+          application/json: !Request &ref_73
             parameters:
               - !Parameter 
-                schema: *ref_67
+                schema: *ref_69
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1427,8 +1456,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_70
-                schema: *ref_68
+              - !Parameter &ref_72
+                schema: *ref_70
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -1440,7 +1469,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_71
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1453,7 +1482,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_70
+              - *ref_72
             language: !Languages 
               default:
                 name: ''
@@ -1467,7 +1496,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_71
+          - *ref_73
         signatureParameters: []
         responses:
           - !Response 
@@ -1481,7 +1510,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_72
+            schema: *ref_74
             language: !Languages 
               default:
                 name: ''
@@ -1504,12 +1533,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_66
+          - *ref_68
         requestMediaTypes:
-          application/json: !Request &ref_75
+          application/json: !Request &ref_77
             parameters:
               - !Parameter 
-                schema: *ref_67
+                schema: *ref_69
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1521,8 +1550,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_74
-                schema: *ref_73
+              - !Parameter &ref_76
+                schema: *ref_75
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -1534,7 +1563,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_71
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1547,7 +1576,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_74
+              - *ref_76
             language: !Languages 
               default:
                 name: ''
@@ -1561,11 +1590,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_75
+          - *ref_77
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_73
+            schema: *ref_75
             language: !Languages 
               default:
                 name: ''
@@ -1588,12 +1617,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_66
+          - *ref_68
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_71
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1618,7 +1647,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_76
+            schema: *ref_78
             language: !Languages 
               default:
                 name: ''
@@ -1641,12 +1670,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_66
+          - *ref_68
         requestMediaTypes:
-          application/json: !Request &ref_79
+          application/json: !Request &ref_81
             parameters:
               - !Parameter 
-                schema: *ref_67
+                schema: *ref_69
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1658,8 +1687,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_78
-                schema: *ref_77
+              - !Parameter &ref_80
+                schema: *ref_79
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -1671,7 +1700,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_71
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1684,7 +1713,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_78
+              - *ref_80
             language: !Languages 
               default:
                 name: ''
@@ -1698,11 +1727,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_79
+          - *ref_81
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_77
+            schema: *ref_79
             language: !Languages 
               default:
                 name: ''
@@ -1725,12 +1754,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_66
+          - *ref_68
         requestMediaTypes:
-          application/json: !Request &ref_86
+          application/json: !Request &ref_88
             parameters:
               - !Parameter 
-                schema: *ref_67
+                schema: *ref_69
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1742,8 +1771,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_81
-                schema: *ref_80
+              - !Parameter &ref_83
+                schema: *ref_82
                 flattened: true
                 implementation: Method
                 required: true
@@ -1757,31 +1786,31 @@ operationGroups:
                   http: !HttpParameter 
                     in: body
                     style: json
-              - !VirtualParameter &ref_84
-                schema: *ref_50
+              - !VirtualParameter &ref_86
+                schema: *ref_51
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_83
                 pathToProperty: []
-                targetProperty: *ref_82
+                targetProperty: *ref_84
                 language: !Languages 
                   default:
                     name: code
                     description: ''
                 protocol: !Protocols {}
-              - !VirtualParameter &ref_85
-                schema: *ref_51
+              - !VirtualParameter &ref_87
+                schema: *ref_52
                 implementation: Method
-                originalParameter: *ref_81
+                originalParameter: *ref_83
                 pathToProperty: []
-                targetProperty: *ref_83
+                targetProperty: *ref_85
                 language: !Languages 
                   default:
                     name: status
                     description: ''
                 protocol: !Protocols {}
             signatureParameters:
-              - *ref_84
-              - *ref_85
+              - *ref_86
+              - *ref_87
             language: !Languages 
               default:
                 name: ''
@@ -1795,7 +1824,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_86
+          - *ref_88
         signatureParameters: []
         responses:
           - !Response 

--- a/test/TestProjects/ModelShapes/Generated/CodeModel.yaml
+++ b/test/TestProjects/ModelShapes/Generated/CodeModel.yaml
@@ -56,7 +56,15 @@ schemas: !Schemas
           name: InputModelNonRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_17
+    - !NumberSchema &ref_14
+      type: number
+      precision: 32
+      language: !Languages 
+        default:
+          name: ArrayItemschema
+          description: ''
+      protocol: !Protocols {}
+    - !NumberSchema &ref_18
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -67,7 +75,7 @@ schemas: !Schemas
           name: MixedModelRequiredInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_21
+    - !NumberSchema &ref_22
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -78,7 +86,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_25
+    - !NumberSchema &ref_26
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -89,7 +97,7 @@ schemas: !Schemas
           name: MixedModelRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_29
+    - !NumberSchema &ref_30
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -100,7 +108,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_32
+    - !NumberSchema &ref_33
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -111,7 +119,7 @@ schemas: !Schemas
           name: MixedModelRequiredReadonlyInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_33
+    - !NumberSchema &ref_34
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -122,15 +130,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredReadonlyInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_34
-      type: number
-      precision: 32
-      language: !Languages 
-        default:
-          name: ArrayItemschema
-          description: ''
-      protocol: !Protocols {}
-    - !NumberSchema &ref_36
+    - !NumberSchema &ref_44
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -141,7 +141,7 @@ schemas: !Schemas
           name: OutputModelRequiredInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_39
+    - !NumberSchema &ref_47
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -152,7 +152,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_42
+    - !NumberSchema &ref_50
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -163,7 +163,7 @@ schemas: !Schemas
           name: OutputModelRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_45
+    - !NumberSchema &ref_53
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -174,7 +174,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredNullableInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_47
+    - !NumberSchema &ref_55
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -185,7 +185,7 @@ schemas: !Schemas
           name: OutputModelRequiredReadonlyInt
           description: ''
       protocol: !Protocols {}
-    - !NumberSchema &ref_48
+    - !NumberSchema &ref_56
       type: integer
       apiVersions:
         - !ApiVersion 
@@ -284,7 +284,7 @@ schemas: !Schemas
           name: InputModelNonRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_14
+    - !StringSchema &ref_15
       type: string
       apiVersions:
         - !ApiVersion 
@@ -294,7 +294,7 @@ schemas: !Schemas
           name: ErrorModelCode
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_15
+    - !StringSchema &ref_16
       type: string
       apiVersions:
         - !ApiVersion 
@@ -304,7 +304,7 @@ schemas: !Schemas
           name: ErrorModelStatus
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_16
+    - !StringSchema &ref_17
       type: string
       apiVersions:
         - !ApiVersion 
@@ -314,7 +314,7 @@ schemas: !Schemas
           name: MixedModelRequiredString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_18
+    - !StringSchema &ref_19
       type: string
       apiVersions:
         - !ApiVersion 
@@ -324,7 +324,7 @@ schemas: !Schemas
           name: MixedModelRequiredStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_20
+    - !StringSchema &ref_21
       type: string
       apiVersions:
         - !ApiVersion 
@@ -334,7 +334,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_22
+    - !StringSchema &ref_23
       type: string
       apiVersions:
         - !ApiVersion 
@@ -344,7 +344,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_24
+    - !StringSchema &ref_25
       type: string
       apiVersions:
         - !ApiVersion 
@@ -354,7 +354,7 @@ schemas: !Schemas
           name: MixedModelRequiredNullableString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_26
+    - !StringSchema &ref_27
       type: string
       apiVersions:
         - !ApiVersion 
@@ -364,7 +364,7 @@ schemas: !Schemas
           name: MixedModelRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_28
+    - !StringSchema &ref_29
       type: string
       apiVersions:
         - !ApiVersion 
@@ -374,7 +374,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredNullableString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_30
+    - !StringSchema &ref_31
       type: string
       apiVersions:
         - !ApiVersion 
@@ -384,7 +384,7 @@ schemas: !Schemas
           name: MixedModelNonRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_35
+    - !StringSchema &ref_43
       type: string
       apiVersions:
         - !ApiVersion 
@@ -394,7 +394,7 @@ schemas: !Schemas
           name: OutputModelRequiredString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_37
+    - !StringSchema &ref_45
       type: string
       apiVersions:
         - !ApiVersion 
@@ -404,7 +404,7 @@ schemas: !Schemas
           name: OutputModelRequiredStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_38
+    - !StringSchema &ref_46
       type: string
       apiVersions:
         - !ApiVersion 
@@ -414,7 +414,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_40
+    - !StringSchema &ref_48
       type: string
       apiVersions:
         - !ApiVersion 
@@ -424,7 +424,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_41
+    - !StringSchema &ref_49
       type: string
       apiVersions:
         - !ApiVersion 
@@ -434,7 +434,7 @@ schemas: !Schemas
           name: OutputModelRequiredNullableString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_43
+    - !StringSchema &ref_51
       type: string
       apiVersions:
         - !ApiVersion 
@@ -444,7 +444,7 @@ schemas: !Schemas
           name: OutputModelRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_44
+    - !StringSchema &ref_52
       type: string
       apiVersions:
         - !ApiVersion 
@@ -454,7 +454,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredNullableString
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_46
+    - !StringSchema &ref_54
       type: string
       apiVersions:
         - !ApiVersion 
@@ -464,7 +464,7 @@ schemas: !Schemas
           name: OutputModelNonRequiredNullableStringListItem
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_49
+    - !StringSchema &ref_57
       type: string
       apiVersions:
         - !ApiVersion 
@@ -474,7 +474,7 @@ schemas: !Schemas
           name: ReadonlyModelName
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_51
+    - !StringSchema &ref_59
       type: string
       apiVersions:
         - !ApiVersion 
@@ -484,7 +484,7 @@ schemas: !Schemas
           name: ParametersModelCode
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_52
+    - !StringSchema &ref_60
       type: string
       apiVersions:
         - !ApiVersion 
@@ -494,7 +494,7 @@ schemas: !Schemas
           name: ParametersModelStatus
           description: ''
       protocol: !Protocols {}
-    - !StringSchema &ref_53
+    - !StringSchema &ref_61
       type: string
       apiVersions:
         - !ApiVersion 
@@ -505,7 +505,7 @@ schemas: !Schemas
           description: ''
       protocol: !Protocols {}
   constants:
-    - !ConstantSchema &ref_69
+    - !ConstantSchema &ref_76
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -515,7 +515,7 @@ schemas: !Schemas
           name: ApplicationJson
           description: Content Type 'application/json'
       protocol: !Protocols {}
-    - !ConstantSchema &ref_71
+    - !ConstantSchema &ref_78
       type: constant
       value: !ConstantValue 
         value: application/json
@@ -526,7 +526,7 @@ schemas: !Schemas
           description: 'Accept: application/json'
       protocol: !Protocols {}
   objects:
-    - !ObjectSchema &ref_70
+    - !ObjectSchema &ref_77
       type: object
       apiVersions:
         - !ApiVersion 
@@ -551,7 +551,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_54
+          schema: !ArraySchema &ref_62
             type: array
             apiVersions:
               - !ApiVersion 
@@ -570,7 +570,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_19
+          schema: !ArraySchema &ref_20
             type: array
             elementType: *ref_4
             language: !Languages 
@@ -604,7 +604,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_55
+          schema: !ArraySchema &ref_63
             type: array
             apiVersions:
               - !ApiVersion 
@@ -623,7 +623,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_23
+          schema: !ArraySchema &ref_24
             type: array
             elementType: *ref_4
             language: !Languages 
@@ -659,7 +659,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_56
+          schema: !ArraySchema &ref_64
             type: array
             apiVersions:
               - !ApiVersion 
@@ -679,7 +679,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_27
+          schema: !ArraySchema &ref_28
             type: array
             elementType: *ref_4
             language: !Languages 
@@ -716,7 +716,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_57
+          schema: !ArraySchema &ref_65
             type: array
             apiVersions:
               - !ApiVersion 
@@ -736,7 +736,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_31
+          schema: !ArraySchema &ref_32
             type: array
             elementType: *ref_4
             language: !Languages 
@@ -752,270 +752,10 @@ schemas: !Schemas
               name: nonRequiredNullableIntList
               description: ''
           protocol: !Protocols {}
-      serializationFormats:
-        - json
-      usage:
-        - input
-      language: !Languages 
-        default:
-          name: InputModel
-          description: ''
-          namespace: ''
-      protocol: !Protocols {}
-    - !ObjectSchema &ref_74
-      type: object
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      properties:
         - !Property 
-          schema: *ref_14
-          serializedName: Code
-          language: !Languages 
-            default:
-              name: code
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_15
-          serializedName: Status
-          language: !Languages 
-            default:
-              name: status
-              description: ''
-          protocol: !Protocols {}
-      serializationFormats:
-        - json
-      usage:
-        - exception
-      language: !Languages 
-        default:
-          name: ErrorModel
-          description: ''
-          namespace: ''
-      protocol: !Protocols {}
-    - !ObjectSchema &ref_75
-      type: object
-      apiVersions:
-        - !ApiVersion 
-          version: 1.0.0
-      properties:
-        - !Property 
-          schema: *ref_16
-          required: true
-          serializedName: RequiredString
-          language: !Languages 
-            default:
-              name: requiredString
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_17
-          required: true
-          serializedName: RequiredInt
-          language: !Languages 
-            default:
-              name: requiredInt
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: !ArraySchema &ref_58
+          schema: !ArraySchema &ref_35
             type: array
-            apiVersions:
-              - !ApiVersion 
-                version: 1.0.0
-            elementType: *ref_18
-            language: !Languages 
-              default:
-                name: MixedModelRequiredStringList
-                description: Array of MixedModelRequiredStringListItem
-            protocol: !Protocols {}
-          required: true
-          serializedName: RequiredStringList
-          language: !Languages 
-            default:
-              name: requiredStringList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_19
-          required: true
-          serializedName: RequiredIntList
-          language: !Languages 
-            default:
-              name: requiredIntList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_20
-          required: false
-          serializedName: NonRequiredString
-          language: !Languages 
-            default:
-              name: nonRequiredString
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_21
-          required: false
-          serializedName: NonRequiredInt
-          language: !Languages 
-            default:
-              name: nonRequiredInt
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: !ArraySchema &ref_59
-            type: array
-            apiVersions:
-              - !ApiVersion 
-                version: 1.0.0
-            elementType: *ref_22
-            language: !Languages 
-              default:
-                name: MixedModelNonRequiredStringList
-                description: Array of MixedModelNonRequiredStringListItem
-            protocol: !Protocols {}
-          required: false
-          serializedName: NonRequiredStringList
-          language: !Languages 
-            default:
-              name: nonRequiredStringList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_23
-          required: false
-          serializedName: NonRequiredIntList
-          language: !Languages 
-            default:
-              name: nonRequiredIntList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_24
-          nullable: true
-          required: true
-          serializedName: RequiredNullableString
-          language: !Languages 
-            default:
-              name: requiredNullableString
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_25
-          nullable: true
-          required: true
-          serializedName: RequiredNullableInt
-          language: !Languages 
-            default:
-              name: requiredNullableInt
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: !ArraySchema &ref_60
-            type: array
-            apiVersions:
-              - !ApiVersion 
-                version: 1.0.0
-            elementType: *ref_26
-            language: !Languages 
-              default:
-                name: MixedModelRequiredNullableStringList
-                description: Array of MixedModelRequiredNullableStringListItem
-            protocol: !Protocols {}
-          nullable: true
-          required: true
-          serializedName: RequiredNullableStringList
-          language: !Languages 
-            default:
-              name: requiredNullableStringList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_27
-          nullable: true
-          required: true
-          serializedName: RequiredNullableIntList
-          language: !Languages 
-            default:
-              name: requiredNullableIntList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_28
-          nullable: true
-          required: false
-          serializedName: NonRequiredNullableString
-          language: !Languages 
-            default:
-              name: nonRequiredNullableString
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_29
-          nullable: true
-          required: false
-          serializedName: NonRequiredNullableInt
-          language: !Languages 
-            default:
-              name: nonRequiredNullableInt
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: !ArraySchema &ref_61
-            type: array
-            apiVersions:
-              - !ApiVersion 
-                version: 1.0.0
-            elementType: *ref_30
-            language: !Languages 
-              default:
-                name: MixedModelNonRequiredNullableStringList
-                description: Array of MixedModelNonRequiredNullableStringListItem
-            protocol: !Protocols {}
-          nullable: true
-          required: false
-          serializedName: NonRequiredNullableStringList
-          language: !Languages 
-            default:
-              name: nonRequiredNullableStringList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_31
-          nullable: true
-          required: false
-          serializedName: NonRequiredNullableIntList
-          language: !Languages 
-            default:
-              name: nonRequiredNullableIntList
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_32
-          readOnly: true
-          required: true
-          serializedName: RequiredReadonlyInt
-          language: !Languages 
-            default:
-              name: requiredReadonlyInt
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: *ref_33
-          readOnly: true
-          required: false
-          serializedName: NonRequiredReadonlyInt
-          language: !Languages 
-            default:
-              name: nonRequiredReadonlyInt
-              description: ''
-          protocol: !Protocols {}
-        - !Property 
-          schema: !ArraySchema &ref_62
-            type: array
-            elementType: *ref_34
+            elementType: *ref_14
             extensions:
               x-ms-embedding-vector: true
             language: !Languages 
@@ -1032,6 +772,510 @@ schemas: !Schemas
               name: vector
               description: The vector representation of a search query.
           protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_36
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          readOnly: true
+          required: false
+          serializedName: vectorReadOnly
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnly
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_37
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          readOnly: true
+          required: true
+          serializedName: vectorReadOnlyRequired
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyRequired
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_38
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          required: true
+          serializedName: vectorRequired
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorRequired
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_39
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          nullable: true
+          required: false
+          serializedName: vectorNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_40
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          nullable: true
+          readOnly: true
+          required: false
+          serializedName: vectorReadOnlyNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_41
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          nullable: true
+          readOnly: true
+          required: true
+          serializedName: vectorReadOnlyRequiredNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyRequiredNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_42
+            type: array
+            elementType: *ref_14
+            extensions:
+              x-ms-embedding-vector: true
+            language: !Languages 
+              default:
+                name: ArrayOfArrayItemschema
+                description: The vector representation of a search query.
+            protocol: !Protocols {}
+          nullable: true
+          required: true
+          serializedName: vectorRequiredNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorRequiredNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+      serializationFormats:
+        - json
+      usage:
+        - input
+      language: !Languages 
+        default:
+          name: InputModel
+          description: ''
+          namespace: ''
+      protocol: !Protocols {}
+    - !ObjectSchema &ref_81
+      type: object
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      properties:
+        - !Property 
+          schema: *ref_15
+          serializedName: Code
+          language: !Languages 
+            default:
+              name: code
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_16
+          serializedName: Status
+          language: !Languages 
+            default:
+              name: status
+              description: ''
+          protocol: !Protocols {}
+      serializationFormats:
+        - json
+      usage:
+        - exception
+      language: !Languages 
+        default:
+          name: ErrorModel
+          description: ''
+          namespace: ''
+      protocol: !Protocols {}
+    - !ObjectSchema &ref_82
+      type: object
+      apiVersions:
+        - !ApiVersion 
+          version: 1.0.0
+      properties:
+        - !Property 
+          schema: *ref_17
+          required: true
+          serializedName: RequiredString
+          language: !Languages 
+            default:
+              name: requiredString
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_18
+          required: true
+          serializedName: RequiredInt
+          language: !Languages 
+            default:
+              name: requiredInt
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_66
+            type: array
+            apiVersions:
+              - !ApiVersion 
+                version: 1.0.0
+            elementType: *ref_19
+            language: !Languages 
+              default:
+                name: MixedModelRequiredStringList
+                description: Array of MixedModelRequiredStringListItem
+            protocol: !Protocols {}
+          required: true
+          serializedName: RequiredStringList
+          language: !Languages 
+            default:
+              name: requiredStringList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_20
+          required: true
+          serializedName: RequiredIntList
+          language: !Languages 
+            default:
+              name: requiredIntList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_21
+          required: false
+          serializedName: NonRequiredString
+          language: !Languages 
+            default:
+              name: nonRequiredString
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_22
+          required: false
+          serializedName: NonRequiredInt
+          language: !Languages 
+            default:
+              name: nonRequiredInt
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_67
+            type: array
+            apiVersions:
+              - !ApiVersion 
+                version: 1.0.0
+            elementType: *ref_23
+            language: !Languages 
+              default:
+                name: MixedModelNonRequiredStringList
+                description: Array of MixedModelNonRequiredStringListItem
+            protocol: !Protocols {}
+          required: false
+          serializedName: NonRequiredStringList
+          language: !Languages 
+            default:
+              name: nonRequiredStringList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_24
+          required: false
+          serializedName: NonRequiredIntList
+          language: !Languages 
+            default:
+              name: nonRequiredIntList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_25
+          nullable: true
+          required: true
+          serializedName: RequiredNullableString
+          language: !Languages 
+            default:
+              name: requiredNullableString
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_26
+          nullable: true
+          required: true
+          serializedName: RequiredNullableInt
+          language: !Languages 
+            default:
+              name: requiredNullableInt
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_68
+            type: array
+            apiVersions:
+              - !ApiVersion 
+                version: 1.0.0
+            elementType: *ref_27
+            language: !Languages 
+              default:
+                name: MixedModelRequiredNullableStringList
+                description: Array of MixedModelRequiredNullableStringListItem
+            protocol: !Protocols {}
+          nullable: true
+          required: true
+          serializedName: RequiredNullableStringList
+          language: !Languages 
+            default:
+              name: requiredNullableStringList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_28
+          nullable: true
+          required: true
+          serializedName: RequiredNullableIntList
+          language: !Languages 
+            default:
+              name: requiredNullableIntList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_29
+          nullable: true
+          required: false
+          serializedName: NonRequiredNullableString
+          language: !Languages 
+            default:
+              name: nonRequiredNullableString
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_30
+          nullable: true
+          required: false
+          serializedName: NonRequiredNullableInt
+          language: !Languages 
+            default:
+              name: nonRequiredNullableInt
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: !ArraySchema &ref_69
+            type: array
+            apiVersions:
+              - !ApiVersion 
+                version: 1.0.0
+            elementType: *ref_31
+            language: !Languages 
+              default:
+                name: MixedModelNonRequiredNullableStringList
+                description: Array of MixedModelNonRequiredNullableStringListItem
+            protocol: !Protocols {}
+          nullable: true
+          required: false
+          serializedName: NonRequiredNullableStringList
+          language: !Languages 
+            default:
+              name: nonRequiredNullableStringList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_32
+          nullable: true
+          required: false
+          serializedName: NonRequiredNullableIntList
+          language: !Languages 
+            default:
+              name: nonRequiredNullableIntList
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_33
+          readOnly: true
+          required: true
+          serializedName: RequiredReadonlyInt
+          language: !Languages 
+            default:
+              name: requiredReadonlyInt
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_34
+          readOnly: true
+          required: false
+          serializedName: NonRequiredReadonlyInt
+          language: !Languages 
+            default:
+              name: nonRequiredReadonlyInt
+              description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_35
+          required: false
+          serializedName: vector
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vector
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_36
+          readOnly: true
+          required: false
+          serializedName: vectorReadOnly
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnly
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_37
+          readOnly: true
+          required: true
+          serializedName: vectorReadOnlyRequired
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyRequired
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_38
+          required: true
+          serializedName: vectorRequired
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorRequired
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_39
+          nullable: true
+          required: false
+          serializedName: vectorNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_40
+          nullable: true
+          readOnly: true
+          required: false
+          serializedName: vectorReadOnlyNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_41
+          nullable: true
+          readOnly: true
+          required: true
+          serializedName: vectorReadOnlyRequiredNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyRequiredNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_42
+          nullable: true
+          required: true
+          serializedName: vectorRequiredNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorRequiredNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
       serializationFormats:
         - json
       usage:
@@ -1043,14 +1287,14 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_78
+    - !ObjectSchema &ref_85
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_35
+          schema: *ref_43
           required: true
           serializedName: RequiredString
           language: !Languages 
@@ -1059,7 +1303,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_36
+          schema: *ref_44
           required: true
           serializedName: RequiredInt
           language: !Languages 
@@ -1068,12 +1312,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_63
+          schema: !ArraySchema &ref_70
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_37
+            elementType: *ref_45
             language: !Languages 
               default:
                 name: OutputModelRequiredStringList
@@ -1087,7 +1331,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_19
+          schema: *ref_20
           required: true
           serializedName: RequiredIntList
           language: !Languages 
@@ -1096,7 +1340,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_38
+          schema: *ref_46
           required: false
           serializedName: NonRequiredString
           language: !Languages 
@@ -1105,7 +1349,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_39
+          schema: *ref_47
           required: false
           serializedName: NonRequiredInt
           language: !Languages 
@@ -1114,12 +1358,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_64
+          schema: !ArraySchema &ref_71
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_40
+            elementType: *ref_48
             language: !Languages 
               default:
                 name: OutputModelNonRequiredStringList
@@ -1133,7 +1377,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_23
+          schema: *ref_24
           required: false
           serializedName: NonRequiredIntList
           language: !Languages 
@@ -1142,7 +1386,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_41
+          schema: *ref_49
           nullable: true
           required: true
           serializedName: RequiredNullableString
@@ -1152,7 +1396,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_42
+          schema: *ref_50
           nullable: true
           required: true
           serializedName: RequiredNullableInt
@@ -1162,12 +1406,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_65
+          schema: !ArraySchema &ref_72
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_43
+            elementType: *ref_51
             language: !Languages 
               default:
                 name: OutputModelRequiredNullableStringList
@@ -1182,7 +1426,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_27
+          schema: *ref_28
           nullable: true
           required: true
           serializedName: RequiredNullableIntList
@@ -1192,7 +1436,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_44
+          schema: *ref_52
           nullable: true
           required: false
           serializedName: NonRequiredNullableString
@@ -1202,7 +1446,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_45
+          schema: *ref_53
           nullable: true
           required: false
           serializedName: NonRequiredNullableInt
@@ -1212,12 +1456,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_66
+          schema: !ArraySchema &ref_73
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_46
+            elementType: *ref_54
             language: !Languages 
               default:
                 name: OutputModelNonRequiredNullableStringList
@@ -1232,7 +1476,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_31
+          schema: *ref_32
           nullable: true
           required: false
           serializedName: NonRequiredNullableIntList
@@ -1242,7 +1486,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_47
+          schema: *ref_55
           readOnly: true
           required: true
           serializedName: RequiredReadonlyInt
@@ -1252,7 +1496,7 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: *ref_48
+          schema: *ref_56
           readOnly: true
           required: false
           serializedName: NonRequiredReadonlyInt
@@ -1260,6 +1504,102 @@ schemas: !Schemas
             default:
               name: nonRequiredReadonlyInt
               description: ''
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_35
+          required: false
+          serializedName: vector
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vector
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_36
+          readOnly: true
+          required: false
+          serializedName: vectorReadOnly
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnly
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_37
+          readOnly: true
+          required: true
+          serializedName: vectorReadOnlyRequired
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyRequired
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_38
+          required: true
+          serializedName: vectorRequired
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorRequired
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_39
+          nullable: true
+          required: false
+          serializedName: vectorNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_40
+          nullable: true
+          readOnly: true
+          required: false
+          serializedName: vectorReadOnlyNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_41
+          nullable: true
+          readOnly: true
+          required: true
+          serializedName: vectorReadOnlyRequiredNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorReadOnlyRequiredNullable
+              description: The vector representation of a search query.
+          protocol: !Protocols {}
+        - !Property 
+          schema: *ref_42
+          nullable: true
+          required: true
+          serializedName: vectorRequiredNullable
+          extensions:
+            x-ms-embedding-vector: true
+          language: !Languages 
+            default:
+              name: vectorRequiredNullable
+              description: The vector representation of a search query.
           protocol: !Protocols {}
       serializationFormats:
         - json
@@ -1271,21 +1611,21 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - !ObjectSchema &ref_79
+    - !ObjectSchema &ref_86
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
         - !Property 
-          schema: !ObjectSchema &ref_50
+          schema: !ObjectSchema &ref_58
             type: object
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
             properties:
               - !Property 
-                schema: *ref_49
+                schema: *ref_57
                 serializedName: Name
                 language: !Languages 
                   default:
@@ -1311,12 +1651,12 @@ schemas: !Schemas
               description: ''
           protocol: !Protocols {}
         - !Property 
-          schema: !ArraySchema &ref_67
+          schema: !ArraySchema &ref_74
             type: array
             apiVersions:
               - !ApiVersion 
                 version: 1.0.0
-            elementType: *ref_50
+            elementType: *ref_58
             language: !Languages 
               default:
                 name: MixedModelWithReadonlyPropertyReadonlyListProperty
@@ -1340,23 +1680,23 @@ schemas: !Schemas
           description: ''
           namespace: ''
       protocol: !Protocols {}
-    - *ref_50
-    - !ObjectSchema &ref_82
+    - *ref_58
+    - !ObjectSchema &ref_89
       type: object
       apiVersions:
         - !ApiVersion 
           version: 1.0.0
       properties:
-        - !Property &ref_84
-          schema: *ref_51
+        - !Property &ref_91
+          schema: *ref_59
           serializedName: Code
           language: !Languages 
             default:
               name: code
               description: ''
           protocol: !Protocols {}
-        - !Property &ref_85
-          schema: *ref_52
+        - !Property &ref_92
+          schema: *ref_60
           serializedName: Status
           language: !Languages 
             default:
@@ -1380,7 +1720,7 @@ schemas: !Schemas
           version: 1.0.0
       properties:
         - !Property 
-          schema: *ref_53
+          schema: *ref_61
           serializedName: UnusedString
           language: !Languages 
             default:
@@ -1394,26 +1734,33 @@ schemas: !Schemas
           namespace: ''
       protocol: !Protocols {}
   arrays:
-    - *ref_54
-    - *ref_19
-    - *ref_55
-    - *ref_23
-    - *ref_56
-    - *ref_27
-    - *ref_57
-    - *ref_31
-    - *ref_58
-    - *ref_59
-    - *ref_60
-    - *ref_61
     - *ref_62
+    - *ref_20
     - *ref_63
+    - *ref_24
     - *ref_64
+    - *ref_28
     - *ref_65
+    - *ref_32
+    - *ref_35
+    - *ref_36
+    - *ref_37
+    - *ref_38
+    - *ref_39
+    - *ref_40
+    - *ref_41
+    - *ref_42
     - *ref_66
     - *ref_67
+    - *ref_68
+    - *ref_69
+    - *ref_70
+    - *ref_71
+    - *ref_72
+    - *ref_73
+    - *ref_74
 globalParameters:
-  - !Parameter &ref_68
+  - !Parameter &ref_75
     schema: *ref_0
     clientDefaultValue: http://localhost:3000
     implementation: Client
@@ -1439,12 +1786,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_68
+          - *ref_75
         requestMediaTypes:
-          application/json: !Request &ref_73
+          application/json: !Request &ref_80
             parameters:
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_76
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1456,8 +1803,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_72
-                schema: *ref_70
+              - !Parameter &ref_79
+                schema: *ref_77
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -1469,7 +1816,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_71
+                schema: *ref_78
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1482,7 +1829,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_72
+              - *ref_79
             language: !Languages 
               default:
                 name: ''
@@ -1496,7 +1843,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_73
+          - *ref_80
         signatureParameters: []
         responses:
           - !Response 
@@ -1510,7 +1857,7 @@ operationGroups:
                   - '200'
         exceptions:
           - !SchemaResponse 
-            schema: *ref_74
+            schema: *ref_81
             language: !Languages 
               default:
                 name: ''
@@ -1533,12 +1880,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_68
+          - *ref_75
         requestMediaTypes:
-          application/json: !Request &ref_77
+          application/json: !Request &ref_84
             parameters:
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_76
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1550,8 +1897,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_76
-                schema: *ref_75
+              - !Parameter &ref_83
+                schema: *ref_82
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -1563,7 +1910,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_71
+                schema: *ref_78
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1576,7 +1923,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_76
+              - *ref_83
             language: !Languages 
               default:
                 name: ''
@@ -1590,11 +1937,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_77
+          - *ref_84
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_75
+            schema: *ref_82
             language: !Languages 
               default:
                 name: ''
@@ -1617,12 +1964,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_68
+          - *ref_75
         requests:
           - !Request 
             parameters:
               - !Parameter 
-                schema: *ref_71
+                schema: *ref_78
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1647,7 +1994,7 @@ operationGroups:
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_78
+            schema: *ref_85
             language: !Languages 
               default:
                 name: ''
@@ -1670,12 +2017,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_68
+          - *ref_75
         requestMediaTypes:
-          application/json: !Request &ref_81
+          application/json: !Request &ref_88
             parameters:
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_76
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1687,8 +2034,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_80
-                schema: *ref_79
+              - !Parameter &ref_87
+                schema: *ref_86
                 implementation: Method
                 required: true
                 language: !Languages 
@@ -1700,7 +2047,7 @@ operationGroups:
                     in: body
                     style: json
               - !Parameter 
-                schema: *ref_71
+                schema: *ref_78
                 implementation: Method
                 origin: modelerfour:synthesized/accept
                 required: true
@@ -1713,7 +2060,7 @@ operationGroups:
                   http: !HttpParameter 
                     in: header
             signatureParameters:
-              - *ref_80
+              - *ref_87
             language: !Languages 
               default:
                 name: ''
@@ -1727,11 +2074,11 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_81
+          - *ref_88
         signatureParameters: []
         responses:
           - !SchemaResponse 
-            schema: *ref_79
+            schema: *ref_86
             language: !Languages 
               default:
                 name: ''
@@ -1754,12 +2101,12 @@ operationGroups:
           - !ApiVersion 
             version: 1.0.0
         parameters:
-          - *ref_68
+          - *ref_75
         requestMediaTypes:
-          application/json: !Request &ref_88
+          application/json: !Request &ref_95
             parameters:
               - !Parameter 
-                schema: *ref_69
+                schema: *ref_76
                 implementation: Method
                 origin: modelerfour:synthesized/content-type
                 required: true
@@ -1771,8 +2118,8 @@ operationGroups:
                 protocol: !Protocols 
                   http: !HttpParameter 
                     in: header
-              - !Parameter &ref_83
-                schema: *ref_82
+              - !Parameter &ref_90
+                schema: *ref_89
                 flattened: true
                 implementation: Method
                 required: true
@@ -1786,31 +2133,31 @@ operationGroups:
                   http: !HttpParameter 
                     in: body
                     style: json
-              - !VirtualParameter &ref_86
-                schema: *ref_51
+              - !VirtualParameter &ref_93
+                schema: *ref_59
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_84
+                targetProperty: *ref_91
                 language: !Languages 
                   default:
                     name: code
                     description: ''
                 protocol: !Protocols {}
-              - !VirtualParameter &ref_87
-                schema: *ref_52
+              - !VirtualParameter &ref_94
+                schema: *ref_60
                 implementation: Method
-                originalParameter: *ref_83
+                originalParameter: *ref_90
                 pathToProperty: []
-                targetProperty: *ref_85
+                targetProperty: *ref_92
                 language: !Languages 
                   default:
                     name: status
                     description: ''
                 protocol: !Protocols {}
             signatureParameters:
-              - *ref_86
-              - *ref_87
+              - *ref_93
+              - *ref_94
             language: !Languages 
               default:
                 name: ''
@@ -1824,7 +2171,7 @@ operationGroups:
                   - application/json
                 uri: '{$host}'
         requests:
-          - *ref_88
+          - *ref_95
         signatureParameters: []
         responses:
           - !Response 

--- a/test/TestProjects/ModelShapes/Generated/ModelShapesModelFactory.cs
+++ b/test/TestProjects/ModelShapes/Generated/ModelShapesModelFactory.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -33,8 +34,15 @@ namespace ModelShapes.Models
         /// <param name="requiredReadonlyInt"></param>
         /// <param name="nonRequiredReadonlyInt"></param>
         /// <param name="vector"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnly"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
         /// <returns> A new <see cref="Models.MixedModel"/> instance for mocking. </returns>
-        public static MixedModel MixedModel(string requiredString = null, int requiredInt = default, IEnumerable<string> requiredStringList = null, IEnumerable<int> requiredIntList = null, string nonRequiredString = null, int? nonRequiredInt = null, IEnumerable<string> nonRequiredStringList = null, IEnumerable<int> nonRequiredIntList = null, string requiredNullableString = null, int? requiredNullableInt = null, IEnumerable<string> requiredNullableStringList = null, IEnumerable<int> requiredNullableIntList = null, string nonRequiredNullableString = null, int? nonRequiredNullableInt = null, IEnumerable<string> nonRequiredNullableStringList = null, IEnumerable<int> nonRequiredNullableIntList = null, int requiredReadonlyInt = default, int? nonRequiredReadonlyInt = null, IEnumerable<float> vector = null)
+        public static MixedModel MixedModel(string requiredString = null, int requiredInt = default, IEnumerable<string> requiredStringList = null, IEnumerable<int> requiredIntList = null, string nonRequiredString = null, int? nonRequiredInt = null, IEnumerable<string> nonRequiredStringList = null, IEnumerable<int> nonRequiredIntList = null, string requiredNullableString = null, int? requiredNullableInt = null, IEnumerable<string> requiredNullableStringList = null, IEnumerable<int> requiredNullableIntList = null, string nonRequiredNullableString = null, int? nonRequiredNullableInt = null, IEnumerable<string> nonRequiredNullableStringList = null, IEnumerable<int> nonRequiredNullableIntList = null, int requiredReadonlyInt = default, int? nonRequiredReadonlyInt = null, ReadOnlyMemory<float> vector = default, ReadOnlyMemory<float> vectorReadOnly = default, ReadOnlyMemory<float> vectorReadOnlyRequired = default, ReadOnlyMemory<float> vectorRequired = default, ReadOnlyMemory<float>? vectorNullable = null, ReadOnlyMemory<float>? vectorReadOnlyNullable = null, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable = null, ReadOnlyMemory<float>? vectorRequiredNullable = null)
         {
             requiredStringList ??= new List<string>();
             requiredIntList ??= new List<int>();
@@ -44,9 +52,8 @@ namespace ModelShapes.Models
             requiredNullableIntList ??= new List<int>();
             nonRequiredNullableStringList ??= new List<string>();
             nonRequiredNullableIntList ??= new List<int>();
-            vector ??= new List<float>();
 
-            return new MixedModel(requiredString, requiredInt, requiredStringList?.ToList(), requiredIntList?.ToList(), nonRequiredString, nonRequiredInt, nonRequiredStringList?.ToList(), nonRequiredIntList?.ToList(), requiredNullableString, requiredNullableInt, requiredNullableStringList?.ToList(), requiredNullableIntList?.ToList(), nonRequiredNullableString, nonRequiredNullableInt, nonRequiredNullableStringList?.ToList(), nonRequiredNullableIntList?.ToList(), requiredReadonlyInt, nonRequiredReadonlyInt, vector);
+            return new MixedModel(requiredString, requiredInt, requiredStringList?.ToList(), requiredIntList?.ToList(), nonRequiredString, nonRequiredInt, nonRequiredStringList?.ToList(), nonRequiredIntList?.ToList(), requiredNullableString, requiredNullableInt, requiredNullableStringList?.ToList(), requiredNullableIntList?.ToList(), nonRequiredNullableString, nonRequiredNullableInt, nonRequiredNullableStringList?.ToList(), nonRequiredNullableIntList?.ToList(), requiredReadonlyInt, nonRequiredReadonlyInt, vector, vectorReadOnly, vectorReadOnlyRequired, vectorRequired, vectorNullable, vectorReadOnlyNullable, vectorReadOnlyRequiredNullable, vectorRequiredNullable);
         }
 
         /// <summary> Initializes a new instance of OutputModel. </summary>
@@ -68,8 +75,16 @@ namespace ModelShapes.Models
         /// <param name="nonRequiredNullableIntList"></param>
         /// <param name="requiredReadonlyInt"></param>
         /// <param name="nonRequiredReadonlyInt"></param>
+        /// <param name="vector"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnly"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
         /// <returns> A new <see cref="Models.OutputModel"/> instance for mocking. </returns>
-        public static OutputModel OutputModel(string requiredString = null, int requiredInt = default, IEnumerable<string> requiredStringList = null, IEnumerable<int> requiredIntList = null, string nonRequiredString = null, int? nonRequiredInt = null, IEnumerable<string> nonRequiredStringList = null, IEnumerable<int> nonRequiredIntList = null, string requiredNullableString = null, int? requiredNullableInt = null, IEnumerable<string> requiredNullableStringList = null, IEnumerable<int> requiredNullableIntList = null, string nonRequiredNullableString = null, int? nonRequiredNullableInt = null, IEnumerable<string> nonRequiredNullableStringList = null, IEnumerable<int> nonRequiredNullableIntList = null, int requiredReadonlyInt = default, int? nonRequiredReadonlyInt = null)
+        public static OutputModel OutputModel(string requiredString = null, int requiredInt = default, IEnumerable<string> requiredStringList = null, IEnumerable<int> requiredIntList = null, string nonRequiredString = null, int? nonRequiredInt = null, IEnumerable<string> nonRequiredStringList = null, IEnumerable<int> nonRequiredIntList = null, string requiredNullableString = null, int? requiredNullableInt = null, IEnumerable<string> requiredNullableStringList = null, IEnumerable<int> requiredNullableIntList = null, string nonRequiredNullableString = null, int? nonRequiredNullableInt = null, IEnumerable<string> nonRequiredNullableStringList = null, IEnumerable<int> nonRequiredNullableIntList = null, int requiredReadonlyInt = default, int? nonRequiredReadonlyInt = null, ReadOnlyMemory<float> vector = default, ReadOnlyMemory<float> vectorReadOnly = default, ReadOnlyMemory<float> vectorReadOnlyRequired = default, ReadOnlyMemory<float> vectorRequired = default, ReadOnlyMemory<float>? vectorNullable = null, ReadOnlyMemory<float>? vectorReadOnlyNullable = null, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable = null, ReadOnlyMemory<float>? vectorRequiredNullable = null)
         {
             requiredStringList ??= new List<string>();
             requiredIntList ??= new List<int>();
@@ -80,7 +95,7 @@ namespace ModelShapes.Models
             nonRequiredNullableStringList ??= new List<string>();
             nonRequiredNullableIntList ??= new List<int>();
 
-            return new OutputModel(requiredString, requiredInt, requiredStringList?.ToList(), requiredIntList?.ToList(), nonRequiredString, nonRequiredInt, nonRequiredStringList?.ToList(), nonRequiredIntList?.ToList(), requiredNullableString, requiredNullableInt, requiredNullableStringList?.ToList(), requiredNullableIntList?.ToList(), nonRequiredNullableString, nonRequiredNullableInt, nonRequiredNullableStringList?.ToList(), nonRequiredNullableIntList?.ToList(), requiredReadonlyInt, nonRequiredReadonlyInt);
+            return new OutputModel(requiredString, requiredInt, requiredStringList?.ToList(), requiredIntList?.ToList(), nonRequiredString, nonRequiredInt, nonRequiredStringList?.ToList(), nonRequiredIntList?.ToList(), requiredNullableString, requiredNullableInt, requiredNullableStringList?.ToList(), requiredNullableIntList?.ToList(), nonRequiredNullableString, nonRequiredNullableInt, nonRequiredNullableStringList?.ToList(), nonRequiredNullableIntList?.ToList(), requiredReadonlyInt, nonRequiredReadonlyInt, vector, vectorReadOnly, vectorReadOnlyRequired, vectorRequired, vectorNullable, vectorReadOnlyNullable, vectorReadOnlyRequiredNullable, vectorRequiredNullable);
         }
 
         /// <summary> Initializes a new instance of MixedModelWithReadonlyProperty. </summary>

--- a/test/TestProjects/ModelShapes/Generated/ModelShapesModelFactory.cs
+++ b/test/TestProjects/ModelShapes/Generated/ModelShapesModelFactory.cs
@@ -32,8 +32,9 @@ namespace ModelShapes.Models
         /// <param name="nonRequiredNullableIntList"></param>
         /// <param name="requiredReadonlyInt"></param>
         /// <param name="nonRequiredReadonlyInt"></param>
+        /// <param name="vector"> The vector representation of a search query. </param>
         /// <returns> A new <see cref="Models.MixedModel"/> instance for mocking. </returns>
-        public static MixedModel MixedModel(string requiredString = null, int requiredInt = default, IEnumerable<string> requiredStringList = null, IEnumerable<int> requiredIntList = null, string nonRequiredString = null, int? nonRequiredInt = null, IEnumerable<string> nonRequiredStringList = null, IEnumerable<int> nonRequiredIntList = null, string requiredNullableString = null, int? requiredNullableInt = null, IEnumerable<string> requiredNullableStringList = null, IEnumerable<int> requiredNullableIntList = null, string nonRequiredNullableString = null, int? nonRequiredNullableInt = null, IEnumerable<string> nonRequiredNullableStringList = null, IEnumerable<int> nonRequiredNullableIntList = null, int requiredReadonlyInt = default, int? nonRequiredReadonlyInt = null)
+        public static MixedModel MixedModel(string requiredString = null, int requiredInt = default, IEnumerable<string> requiredStringList = null, IEnumerable<int> requiredIntList = null, string nonRequiredString = null, int? nonRequiredInt = null, IEnumerable<string> nonRequiredStringList = null, IEnumerable<int> nonRequiredIntList = null, string requiredNullableString = null, int? requiredNullableInt = null, IEnumerable<string> requiredNullableStringList = null, IEnumerable<int> requiredNullableIntList = null, string nonRequiredNullableString = null, int? nonRequiredNullableInt = null, IEnumerable<string> nonRequiredNullableStringList = null, IEnumerable<int> nonRequiredNullableIntList = null, int requiredReadonlyInt = default, int? nonRequiredReadonlyInt = null, IEnumerable<float> vector = null)
         {
             requiredStringList ??= new List<string>();
             requiredIntList ??= new List<int>();
@@ -43,8 +44,9 @@ namespace ModelShapes.Models
             requiredNullableIntList ??= new List<int>();
             nonRequiredNullableStringList ??= new List<string>();
             nonRequiredNullableIntList ??= new List<int>();
+            vector ??= new List<float>();
 
-            return new MixedModel(requiredString, requiredInt, requiredStringList?.ToList(), requiredIntList?.ToList(), nonRequiredString, nonRequiredInt, nonRequiredStringList?.ToList(), nonRequiredIntList?.ToList(), requiredNullableString, requiredNullableInt, requiredNullableStringList?.ToList(), requiredNullableIntList?.ToList(), nonRequiredNullableString, nonRequiredNullableInt, nonRequiredNullableStringList?.ToList(), nonRequiredNullableIntList?.ToList(), requiredReadonlyInt, nonRequiredReadonlyInt);
+            return new MixedModel(requiredString, requiredInt, requiredStringList?.ToList(), requiredIntList?.ToList(), nonRequiredString, nonRequiredInt, nonRequiredStringList?.ToList(), nonRequiredIntList?.ToList(), requiredNullableString, requiredNullableInt, requiredNullableStringList?.ToList(), requiredNullableIntList?.ToList(), nonRequiredNullableString, nonRequiredNullableInt, nonRequiredNullableStringList?.ToList(), nonRequiredNullableIntList?.ToList(), requiredReadonlyInt, nonRequiredReadonlyInt, vector);
         }
 
         /// <summary> Initializes a new instance of OutputModel. </summary>

--- a/test/TestProjects/ModelShapes/Generated/Models/InputModel.Serialization.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/InputModel.Serialization.cs
@@ -38,11 +38,8 @@ namespace ModelShapes.Models
                 writer.WritePropertyName("NonRequiredString"u8);
                 writer.WriteStringValue(NonRequiredString);
             }
-            if (Optional.IsDefined(NonRequiredInt))
-            {
-                writer.WritePropertyName("NonRequiredInt"u8);
-                writer.WriteNumberValue(NonRequiredInt.Value);
-            }
+            writer.WritePropertyName("NonRequiredInt"u8);
+            writer.WriteNumberValue(NonRequiredInt.Value);
             if (Optional.IsCollectionDefined(NonRequiredStringList))
             {
                 writer.WritePropertyName("NonRequiredStringList"u8);
@@ -121,17 +118,14 @@ namespace ModelShapes.Models
                     writer.WriteNull("NonRequiredNullableString");
                 }
             }
-            if (Optional.IsDefined(NonRequiredNullableInt))
+            if (NonRequiredNullableInt != null)
             {
-                if (NonRequiredNullableInt != null)
-                {
-                    writer.WritePropertyName("NonRequiredNullableInt"u8);
-                    writer.WriteNumberValue(NonRequiredNullableInt.Value);
-                }
-                else
-                {
-                    writer.WriteNull("NonRequiredNullableInt");
-                }
+                writer.WritePropertyName("NonRequiredNullableInt"u8);
+                writer.WriteNumberValue(NonRequiredNullableInt.Value);
+            }
+            else
+            {
+                writer.WriteNull("NonRequiredNullableInt");
             }
             if (Optional.IsCollectionDefined(NonRequiredNullableStringList))
             {

--- a/test/TestProjects/ModelShapes/Generated/Models/InputModel.Serialization.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/InputModel.Serialization.cs
@@ -38,8 +38,11 @@ namespace ModelShapes.Models
                 writer.WritePropertyName("NonRequiredString"u8);
                 writer.WriteStringValue(NonRequiredString);
             }
-            writer.WritePropertyName("NonRequiredInt"u8);
-            writer.WriteNumberValue(NonRequiredInt.Value);
+            if (Optional.IsDefined(NonRequiredInt))
+            {
+                writer.WritePropertyName("NonRequiredInt"u8);
+                writer.WriteNumberValue(NonRequiredInt.Value);
+            }
             if (Optional.IsCollectionDefined(NonRequiredStringList))
             {
                 writer.WritePropertyName("NonRequiredStringList"u8);
@@ -118,14 +121,17 @@ namespace ModelShapes.Models
                     writer.WriteNull("NonRequiredNullableString");
                 }
             }
-            if (NonRequiredNullableInt != null)
+            if (Optional.IsDefined(NonRequiredNullableInt))
             {
-                writer.WritePropertyName("NonRequiredNullableInt"u8);
-                writer.WriteNumberValue(NonRequiredNullableInt.Value);
-            }
-            else
-            {
-                writer.WriteNull("NonRequiredNullableInt");
+                if (NonRequiredNullableInt != null)
+                {
+                    writer.WritePropertyName("NonRequiredNullableInt"u8);
+                    writer.WriteNumberValue(NonRequiredNullableInt.Value);
+                }
+                else
+                {
+                    writer.WriteNull("NonRequiredNullableInt");
+                }
             }
             if (Optional.IsCollectionDefined(NonRequiredNullableStringList))
             {
@@ -160,6 +166,48 @@ namespace ModelShapes.Models
                 {
                     writer.WriteNull("NonRequiredNullableIntList");
                 }
+            }
+            writer.WritePropertyName("vector"u8);
+            writer.WriteStartArray();
+            foreach (var item in Vector.Span)
+            {
+                writer.WriteNumberValue(item);
+            }
+            writer.WriteEndArray();
+            writer.WritePropertyName("vectorRequired"u8);
+            writer.WriteStartArray();
+            foreach (var item in VectorRequired.Span)
+            {
+                writer.WriteNumberValue(item);
+            }
+            writer.WriteEndArray();
+            if (VectorNullable != null)
+            {
+                writer.WritePropertyName("vectorNullable"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorNullable.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorNullable");
+            }
+            if (VectorRequiredNullable != null)
+            {
+                writer.WritePropertyName("vectorRequiredNullable"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorRequiredNullable.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorRequiredNullable");
             }
             writer.WriteEndObject();
         }

--- a/test/TestProjects/ModelShapes/Generated/Models/InputModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/InputModel.cs
@@ -24,8 +24,12 @@ namespace ModelShapes.Models
         /// <param name="requiredNullableInt"></param>
         /// <param name="requiredNullableStringList"></param>
         /// <param name="requiredNullableIntList"></param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="requiredString"/>, <paramref name="requiredStringList"/> or <paramref name="requiredIntList"/> is null. </exception>
-        public InputModel(string requiredString, int requiredInt, IEnumerable<string> requiredStringList, IEnumerable<int> requiredIntList, string requiredNullableString, int? requiredNullableInt, IEnumerable<string> requiredNullableStringList, IEnumerable<int> requiredNullableIntList)
+        public InputModel(string requiredString, int requiredInt, IEnumerable<string> requiredStringList, IEnumerable<int> requiredIntList, string requiredNullableString, int? requiredNullableInt, IEnumerable<string> requiredNullableStringList, IEnumerable<int> requiredNullableIntList, ReadOnlyMemory<float> vectorReadOnlyRequired, ReadOnlyMemory<float> vectorRequired, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable, ReadOnlyMemory<float>? vectorRequiredNullable)
         {
             Argument.AssertNotNull(requiredString, nameof(requiredString));
             Argument.AssertNotNull(requiredStringList, nameof(requiredStringList));
@@ -43,6 +47,12 @@ namespace ModelShapes.Models
             RequiredNullableIntList = requiredNullableIntList?.ToList();
             NonRequiredNullableStringList = new ChangeTrackingList<string>();
             NonRequiredNullableIntList = new ChangeTrackingList<int>();
+            Vector = ReadOnlyMemory<float>.Empty;
+            VectorReadOnly = ReadOnlyMemory<float>.Empty;
+            VectorReadOnlyRequired = vectorReadOnlyRequired;
+            VectorRequired = vectorRequired;
+            VectorReadOnlyRequiredNullable = vectorReadOnlyRequiredNullable;
+            VectorRequiredNullable = vectorRequiredNullable;
         }
 
         /// <summary> Gets the required string. </summary>
@@ -77,5 +87,21 @@ namespace ModelShapes.Models
         public IList<string> NonRequiredNullableStringList { get; set; }
         /// <summary> Gets or sets the non required nullable int list. </summary>
         public IList<int> NonRequiredNullableIntList { get; set; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> Vector { get; set; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorReadOnly { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorReadOnlyRequired { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorRequired { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorNullable { get; set; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorReadOnlyNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorReadOnlyRequiredNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorRequiredNullable { get; }
     }
 }

--- a/test/TestProjects/ModelShapes/Generated/Models/MixedModel.Serialization.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/MixedModel.Serialization.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
@@ -39,11 +40,8 @@ namespace ModelShapes.Models
                 writer.WritePropertyName("NonRequiredString"u8);
                 writer.WriteStringValue(NonRequiredString);
             }
-            if (Optional.IsDefined(NonRequiredInt))
-            {
-                writer.WritePropertyName("NonRequiredInt"u8);
-                writer.WriteNumberValue(NonRequiredInt.Value);
-            }
+            writer.WritePropertyName("NonRequiredInt"u8);
+            writer.WriteNumberValue(NonRequiredInt.Value);
             if (Optional.IsCollectionDefined(NonRequiredStringList))
             {
                 writer.WritePropertyName("NonRequiredStringList"u8);
@@ -122,17 +120,14 @@ namespace ModelShapes.Models
                     writer.WriteNull("NonRequiredNullableString");
                 }
             }
-            if (Optional.IsDefined(NonRequiredNullableInt))
+            if (NonRequiredNullableInt != null)
             {
-                if (NonRequiredNullableInt != null)
-                {
-                    writer.WritePropertyName("NonRequiredNullableInt"u8);
-                    writer.WriteNumberValue(NonRequiredNullableInt.Value);
-                }
-                else
-                {
-                    writer.WriteNull("NonRequiredNullableInt");
-                }
+                writer.WritePropertyName("NonRequiredNullableInt"u8);
+                writer.WriteNumberValue(NonRequiredNullableInt.Value);
+            }
+            else
+            {
+                writer.WriteNull("NonRequiredNullableInt");
             }
             if (Optional.IsCollectionDefined(NonRequiredNullableStringList))
             {
@@ -168,6 +163,13 @@ namespace ModelShapes.Models
                     writer.WriteNull("NonRequiredNullableIntList");
                 }
             }
+            writer.WritePropertyName("vector"u8);
+            writer.WriteStartArray();
+            foreach (var item in Vector.Span)
+            {
+                writer.WriteNumberValue(item);
+            }
+            writer.WriteEndArray();
             writer.WriteEndObject();
         }
 
@@ -195,6 +197,7 @@ namespace ModelShapes.Models
             Optional<IList<int>> nonRequiredNullableIntList = default;
             int requiredReadonlyInt = default;
             Optional<int> nonRequiredReadonlyInt = default;
+            Optional<ReadOnlyMemory<float>> vector = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("RequiredString"u8))
@@ -381,8 +384,24 @@ namespace ModelShapes.Models
                     nonRequiredReadonlyInt = property.Value.GetInt32();
                     continue;
                 }
+                if (property.NameEquals("vector"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vector = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
             }
-            return new MixedModel(requiredString, requiredInt, requiredStringList, requiredIntList, nonRequiredString.Value, Optional.ToNullable(nonRequiredInt), Optional.ToList(nonRequiredStringList), Optional.ToList(nonRequiredIntList), requiredNullableString, requiredNullableInt, requiredNullableStringList, requiredNullableIntList, nonRequiredNullableString.Value, Optional.ToNullable(nonRequiredNullableInt), Optional.ToList(nonRequiredNullableStringList), Optional.ToList(nonRequiredNullableIntList), requiredReadonlyInt, Optional.ToNullable(nonRequiredReadonlyInt));
+            return new MixedModel(requiredString, requiredInt, requiredStringList, requiredIntList, nonRequiredString.Value, Optional.ToNullable(nonRequiredInt), Optional.ToList(nonRequiredStringList), Optional.ToList(nonRequiredIntList), requiredNullableString, requiredNullableInt, requiredNullableStringList, requiredNullableIntList, nonRequiredNullableString.Value, Optional.ToNullable(nonRequiredNullableInt), Optional.ToList(nonRequiredNullableStringList), Optional.ToList(nonRequiredNullableIntList), requiredReadonlyInt, Optional.ToNullable(nonRequiredReadonlyInt), vector);
         }
     }
 }

--- a/test/TestProjects/ModelShapes/Generated/Models/MixedModel.Serialization.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/MixedModel.Serialization.cs
@@ -40,8 +40,11 @@ namespace ModelShapes.Models
                 writer.WritePropertyName("NonRequiredString"u8);
                 writer.WriteStringValue(NonRequiredString);
             }
-            writer.WritePropertyName("NonRequiredInt"u8);
-            writer.WriteNumberValue(NonRequiredInt.Value);
+            if (Optional.IsDefined(NonRequiredInt))
+            {
+                writer.WritePropertyName("NonRequiredInt"u8);
+                writer.WriteNumberValue(NonRequiredInt.Value);
+            }
             if (Optional.IsCollectionDefined(NonRequiredStringList))
             {
                 writer.WritePropertyName("NonRequiredStringList"u8);
@@ -120,14 +123,17 @@ namespace ModelShapes.Models
                     writer.WriteNull("NonRequiredNullableString");
                 }
             }
-            if (NonRequiredNullableInt != null)
+            if (Optional.IsDefined(NonRequiredNullableInt))
             {
-                writer.WritePropertyName("NonRequiredNullableInt"u8);
-                writer.WriteNumberValue(NonRequiredNullableInt.Value);
-            }
-            else
-            {
-                writer.WriteNull("NonRequiredNullableInt");
+                if (NonRequiredNullableInt != null)
+                {
+                    writer.WritePropertyName("NonRequiredNullableInt"u8);
+                    writer.WriteNumberValue(NonRequiredNullableInt.Value);
+                }
+                else
+                {
+                    writer.WriteNull("NonRequiredNullableInt");
+                }
             }
             if (Optional.IsCollectionDefined(NonRequiredNullableStringList))
             {
@@ -170,6 +176,41 @@ namespace ModelShapes.Models
                 writer.WriteNumberValue(item);
             }
             writer.WriteEndArray();
+            writer.WritePropertyName("vectorRequired"u8);
+            writer.WriteStartArray();
+            foreach (var item in VectorRequired.Span)
+            {
+                writer.WriteNumberValue(item);
+            }
+            writer.WriteEndArray();
+            if (VectorNullable != null)
+            {
+                writer.WritePropertyName("vectorNullable"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorNullable.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorNullable");
+            }
+            if (VectorRequiredNullable != null)
+            {
+                writer.WritePropertyName("vectorRequiredNullable"u8);
+                writer.WriteStartArray();
+                foreach (var item in VectorRequiredNullable.Value.Span)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("vectorRequiredNullable");
+            }
             writer.WriteEndObject();
         }
 
@@ -198,6 +239,13 @@ namespace ModelShapes.Models
             int requiredReadonlyInt = default;
             Optional<int> nonRequiredReadonlyInt = default;
             Optional<ReadOnlyMemory<float>> vector = default;
+            Optional<ReadOnlyMemory<float>> vectorReadOnly = default;
+            ReadOnlyMemory<float> vectorReadOnlyRequired = default;
+            ReadOnlyMemory<float> vectorRequired = default;
+            Optional<ReadOnlyMemory<float>?> vectorNullable = default;
+            Optional<ReadOnlyMemory<float>?> vectorReadOnlyNullable = default;
+            ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable = default;
+            ReadOnlyMemory<float>? vectorRequiredNullable = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("RequiredString"u8))
@@ -400,8 +448,120 @@ namespace ModelShapes.Models
                     vector = new ReadOnlyMemory<float>(array);
                     continue;
                 }
+                if (property.NameEquals("vectorReadOnly"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnly = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnlyRequired"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnlyRequired = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorRequired"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorRequired = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnlyNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnlyNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnlyRequiredNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnlyRequiredNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorRequiredNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorRequiredNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
             }
-            return new MixedModel(requiredString, requiredInt, requiredStringList, requiredIntList, nonRequiredString.Value, Optional.ToNullable(nonRequiredInt), Optional.ToList(nonRequiredStringList), Optional.ToList(nonRequiredIntList), requiredNullableString, requiredNullableInt, requiredNullableStringList, requiredNullableIntList, nonRequiredNullableString.Value, Optional.ToNullable(nonRequiredNullableInt), Optional.ToList(nonRequiredNullableStringList), Optional.ToList(nonRequiredNullableIntList), requiredReadonlyInt, Optional.ToNullable(nonRequiredReadonlyInt), vector);
+            return new MixedModel(requiredString, requiredInt, requiredStringList, requiredIntList, nonRequiredString.Value, Optional.ToNullable(nonRequiredInt), Optional.ToList(nonRequiredStringList), Optional.ToList(nonRequiredIntList), requiredNullableString, requiredNullableInt, requiredNullableStringList, requiredNullableIntList, nonRequiredNullableString.Value, Optional.ToNullable(nonRequiredNullableInt), Optional.ToList(nonRequiredNullableStringList), Optional.ToList(nonRequiredNullableIntList), requiredReadonlyInt, Optional.ToNullable(nonRequiredReadonlyInt), vector, vectorReadOnly, vectorReadOnlyRequired, vectorRequired, Optional.ToNullable(vectorNullable), Optional.ToNullable(vectorReadOnlyNullable), vectorReadOnlyRequiredNullable, vectorRequiredNullable);
         }
     }
 }

--- a/test/TestProjects/ModelShapes/Generated/Models/MixedModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/MixedModel.cs
@@ -25,8 +25,12 @@ namespace ModelShapes.Models
         /// <param name="requiredNullableStringList"></param>
         /// <param name="requiredNullableIntList"></param>
         /// <param name="requiredReadonlyInt"></param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="requiredString"/>, <paramref name="requiredStringList"/> or <paramref name="requiredIntList"/> is null. </exception>
-        public MixedModel(string requiredString, int requiredInt, IEnumerable<string> requiredStringList, IEnumerable<int> requiredIntList, string requiredNullableString, int? requiredNullableInt, IEnumerable<string> requiredNullableStringList, IEnumerable<int> requiredNullableIntList, int requiredReadonlyInt)
+        public MixedModel(string requiredString, int requiredInt, IEnumerable<string> requiredStringList, IEnumerable<int> requiredIntList, string requiredNullableString, int? requiredNullableInt, IEnumerable<string> requiredNullableStringList, IEnumerable<int> requiredNullableIntList, int requiredReadonlyInt, ReadOnlyMemory<float> vectorReadOnlyRequired, ReadOnlyMemory<float> vectorRequired, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable, ReadOnlyMemory<float>? vectorRequiredNullable)
         {
             Argument.AssertNotNull(requiredString, nameof(requiredString));
             Argument.AssertNotNull(requiredStringList, nameof(requiredStringList));
@@ -45,7 +49,12 @@ namespace ModelShapes.Models
             NonRequiredNullableStringList = new ChangeTrackingList<string>();
             NonRequiredNullableIntList = new ChangeTrackingList<int>();
             RequiredReadonlyInt = requiredReadonlyInt;
-            Vector = new ChangeTrackingList<float>();
+            Vector = ReadOnlyMemory<float>.Empty;
+            VectorReadOnly = ReadOnlyMemory<float>.Empty;
+            VectorReadOnlyRequired = vectorReadOnlyRequired;
+            VectorRequired = vectorRequired;
+            VectorReadOnlyRequiredNullable = vectorReadOnlyRequiredNullable;
+            VectorRequiredNullable = vectorRequiredNullable;
         }
 
         /// <summary> Initializes a new instance of MixedModel. </summary>
@@ -68,7 +77,14 @@ namespace ModelShapes.Models
         /// <param name="requiredReadonlyInt"></param>
         /// <param name="nonRequiredReadonlyInt"></param>
         /// <param name="vector"> The vector representation of a search query. </param>
-        internal MixedModel(string requiredString, int requiredInt, IList<string> requiredStringList, IList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IList<string> nonRequiredStringList, IList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IList<string> requiredNullableStringList, IList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IList<string> nonRequiredNullableStringList, IList<int> nonRequiredNullableIntList, int requiredReadonlyInt, int? nonRequiredReadonlyInt, ReadOnlyMemory<float> vector)
+        /// <param name="vectorReadOnly"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
+        internal MixedModel(string requiredString, int requiredInt, IList<string> requiredStringList, IList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IList<string> nonRequiredStringList, IList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IList<string> requiredNullableStringList, IList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IList<string> nonRequiredNullableStringList, IList<int> nonRequiredNullableIntList, int requiredReadonlyInt, int? nonRequiredReadonlyInt, ReadOnlyMemory<float> vector, ReadOnlyMemory<float> vectorReadOnly, ReadOnlyMemory<float> vectorReadOnlyRequired, ReadOnlyMemory<float> vectorRequired, ReadOnlyMemory<float>? vectorNullable, ReadOnlyMemory<float>? vectorReadOnlyNullable, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable, ReadOnlyMemory<float>? vectorRequiredNullable)
         {
             RequiredString = requiredString;
             RequiredInt = requiredInt;
@@ -89,6 +105,13 @@ namespace ModelShapes.Models
             RequiredReadonlyInt = requiredReadonlyInt;
             NonRequiredReadonlyInt = nonRequiredReadonlyInt;
             Vector = vector;
+            VectorReadOnly = vectorReadOnly;
+            VectorReadOnlyRequired = vectorReadOnlyRequired;
+            VectorRequired = vectorRequired;
+            VectorNullable = vectorNullable;
+            VectorReadOnlyNullable = vectorReadOnlyNullable;
+            VectorReadOnlyRequiredNullable = vectorReadOnlyRequiredNullable;
+            VectorRequiredNullable = vectorRequiredNullable;
         }
 
         /// <summary> Gets or sets the required string. </summary>
@@ -128,6 +151,20 @@ namespace ModelShapes.Models
         /// <summary> Gets the non required readonly int. </summary>
         public int? NonRequiredReadonlyInt { get; }
         /// <summary> The vector representation of a search query. </summary>
-        public ReadOnlyMemory<float> Vector { get; }
+        public ReadOnlyMemory<float> Vector { get; set; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorReadOnly { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorReadOnlyRequired { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorRequired { get; set; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorNullable { get; set; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorReadOnlyNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorReadOnlyRequiredNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorRequiredNullable { get; set; }
     }
 }

--- a/test/TestProjects/ModelShapes/Generated/Models/MixedModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/MixedModel.cs
@@ -45,6 +45,7 @@ namespace ModelShapes.Models
             NonRequiredNullableStringList = new ChangeTrackingList<string>();
             NonRequiredNullableIntList = new ChangeTrackingList<int>();
             RequiredReadonlyInt = requiredReadonlyInt;
+            Vector = new ChangeTrackingList<float>();
         }
 
         /// <summary> Initializes a new instance of MixedModel. </summary>
@@ -66,7 +67,8 @@ namespace ModelShapes.Models
         /// <param name="nonRequiredNullableIntList"></param>
         /// <param name="requiredReadonlyInt"></param>
         /// <param name="nonRequiredReadonlyInt"></param>
-        internal MixedModel(string requiredString, int requiredInt, IList<string> requiredStringList, IList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IList<string> nonRequiredStringList, IList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IList<string> requiredNullableStringList, IList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IList<string> nonRequiredNullableStringList, IList<int> nonRequiredNullableIntList, int requiredReadonlyInt, int? nonRequiredReadonlyInt)
+        /// <param name="vector"> The vector representation of a search query. </param>
+        internal MixedModel(string requiredString, int requiredInt, IList<string> requiredStringList, IList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IList<string> nonRequiredStringList, IList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IList<string> requiredNullableStringList, IList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IList<string> nonRequiredNullableStringList, IList<int> nonRequiredNullableIntList, int requiredReadonlyInt, int? nonRequiredReadonlyInt, ReadOnlyMemory<float> vector)
         {
             RequiredString = requiredString;
             RequiredInt = requiredInt;
@@ -86,6 +88,7 @@ namespace ModelShapes.Models
             NonRequiredNullableIntList = nonRequiredNullableIntList;
             RequiredReadonlyInt = requiredReadonlyInt;
             NonRequiredReadonlyInt = nonRequiredReadonlyInt;
+            Vector = vector;
         }
 
         /// <summary> Gets or sets the required string. </summary>
@@ -124,5 +127,7 @@ namespace ModelShapes.Models
         public int RequiredReadonlyInt { get; }
         /// <summary> Gets the non required readonly int. </summary>
         public int? NonRequiredReadonlyInt { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> Vector { get; }
     }
 }

--- a/test/TestProjects/ModelShapes/Generated/Models/OutputModel.Serialization.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/OutputModel.Serialization.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Azure.Core;
@@ -37,6 +38,14 @@ namespace ModelShapes.Models
             Optional<IReadOnlyList<int>> nonRequiredNullableIntList = default;
             int requiredReadonlyInt = default;
             Optional<int> nonRequiredReadonlyInt = default;
+            Optional<ReadOnlyMemory<float>> vector = default;
+            Optional<ReadOnlyMemory<float>> vectorReadOnly = default;
+            ReadOnlyMemory<float> vectorReadOnlyRequired = default;
+            ReadOnlyMemory<float> vectorRequired = default;
+            Optional<ReadOnlyMemory<float>?> vectorNullable = default;
+            Optional<ReadOnlyMemory<float>?> vectorReadOnlyNullable = default;
+            ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable = default;
+            ReadOnlyMemory<float>? vectorRequiredNullable = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("RequiredString"u8))
@@ -223,8 +232,136 @@ namespace ModelShapes.Models
                     nonRequiredReadonlyInt = property.Value.GetInt32();
                     continue;
                 }
+                if (property.NameEquals("vector"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vector = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnly"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnly = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnlyRequired"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnlyRequired = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorRequired"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorRequired = new ReadOnlyMemory<float>(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnlyNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnlyNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorReadOnlyRequiredNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorReadOnlyRequiredNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
+                if (property.NameEquals("vectorRequiredNullable"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+                    int index = 0;
+                    float[] array = new float[property.Value.GetArrayLength()];
+                    foreach (var item in property.Value.EnumerateArray())
+                    {
+                        array[index] = item.GetSingle();
+                        index++;
+                    }
+                    vectorRequiredNullable = new ReadOnlyMemory<float>?(array);
+                    continue;
+                }
             }
-            return new OutputModel(requiredString, requiredInt, requiredStringList, requiredIntList, nonRequiredString.Value, Optional.ToNullable(nonRequiredInt), Optional.ToList(nonRequiredStringList), Optional.ToList(nonRequiredIntList), requiredNullableString, requiredNullableInt, requiredNullableStringList, requiredNullableIntList, nonRequiredNullableString.Value, Optional.ToNullable(nonRequiredNullableInt), Optional.ToList(nonRequiredNullableStringList), Optional.ToList(nonRequiredNullableIntList), requiredReadonlyInt, Optional.ToNullable(nonRequiredReadonlyInt));
+            return new OutputModel(requiredString, requiredInt, requiredStringList, requiredIntList, nonRequiredString.Value, Optional.ToNullable(nonRequiredInt), Optional.ToList(nonRequiredStringList), Optional.ToList(nonRequiredIntList), requiredNullableString, requiredNullableInt, requiredNullableStringList, requiredNullableIntList, nonRequiredNullableString.Value, Optional.ToNullable(nonRequiredNullableInt), Optional.ToList(nonRequiredNullableStringList), Optional.ToList(nonRequiredNullableIntList), requiredReadonlyInt, Optional.ToNullable(nonRequiredReadonlyInt), vector, vectorReadOnly, vectorReadOnlyRequired, vectorRequired, Optional.ToNullable(vectorNullable), Optional.ToNullable(vectorReadOnlyNullable), vectorReadOnlyRequiredNullable, vectorRequiredNullable);
         }
     }
 }

--- a/test/TestProjects/ModelShapes/Generated/Models/OutputModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/OutputModel.cs
@@ -25,8 +25,12 @@ namespace ModelShapes.Models
         /// <param name="requiredNullableStringList"></param>
         /// <param name="requiredNullableIntList"></param>
         /// <param name="requiredReadonlyInt"></param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="requiredString"/>, <paramref name="requiredStringList"/> or <paramref name="requiredIntList"/> is null. </exception>
-        internal OutputModel(string requiredString, int requiredInt, IEnumerable<string> requiredStringList, IEnumerable<int> requiredIntList, string requiredNullableString, int? requiredNullableInt, IEnumerable<string> requiredNullableStringList, IEnumerable<int> requiredNullableIntList, int requiredReadonlyInt)
+        internal OutputModel(string requiredString, int requiredInt, IEnumerable<string> requiredStringList, IEnumerable<int> requiredIntList, string requiredNullableString, int? requiredNullableInt, IEnumerable<string> requiredNullableStringList, IEnumerable<int> requiredNullableIntList, int requiredReadonlyInt, ReadOnlyMemory<float> vectorReadOnlyRequired, ReadOnlyMemory<float> vectorRequired, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable, ReadOnlyMemory<float>? vectorRequiredNullable)
         {
             Argument.AssertNotNull(requiredString, nameof(requiredString));
             Argument.AssertNotNull(requiredStringList, nameof(requiredStringList));
@@ -45,6 +49,12 @@ namespace ModelShapes.Models
             NonRequiredNullableStringList = new ChangeTrackingList<string>();
             NonRequiredNullableIntList = new ChangeTrackingList<int>();
             RequiredReadonlyInt = requiredReadonlyInt;
+            Vector = ReadOnlyMemory<float>.Empty;
+            VectorReadOnly = ReadOnlyMemory<float>.Empty;
+            VectorReadOnlyRequired = vectorReadOnlyRequired;
+            VectorRequired = vectorRequired;
+            VectorReadOnlyRequiredNullable = vectorReadOnlyRequiredNullable;
+            VectorRequiredNullable = vectorRequiredNullable;
         }
 
         /// <summary> Initializes a new instance of OutputModel. </summary>
@@ -66,7 +76,15 @@ namespace ModelShapes.Models
         /// <param name="nonRequiredNullableIntList"></param>
         /// <param name="requiredReadonlyInt"></param>
         /// <param name="nonRequiredReadonlyInt"></param>
-        internal OutputModel(string requiredString, int requiredInt, IReadOnlyList<string> requiredStringList, IReadOnlyList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IReadOnlyList<string> nonRequiredStringList, IReadOnlyList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IReadOnlyList<string> requiredNullableStringList, IReadOnlyList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IReadOnlyList<string> nonRequiredNullableStringList, IReadOnlyList<int> nonRequiredNullableIntList, int requiredReadonlyInt, int? nonRequiredReadonlyInt)
+        /// <param name="vector"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnly"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
+        internal OutputModel(string requiredString, int requiredInt, IReadOnlyList<string> requiredStringList, IReadOnlyList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IReadOnlyList<string> nonRequiredStringList, IReadOnlyList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IReadOnlyList<string> requiredNullableStringList, IReadOnlyList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IReadOnlyList<string> nonRequiredNullableStringList, IReadOnlyList<int> nonRequiredNullableIntList, int requiredReadonlyInt, int? nonRequiredReadonlyInt, ReadOnlyMemory<float> vector, ReadOnlyMemory<float> vectorReadOnly, ReadOnlyMemory<float> vectorReadOnlyRequired, ReadOnlyMemory<float> vectorRequired, ReadOnlyMemory<float>? vectorNullable, ReadOnlyMemory<float>? vectorReadOnlyNullable, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable, ReadOnlyMemory<float>? vectorRequiredNullable)
         {
             RequiredString = requiredString;
             RequiredInt = requiredInt;
@@ -86,6 +104,14 @@ namespace ModelShapes.Models
             NonRequiredNullableIntList = nonRequiredNullableIntList;
             RequiredReadonlyInt = requiredReadonlyInt;
             NonRequiredReadonlyInt = nonRequiredReadonlyInt;
+            Vector = vector;
+            VectorReadOnly = vectorReadOnly;
+            VectorReadOnlyRequired = vectorReadOnlyRequired;
+            VectorRequired = vectorRequired;
+            VectorNullable = vectorNullable;
+            VectorReadOnlyNullable = vectorReadOnlyNullable;
+            VectorReadOnlyRequiredNullable = vectorReadOnlyRequiredNullable;
+            VectorRequiredNullable = vectorRequiredNullable;
         }
 
         /// <summary> Gets the required string. </summary>
@@ -124,5 +150,21 @@ namespace ModelShapes.Models
         public int RequiredReadonlyInt { get; }
         /// <summary> Gets the non required readonly int. </summary>
         public int? NonRequiredReadonlyInt { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> Vector { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorReadOnly { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorReadOnlyRequired { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float> VectorRequired { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorReadOnlyNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorReadOnlyRequiredNullable { get; }
+        /// <summary> The vector representation of a search query. </summary>
+        public ReadOnlyMemory<float>? VectorRequiredNullable { get; }
     }
 }

--- a/test/TestProjects/ModelShapes/ModelShapes.json
+++ b/test/TestProjects/ModelShapes/ModelShapes.json
@@ -183,7 +183,17 @@
         "NonRequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } },
 
         "RequiredReadonlyInt": { "type": "integer", "readOnly": true },
-        "NonRequiredReadonlyInt": { "type": "integer", "readOnly": true }
+        "NonRequiredReadonlyInt": { "type": "integer", "readOnly": true },
+
+        "vector": {
+            "x-ms-embedding-vector": true,
+            "type": "array",
+            "items": {
+                "type": "number",
+                "format": "float"
+            },
+            "description": "The vector representation of a search query."
+        }
       },
       "required": [
         "RequiredString",

--- a/test/TestProjects/ModelShapes/ModelShapes.json
+++ b/test/TestProjects/ModelShapes/ModelShapes.json
@@ -127,123 +127,497 @@
   "definitions": {
     "InputModel": {
       "type": "object",
-      "properties": {
-        "RequiredString": { "type": "string" },
-        "RequiredInt": { "type": "integer" },
-        "RequiredStringList": { "type": "array", "items": { "type": "string" } },
-        "RequiredIntList": { "type": "array", "items": { "type": "integer" } },
+        "properties": {
+            "RequiredString": { "type": "string" },
+            "RequiredInt": { "type": "integer" },
+            "RequiredStringList": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "RequiredIntList": {
+                "type": "array",
+                "items": { "type": "integer" }
+            },
 
-        "NonRequiredString": { "type": "string" },
-        "NonRequiredInt": { "type": "integer" },
-        "NonRequiredStringList": { "type": "array", "items": { "type": "string" } },
-        "NonRequiredIntList": { "type": "array", "items": { "type": "integer" } },
+            "NonRequiredString": { "type": "string" },
+            "NonRequiredInt": { "type": "integer" },
+            "NonRequiredStringList": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "NonRequiredIntList": {
+                "type": "array",
+                "items": { "type": "integer" }
+            },
 
-        "RequiredNullableString": { "type": "string", "x-nullable": true },
-        "RequiredNullableInt": { "type": "integer", "x-nullable": true },
-        "RequiredNullableStringList": { "type": "array", "x-nullable": true, "items": { "type": "string" } },
-        "RequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } },
+            "RequiredNullableString": {
+                "type": "string",
+                "x-nullable": true
+            },
+            "RequiredNullableInt": {
+                "type": "integer",
+                "x-nullable": true
+            },
+            "RequiredNullableStringList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "string" }
+            },
+            "RequiredNullableIntList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "integer" }
+            },
 
-        "NonRequiredNullableString": { "type": "string", "x-nullable": true },
-        "NonRequiredNullableInt": { "type": "integer", "x-nullable": true },
-        "NonRequiredNullableStringList": { "type": "array", "x-nullable": true, "items": { "type": "string" } },
-        "NonRequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } }
-      },
-      "required": [
-        "RequiredString",
-        "RequiredInt",
-        "RequiredStringList",
-        "RequiredIntList",
-        "RequiredNullableInt",
-        "RequiredNullableString",
-        "RequiredNullableStringList",
-        "RequiredNullableIntList"
-      ]
+            "NonRequiredNullableString": {
+                "type": "string",
+                "x-nullable": true
+            },
+            "NonRequiredNullableInt": {
+                "type": "integer",
+                "x-nullable": true
+            },
+            "NonRequiredNullableStringList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "string" }
+            },
+            "NonRequiredNullableIntList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "integer" }
+            },
+            "vector": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnly": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyRequired": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorRequired": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorNullable": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyNullable": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyRequiredNullable": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorRequiredNullable": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            }
+        },
+        "required": [
+            "RequiredString",
+            "RequiredInt",
+            "RequiredStringList",
+            "RequiredIntList",
+            "RequiredNullableInt",
+            "RequiredNullableString",
+            "RequiredNullableStringList",
+            "RequiredNullableIntList",
+            "vectorReadOnlyRequired",
+            "vectorRequired",
+            "vectorReadOnlyRequiredNullable",
+            "vectorRequiredNullable"
+        ]
     },
     "MixedModel": {
       "type": "object",
-      "properties": {
-        "RequiredString": { "type": "string" },
-        "RequiredInt": { "type": "integer" },
-        "RequiredStringList": { "type": "array", "items": { "type": "string" } },
-        "RequiredIntList": { "type": "array", "items": { "type": "integer" } },
-
-        "NonRequiredString": { "type": "string" },
-        "NonRequiredInt": { "type": "integer" },
-        "NonRequiredStringList": { "type": "array", "items": { "type": "string" } },
-        "NonRequiredIntList": { "type": "array", "items": { "type": "integer" } },
-
-        "RequiredNullableString": { "type": "string", "x-nullable": true },
-        "RequiredNullableInt": { "type": "integer", "x-nullable": true },
-        "RequiredNullableStringList": { "type": "array", "x-nullable": true, "items": { "type": "string" } },
-        "RequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } },
-
-        "NonRequiredNullableString": { "type": "string", "x-nullable": true },
-        "NonRequiredNullableInt": { "type": "integer", "x-nullable": true },
-        "NonRequiredNullableStringList": { "type": "array", "x-nullable": true, "items": { "type": "string" } },
-        "NonRequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } },
-
-        "RequiredReadonlyInt": { "type": "integer", "readOnly": true },
-        "NonRequiredReadonlyInt": { "type": "integer", "readOnly": true },
-
-        "vector": {
-            "x-ms-embedding-vector": true,
-            "type": "array",
-            "items": {
-                "type": "number",
-                "format": "float"
+        "properties": {
+            "RequiredString": { "type": "string" },
+            "RequiredInt": { "type": "integer" },
+            "RequiredStringList": {
+                "type": "array",
+                "items": { "type": "string" }
             },
-            "description": "The vector representation of a search query."
-        }
-      },
-      "required": [
-        "RequiredString",
-        "RequiredInt",
-        "RequiredStringList",
-        "RequiredIntList",
-        "RequiredNullableInt",
-        "RequiredNullableString",
-        "RequiredNullableStringList",
-        "RequiredNullableIntList",
-        "RequiredReadonlyInt"
-      ]
+            "RequiredIntList": {
+                "type": "array",
+                "items": { "type": "integer" }
+            },
+
+            "NonRequiredString": { "type": "string" },
+            "NonRequiredInt": { "type": "integer" },
+            "NonRequiredStringList": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "NonRequiredIntList": {
+                "type": "array",
+                "items": { "type": "integer" }
+            },
+
+            "RequiredNullableString": {
+                "type": "string",
+                "x-nullable": true
+            },
+            "RequiredNullableInt": {
+                "type": "integer",
+                "x-nullable": true
+            },
+            "RequiredNullableStringList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "string" }
+            },
+            "RequiredNullableIntList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "integer" }
+            },
+
+            "NonRequiredNullableString": {
+                "type": "string",
+                "x-nullable": true
+            },
+            "NonRequiredNullableInt": {
+                "type": "integer",
+                "x-nullable": true
+            },
+            "NonRequiredNullableStringList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "string" }
+            },
+            "NonRequiredNullableIntList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "integer" }
+            },
+
+            "RequiredReadonlyInt": {
+                "type": "integer",
+                "readOnly": true
+            },
+            "NonRequiredReadonlyInt": {
+                "type": "integer",
+                "readOnly": true
+            },
+            "vector": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnly": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyRequired": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorRequired": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorNullable": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyNullable": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyRequiredNullable": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorRequiredNullable": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            }
+        },
+        "required": [
+            "RequiredString",
+            "RequiredInt",
+            "RequiredStringList",
+            "RequiredIntList",
+            "RequiredNullableInt",
+            "RequiredNullableString",
+            "RequiredNullableStringList",
+            "RequiredNullableIntList",
+            "RequiredReadonlyInt",
+            "vectorReadOnlyRequired",
+            "vectorRequired",
+            "vectorReadOnlyRequiredNullable",
+            "vectorRequiredNullable"
+        ]
     },
     "OutputModel": {
       "type": "object",
-      "properties": {
-        "RequiredString": { "type": "string" },
-        "RequiredInt": { "type": "integer" },
-        "RequiredStringList": { "type": "array", "items": { "type": "string" } },
-        "RequiredIntList": { "type": "array", "items": { "type": "integer" } },
+        "properties": {
+            "RequiredString": { "type": "string" },
+            "RequiredInt": { "type": "integer" },
+            "RequiredStringList": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "RequiredIntList": {
+                "type": "array",
+                "items": { "type": "integer" }
+            },
 
-        "NonRequiredString": { "type": "string" },
-        "NonRequiredInt": { "type": "integer" },
-        "NonRequiredStringList": { "type": "array", "items": { "type": "string" } },
-        "NonRequiredIntList": { "type": "array", "items": { "type": "integer" } },
+            "NonRequiredString": { "type": "string" },
+            "NonRequiredInt": { "type": "integer" },
+            "NonRequiredStringList": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "NonRequiredIntList": {
+                "type": "array",
+                "items": { "type": "integer" }
+            },
 
-        "RequiredNullableString": { "type": "string", "x-nullable": true },
-        "RequiredNullableInt": { "type": "integer", "x-nullable": true },
-        "RequiredNullableStringList": { "type": "array", "x-nullable": true, "items": { "type": "string" } },
-        "RequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } },
+            "RequiredNullableString": {
+                "type": "string",
+                "x-nullable": true
+            },
+            "RequiredNullableInt": {
+                "type": "integer",
+                "x-nullable": true
+            },
+            "RequiredNullableStringList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "string" }
+            },
+            "RequiredNullableIntList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "integer" }
+            },
 
-        "NonRequiredNullableString": { "type": "string", "x-nullable": true },
-        "NonRequiredNullableInt": { "type": "integer", "x-nullable": true },
-        "NonRequiredNullableStringList": { "type": "array", "x-nullable": true, "items": { "type": "string" } },
-        "NonRequiredNullableIntList": { "type": "array", "x-nullable": true, "items": { "type": "integer" } },
+            "NonRequiredNullableString": {
+                "type": "string",
+                "x-nullable": true
+            },
+            "NonRequiredNullableInt": {
+                "type": "integer",
+                "x-nullable": true
+            },
+            "NonRequiredNullableStringList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "string" }
+            },
+            "NonRequiredNullableIntList": {
+                "type": "array",
+                "x-nullable": true,
+                "items": { "type": "integer" }
+            },
 
-        "RequiredReadonlyInt": { "type": "integer", "readOnly": true },
-        "NonRequiredReadonlyInt": { "type": "integer", "readOnly": true }
-      },
-      "required": [
-        "RequiredString",
-        "RequiredInt",
-        "RequiredStringList",
-        "RequiredIntList",
-        "RequiredNullableInt",
-        "RequiredNullableString",
-        "RequiredNullableStringList",
-        "RequiredNullableIntList",
-        "RequiredReadonlyInt"
-      ]
+            "RequiredReadonlyInt": {
+                "type": "integer",
+                "readOnly": true
+            },
+            "NonRequiredReadonlyInt": {
+                "type": "integer",
+                "readOnly": true
+            },
+            "vector": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnly": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyRequired": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorRequired": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorNullable": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyNullable": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorReadOnlyRequiredNullable": {
+                "x-ms-embedding-vector": true,
+                "readOnly": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            },
+            "vectorRequiredNullable": {
+                "x-ms-embedding-vector": true,
+                "type": "array",
+                "x-nullable": true,
+                "items": {
+                    "type": "number",
+                    "format": "float"
+                },
+                "description": "The vector representation of a search query."
+            }
+        },
+        "required": [
+            "RequiredString",
+            "RequiredInt",
+            "RequiredStringList",
+            "RequiredIntList",
+            "RequiredNullableInt",
+            "RequiredNullableString",
+            "RequiredNullableStringList",
+            "RequiredNullableIntList",
+            "RequiredReadonlyInt",
+            "vectorReadOnlyRequired",
+            "vectorRequired",
+            "vectorReadOnlyRequiredNullable",
+            "vectorRequiredNullable"
+        ]
     },
     "UnusedModel": {
       "type": "object",


### PR DESCRIPTION
# Description
Addresses this comment https://github.com/Azure/azure-sdk-for-net/pull/39305#discussion_r1374076919

Adds support for ReadOnlyMemory<T>

For swagger you can use `"x-ms-embedding-vectory": true`
For tsp you will need to customize the property type, but the generator should handle serialization / initialization for you.  https://github.com/Azure/typespec-azure/issues/3781

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first