### PR TITLE
update the version of azure.identity and azure.core

### DIFF
--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -29,7 +29,7 @@
     <PackageReference Update="System.Net.ClientModel" Version="1.0.0-beta.1" />
     <PackageReference Update="Azure.Core" Version="1.36.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.18" />
-    <PackageReference Update="Azure.ResourceManager" Version="1.8.1" />
+    <PackageReference Update="Azure.ResourceManager" Version="1.9.0" />
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0-beta.4" />
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.1" />

--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <PackageReference Update="Azure.Identity" Version="1.7.0" />
+    <PackageReference Update="Azure.Identity" Version="1.10.4" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="System.Net.ClientModel" Version="1.0.0-beta.1" />
-    <PackageReference Update="Azure.Core" Version="1.35.0" />
+    <PackageReference Update="Azure.Core" Version="1.36.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Update="Azure.ResourceManager" Version="1.8.1" />
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0-beta.4" />


### PR DESCRIPTION
# Description

after the VS gets updated to latest version, older version of Azure.Identity has been marked as vulnerable and it constantly gives warnings and errors about this.
This PR updates the version of Azure.Identity and Azure.Core to latest so that the warning goes away.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first