### PR TITLE
Fix #3876: Fix duplicates in the list of derived models or remove the list

### DIFF
--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputModelTypeConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputModelTypeConverter.cs
@@ -30,7 +30,6 @@ namespace AutoRest.CSharp.Common.Input
         {
             var isFirstProperty = id == null && name == null;
             var properties = new List<InputModelProperty>();
-            var derivedModels = new List<InputModelType>();
             bool isNullable = false;
             string? ns = null;
             string? accessibility = null;
@@ -53,8 +52,7 @@ namespace AutoRest.CSharp.Common.Input
                     || reader.TryReadString(nameof(InputModelType.Usage), ref usageString)
                     || reader.TryReadString(nameof(InputModelType.DiscriminatorPropertyName), ref discriminatorPropertyName)
                     || reader.TryReadString(nameof(InputModelType.DiscriminatorValue), ref discriminatorValue)
-                    || reader.TryReadWithConverter(nameof(InputModelType.BaseModel), options, ref baseModel)
-                    || reader.TryReadBoolean(nameof(InputModelType.IsNullable), ref isNullable);
+                    || reader.TryReadWithConverter(nameof(InputModelType.BaseModel), options, ref baseModel);
 
                 if (isKnownProperty)
                 {
@@ -63,14 +61,9 @@ namespace AutoRest.CSharp.Common.Input
 
                 if (reader.GetString() == nameof(InputModelType.Properties))
                 {
-                    model = CreateInputModelTypeInstance(id, name, ns, accessibility, deprecated, description, usageString, discriminatorValue, discriminatorPropertyName, baseModel, properties, derivedModels, isNullable, resolver);
+                    model = CreateInputModelTypeInstance(id, name, ns, accessibility, deprecated, description, usageString, discriminatorValue, discriminatorPropertyName, baseModel, properties, isNullable, resolver);
                     reader.Read();
                     CreateProperties(ref reader, properties, options);
-                }
-                else if (reader.GetString() == nameof(InputModelType.DerivedModels))
-                {
-                    reader.Read();
-                    CreateDerivedModels(ref reader, derivedModels, options);
                     if (reader.TokenType != JsonTokenType.EndObject)
                     {
                         throw new JsonException($"{nameof(InputModelType)}.{nameof(InputModelType.Properties)} must be the last defined property.");
@@ -82,51 +75,43 @@ namespace AutoRest.CSharp.Common.Input
                 }
             }
 
-            return model ?? CreateInputModelTypeInstance(id, name, ns, accessibility, deprecated, description, usageString, discriminatorValue, discriminatorPropertyName, baseModel, properties, derivedModels, isNullable, resolver);
+            return model ?? CreateInputModelTypeInstance(id, name, ns, accessibility, deprecated, description, usageString, discriminatorValue, discriminatorPropertyName, baseModel, properties, isNullable, resolver);
         }
 
-        private static InputModelType CreateInputModelTypeInstance(string? id, string? name, string? ns, string? accessibility, string? deprecated, string? description, string? usageString, string? discriminatorValue, string? discriminatorPropertyName, InputModelType? baseModel, List<InputModelProperty> properties, List<InputModelType> derivedModels, bool isNullable, ReferenceResolver resolver)
+        private static InputModelType CreateInputModelTypeInstance(string? id, string? name, string? ns, string? accessibility, string? deprecated, string? description, string? usageString, string? discriminatorValue, string? discriminatorPropertyValue, InputModelType? baseModel, IReadOnlyList<InputModelProperty> properties, bool isNullable, ReferenceResolver resolver)
         {
-            if (name == null)
-                throw new JsonException("Model must have name");
-
+            name = name ?? throw new JsonException("Model must have name");
             bool isAnonymousModel = false;
             if (name.StartsWith("Anon_", StringComparison.Ordinal))
             {
                 name = id ?? throw new JsonException("Model must have id"); // we just use id as the name of the model
                 isAnonymousModel = true;
             }
-
             InputModelTypeUsage usage = InputModelTypeUsage.None;
             if (usageString != null)
             {
-                Enum.TryParse<InputModelTypeUsage>(usageString, ignoreCase: true, out usage);
+                Enum.TryParse(usageString, ignoreCase: true, out usage);
             }
-            var model = new InputModelType(name, ns, accessibility, deprecated, description, usage, properties, baseModel, derivedModels, discriminatorValue, discriminatorPropertyName, isNullable)
+
+            var derivedModels = new List<InputModelType>();
+            var model = new InputModelType(name, ns, accessibility, deprecated, description, usage, properties, baseModel, derivedModels, discriminatorValue, discriminatorPropertyValue, IsNullable: isNullable)
             {
                 IsAnonymousModel = isAnonymousModel
             };
-            if (id != null)
+
+            if (id is not null)
             {
                 resolver.AddReference(id, model);
+                resolver.AddReference($"{model.Name}.{nameof(InputModelType.DerivedModels)}", derivedModels);
             }
+
+            if (baseModel is not null)
+            {
+                var baseModelDerived = (List<InputModelType>)resolver.ResolveReference($"{baseModel.Name}.{nameof(InputModelType.DerivedModels)}");
+                baseModelDerived.Add(model);
+            }
+
             return model;
-        }
-
-        private static void CreateDerivedModels(ref Utf8JsonReader reader, ICollection<InputModelType> derivedModels, JsonSerializerOptions options)
-        {
-            if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                throw new JsonException();
-            }
-            reader.Read();
-
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                var dm = reader.ReadWithConverter<InputModelType>(options);
-                derivedModels.Add(dm ?? throw new JsonException($"null {nameof(InputModelType)} is not allowed"));
-            }
-            reader.Read();
         }
 
         private static void CreateProperties(ref Utf8JsonReader reader, ICollection<InputModelProperty> properties, JsonSerializerOptions options)

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecReferenceHandler.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecReferenceHandler.cs
@@ -20,12 +20,7 @@ namespace AutoRest.CSharp.Common.Input
 
         private class TypeSpecReferenceResolver : ReferenceResolver
         {
-            private readonly Dictionary<string, object> _referenceIdToObjectMap;
-
-            public TypeSpecReferenceResolver()
-            {
-                _referenceIdToObjectMap = new Dictionary<string, object>();
-            }
+            private readonly Dictionary<string, object> _referenceIdToObjectMap = new();
 
             public override void AddReference(string referenceId, object value)
             {

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/model.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/model.ts
@@ -558,7 +558,7 @@ export function getInputType(
                 DiscriminatorValue: getDiscriminatorValue(m, baseModel),
                 BaseModel: baseModel,
                 Usage: Usage.None,
-                Properties: properties // DerivedModels should be the last assigned to model, if no derived models, properties should be the last
+                Properties: properties // Properties should be the last assigned to model
             } as InputModelType;
             setUsage(context, m, model);
 
@@ -571,23 +571,16 @@ export function getInputType(
             // Resolve properties after model is added to the map to resolve possible circular dependencies
             addModelProperties(model, m.properties, properties);
 
-            // add the derived models into the list
-            if (m.derivedModels !== undefined && m.derivedModels.length > 0) {
-                model.DerivedModels = [];
+            // Temporary part. Derived types may not be referenced directly by any operation
+            // We should be able to remove it when https://github.com/Azure/typespec-azure/issues/1733 is closed
+            if (model.DiscriminatorPropertyName && m.derivedModels) {
                 for (const dm of m.derivedModels) {
-                    // skip open generic type model which has un-instanced template parameter. e.g.
-                    // model GenericModel<T> { value: T }
-                    if (dm.isFinished) {
-                        const derivedModel = getInputType(
-                            context,
-                            getFormattedType(program, dm),
-                            models,
-                            enums
-                        );
-                        model.DerivedModels.push(
-                            derivedModel as InputModelType
-                        );
-                    }
+                    getInputType(
+                        context,
+                        getFormattedType(program, dm),
+                        models,
+                        enums
+                    );
                 }
             }
         }

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/model.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/model.ts
@@ -570,19 +570,6 @@ export function getInputType(
 
             // Resolve properties after model is added to the map to resolve possible circular dependencies
             addModelProperties(model, m.properties, properties);
-
-            // Temporary part. Derived types may not be referenced directly by any operation
-            // We should be able to remove it when https://github.com/Azure/typespec-azure/issues/1733 is closed
-            if (model.DiscriminatorPropertyName && m.derivedModels) {
-                for (const dm of m.derivedModels) {
-                    getInputType(
-                        context,
-                        getFormattedType(program, dm),
-                        models,
-                        enums
-                    );
-                }
-            }
         }
 
         return model;

--- a/src/TypeSpec.Extension/Emitter.Csharp/test/TestProjects/polymorphism/src/Generated/tspCodeModel.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/test/TestProjects/polymorphism/src/Generated/tspCodeModel.json
@@ -45,143 +45,127 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
+   ]
+  },
+  {
+   "$id": "7",
+   "Name": "Shark",
+   "Namespace": "PolymorphismOperation",
+   "Description": "The second level model in polymorphic multiple levels inheritance and it defines a new discriminator.",
+   "IsNullable": false,
+   "DiscriminatorPropertyName": "sharktype",
+   "DiscriminatorValue": "shark",
+   "BaseModel": {
+    "$ref": "2"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
     {
-     "$id": "7",
-     "Name": "Shark",
-     "Namespace": "PolymorphismOperation",
-     "Description": "The second level model in polymorphic multiple levels inheritance and it defines a new discriminator.",
+     "$id": "8",
+     "Name": "sharktype",
+     "SerializedName": "sharktype",
+     "Description": "Discriminator",
+     "IsRequired": true,
+     "IsReadOnly": false,
      "IsNullable": false,
-     "DiscriminatorPropertyName": "sharktype",
-     "DiscriminatorValue": "shark",
-     "BaseModel": {
-      "$ref": "2"
+     "Type": {
+      "$id": "9",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
      },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "8",
-       "Name": "sharktype",
-       "SerializedName": "sharktype",
-       "Description": "Discriminator",
-       "IsRequired": true,
-       "IsReadOnly": false,
-       "IsNullable": false,
-       "Type": {
-        "$id": "9",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "IsDiscriminator": true
-      }
-     ],
-     "DerivedModels": [
-      {
-       "$id": "10",
-       "Name": "SawShark",
-       "Namespace": "PolymorphismOperation",
-       "Description": "The third level model SawShark in polymorphic multiple levels inheritance.",
-       "IsNullable": false,
-       "DiscriminatorValue": "saw",
-       "BaseModel": {
-        "$ref": "7"
-       },
-       "Usage": "RoundTrip",
-       "Properties": []
-      },
-      {
-       "$id": "11",
-       "Name": "GoblinShark",
-       "Namespace": "PolymorphismOperation",
-       "Description": "The third level model GoblinShark in polymorphic multiple levels inheritance.",
-       "IsNullable": false,
-       "DiscriminatorValue": "goblin",
-       "BaseModel": {
-        "$ref": "7"
-       },
-       "Usage": "RoundTrip",
-       "Properties": []
-      }
-     ]
-    },
-    {
-     "$id": "12",
-     "Name": "Salmon",
-     "Namespace": "PolymorphismOperation",
-     "Description": "The second level model in polymorphic multiple levels inheritance which contains references to other polymorphic instances.",
-     "IsNullable": false,
-     "DiscriminatorValue": "salmon",
-     "BaseModel": {
-      "$ref": "2"
-     },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "13",
-       "Name": "friends",
-       "SerializedName": "friends",
-       "Description": "",
-       "Type": {
-        "$id": "14",
-        "Name": "Array",
-        "ElementType": {
-         "$ref": "2"
-        },
-        "IsNullable": false
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      },
-      {
-       "$id": "15",
-       "Name": "hate",
-       "SerializedName": "hate",
-       "Description": "",
-       "Type": {
-        "$id": "16",
-        "Name": "Dictionary",
-        "KeyType": {
-         "$id": "17",
-         "Name": "string",
-         "Kind": "String",
-         "IsNullable": false
-        },
-        "ValueType": {
-         "$ref": "2"
-        },
-        "IsNullable": false
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      },
-      {
-       "$id": "18",
-       "Name": "partner",
-       "SerializedName": "partner",
-       "Description": "",
-       "Type": {
-        "$ref": "2"
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      }
-     ]
+     "IsDiscriminator": true
     }
    ]
   },
   {
-   "$ref": "7"
+   "$id": "10",
+   "Name": "SawShark",
+   "Namespace": "PolymorphismOperation",
+   "Description": "The third level model SawShark in polymorphic multiple levels inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "saw",
+   "BaseModel": {
+    "$ref": "7"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   },
   {
-   "$ref": "10"
+   "$id": "11",
+   "Name": "GoblinShark",
+   "Namespace": "PolymorphismOperation",
+   "Description": "The third level model GoblinShark in polymorphic multiple levels inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "goblin",
+   "BaseModel": {
+    "$ref": "7"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   },
   {
-   "$ref": "11"
-  },
-  {
-   "$ref": "12"
+   "$id": "12",
+   "Name": "Salmon",
+   "Namespace": "PolymorphismOperation",
+   "Description": "The second level model in polymorphic multiple levels inheritance which contains references to other polymorphic instances.",
+   "IsNullable": false,
+   "DiscriminatorValue": "salmon",
+   "BaseModel": {
+    "$ref": "2"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "13",
+     "Name": "friends",
+     "SerializedName": "friends",
+     "Description": "",
+     "Type": {
+      "$id": "14",
+      "Name": "Array",
+      "ElementType": {
+       "$ref": "2"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "15",
+     "Name": "hate",
+     "SerializedName": "hate",
+     "Description": "",
+     "Type": {
+      "$id": "16",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "17",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "2"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "18",
+     "Name": "partner",
+     "SerializedName": "partner",
+     "Description": "",
+     "Type": {
+      "$ref": "2"
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
   }
  ],
  "Clients": [

--- a/src/TypeSpec.Extension/Emitter.Csharp/test/TestProjects/polymorphism/src/Generated/tspCodeModel.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/test/TestProjects/polymorphism/src/Generated/tspCodeModel.json
@@ -80,32 +80,6 @@
   },
   {
    "$id": "10",
-   "Name": "SawShark",
-   "Namespace": "PolymorphismOperation",
-   "Description": "The third level model SawShark in polymorphic multiple levels inheritance.",
-   "IsNullable": false,
-   "DiscriminatorValue": "saw",
-   "BaseModel": {
-    "$ref": "7"
-   },
-   "Usage": "RoundTrip",
-   "Properties": []
-  },
-  {
-   "$id": "11",
-   "Name": "GoblinShark",
-   "Namespace": "PolymorphismOperation",
-   "Description": "The third level model GoblinShark in polymorphic multiple levels inheritance.",
-   "IsNullable": false,
-   "DiscriminatorValue": "goblin",
-   "BaseModel": {
-    "$ref": "7"
-   },
-   "Usage": "RoundTrip",
-   "Properties": []
-  },
-  {
-   "$id": "12",
    "Name": "Salmon",
    "Namespace": "PolymorphismOperation",
    "Description": "The second level model in polymorphic multiple levels inheritance which contains references to other polymorphic instances.",
@@ -117,12 +91,12 @@
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "13",
+     "$id": "11",
      "Name": "friends",
      "SerializedName": "friends",
      "Description": "",
      "Type": {
-      "$id": "14",
+      "$id": "12",
       "Name": "Array",
       "ElementType": {
        "$ref": "2"
@@ -133,15 +107,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "15",
+     "$id": "13",
      "Name": "hate",
      "SerializedName": "hate",
      "Description": "",
      "Type": {
-      "$id": "16",
+      "$id": "14",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "17",
+       "$id": "15",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -155,7 +129,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "18",
+     "$id": "16",
      "Name": "partner",
      "SerializedName": "partner",
      "Description": "",
@@ -166,6 +140,32 @@
      "IsReadOnly": false
     }
    ]
+  },
+  {
+   "$id": "17",
+   "Name": "SawShark",
+   "Namespace": "PolymorphismOperation",
+   "Description": "The third level model SawShark in polymorphic multiple levels inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "saw",
+   "BaseModel": {
+    "$ref": "7"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
+  },
+  {
+   "$id": "18",
+   "Name": "GoblinShark",
+   "Namespace": "PolymorphismOperation",
+   "Description": "The third level model GoblinShark in polymorphic multiple levels inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "goblin",
+   "BaseModel": {
+    "$ref": "7"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   }
  ],
  "Clients": [

--- a/test/CadlRanchProjects/azure/client-generator-core/access/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/client-generator-core/access/src/Generated/tspCodeModel.json
@@ -180,59 +180,10 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "23",
-     "Name": "OuterModel",
-     "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
-     "Accessibility": "internal",
-     "Description": "Used in internal operations, should be generated but not exported.",
-     "IsNullable": false,
-     "BaseModel": {
-      "$ref": "20"
-     },
-     "Usage": "None",
-     "Properties": [
-      {
-       "$id": "24",
-       "Name": "inner",
-       "SerializedName": "inner",
-       "Description": "",
-       "Type": {
-        "$id": "25",
-        "Name": "InnerModel",
-        "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
-        "Accessibility": "internal",
-        "Description": "Used in internal operations, should be generated but not exported.",
-        "IsNullable": false,
-        "Usage": "Output",
-        "Properties": [
-         {
-          "$id": "26",
-          "Name": "name",
-          "SerializedName": "name",
-          "Description": "",
-          "Type": {
-           "$id": "27",
-           "Name": "string",
-           "Kind": "String",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         }
-        ]
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
-    }
    ]
   },
   {
-   "$id": "28",
+   "$id": "23",
    "Name": "OuterModel",
    "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
    "Accessibility": "internal",
@@ -244,12 +195,34 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "29",
+     "$id": "24",
      "Name": "inner",
      "SerializedName": "inner",
      "Description": "",
      "Type": {
-      "$ref": "25"
+      "$id": "25",
+      "Name": "InnerModel",
+      "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
+      "Accessibility": "internal",
+      "Description": "Used in internal operations, should be generated but not exported.",
+      "IsNullable": false,
+      "Usage": "Output",
+      "Properties": [
+       {
+        "$id": "26",
+        "Name": "name",
+        "SerializedName": "name",
+        "Description": "",
+        "Type": {
+         "$id": "27",
+         "Name": "string",
+         "Kind": "String",
+         "IsNullable": false
+        },
+        "IsRequired": true,
+        "IsReadOnly": false
+       }
+      ]
      },
      "IsRequired": true,
      "IsReadOnly": false
@@ -260,7 +233,7 @@
    "$ref": "25"
   },
   {
-   "$id": "30",
+   "$id": "28",
    "Name": "AbstractModel",
    "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
    "Accessibility": "internal",
@@ -270,7 +243,7 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "31",
+     "$id": "29",
      "Name": "kind",
      "SerializedName": "kind",
      "Description": "Discriminator",
@@ -278,7 +251,7 @@
      "IsReadOnly": false,
      "IsNullable": false,
      "Type": {
-      "$id": "32",
+      "$id": "30",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -286,12 +259,12 @@
      "IsDiscriminator": true
     },
     {
-     "$id": "33",
+     "$id": "31",
      "Name": "name",
      "SerializedName": "name",
      "Description": "",
      "Type": {
-      "$id": "34",
+      "$id": "32",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -299,57 +272,52 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "35",
-     "Name": "RealModel",
-     "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
-     "Accessibility": "internal",
-     "Description": "Used in internal operations, should be generated but not exported.",
-     "IsNullable": false,
-     "DiscriminatorValue": "real",
-     "BaseModel": {
-      "$ref": "30"
-     },
-     "Usage": "Output",
-     "Properties": []
-    }
    ]
   },
   {
-   "$ref": "35"
+   "$id": "33",
+   "Name": "RealModel",
+   "Namespace": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation",
+   "Accessibility": "internal",
+   "Description": "Used in internal operations, should be generated but not exported.",
+   "IsNullable": false,
+   "DiscriminatorValue": "real",
+   "BaseModel": {
+    "$ref": "28"
+   },
+   "Usage": "Output",
+   "Properties": []
   }
  ],
  "Clients": [
   {
-   "$id": "36",
+   "$id": "34",
    "Name": "AccessClient",
    "Description": "",
    "Operations": [],
    "Protocol": {
-    "$id": "37"
+    "$id": "35"
    },
    "Creatable": true
   },
   {
-   "$id": "38",
+   "$id": "36",
    "Name": "PublicOperation",
    "Description": "",
    "Operations": [
     {
-     "$id": "39",
+     "$id": "37",
      "Name": "noDecoratorInPublic",
      "ResourceName": "PublicOperation",
      "Accessibility": "public",
      "Parameters": [
       {
-       "$id": "40",
+       "$id": "38",
        "Name": "host",
        "NameInRequest": "host",
        "Description": "TestServer endpoint",
        "Type": {
-        "$id": "41",
+        "$id": "39",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -364,9 +332,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "42",
+        "$id": "40",
         "Type": {
-         "$id": "43",
+         "$id": "41",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -375,11 +343,11 @@
        }
       },
       {
-       "$id": "44",
+       "$id": "42",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "45",
+        "$id": "43",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -395,11 +363,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "46",
+       "$id": "44",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "47",
+        "$id": "45",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -414,20 +382,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "48",
+        "$id": "46",
         "Type": {
-         "$ref": "47"
+         "$ref": "45"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "49",
+       "$id": "47",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "50",
+        "$id": "48",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -442,9 +410,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "51",
+        "$id": "49",
         "Type": {
-         "$id": "52",
+         "$id": "50",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -455,7 +423,7 @@
      ],
      "Responses": [
       {
-       "$id": "53",
+       "$id": "51",
        "StatusCodes": [
         200
        ],
@@ -476,20 +444,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "54",
+     "$id": "52",
      "Name": "publicDecoratorInPublic",
      "ResourceName": "PublicOperation",
      "Accessibility": "public",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "55",
+       "$id": "53",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "56",
+        "$id": "54",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -505,11 +473,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "57",
+       "$id": "55",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "58",
+        "$id": "56",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -524,20 +492,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "59",
+        "$id": "57",
         "Type": {
-         "$ref": "58"
+         "$ref": "56"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "60",
+       "$id": "58",
        "StatusCodes": [
         200
        ],
@@ -559,31 +527,31 @@
     }
    ],
    "Protocol": {
-    "$id": "61"
+    "$id": "59"
    },
    "Creatable": false,
    "Parent": "AccessClient"
   },
   {
-   "$id": "62",
+   "$id": "60",
    "Name": "InternalOperation",
    "Description": "",
    "Operations": [
     {
-     "$id": "63",
+     "$id": "61",
      "Name": "noDecoratorInInternal",
      "ResourceName": "InternalOperation",
      "Accessibility": "internal",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "64",
+       "$id": "62",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "65",
+        "$id": "63",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -599,11 +567,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "66",
+       "$id": "64",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "67",
+        "$id": "65",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -618,20 +586,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "68",
+        "$id": "66",
         "Type": {
-         "$ref": "67"
+         "$ref": "65"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "69",
+       "$id": "67",
        "StatusCodes": [
         200
        ],
@@ -652,20 +620,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "70",
+     "$id": "68",
      "Name": "internalDecoratorInInternal",
      "ResourceName": "InternalOperation",
      "Accessibility": "internal",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "71",
+       "$id": "69",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "72",
+        "$id": "70",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -681,11 +649,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "73",
+       "$id": "71",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "74",
+        "$id": "72",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -700,20 +668,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "75",
+        "$id": "73",
         "Type": {
-         "$ref": "74"
+         "$ref": "72"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "76",
+       "$id": "74",
        "StatusCodes": [
         200
        ],
@@ -734,20 +702,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "77",
+     "$id": "75",
      "Name": "publicDecoratorInInternal",
      "ResourceName": "InternalOperation",
      "Accessibility": "internal",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "78",
+       "$id": "76",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "79",
+        "$id": "77",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -763,11 +731,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "80",
+       "$id": "78",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "81",
+        "$id": "79",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -782,20 +750,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "82",
+        "$id": "80",
         "Type": {
-         "$ref": "81"
+         "$ref": "79"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "83",
+       "$id": "81",
        "StatusCodes": [
         200
        ],
@@ -817,31 +785,31 @@
     }
    ],
    "Protocol": {
-    "$id": "84"
+    "$id": "82"
    },
    "Creatable": false,
    "Parent": "AccessClient"
   },
   {
-   "$id": "85",
+   "$id": "83",
    "Name": "SharedModelInOperation",
    "Description": "",
    "Operations": [
     {
-     "$id": "86",
+     "$id": "84",
      "Name": "public",
      "ResourceName": "SharedModelInOperation",
      "Accessibility": "public",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "87",
+       "$id": "85",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "88",
+        "$id": "86",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -857,11 +825,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "89",
+       "$id": "87",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "90",
+        "$id": "88",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -876,20 +844,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "91",
+        "$id": "89",
         "Type": {
-         "$ref": "90"
+         "$ref": "88"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "92",
+       "$id": "90",
        "StatusCodes": [
         200
        ],
@@ -910,20 +878,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "93",
+     "$id": "91",
      "Name": "internal",
      "ResourceName": "SharedModelInOperation",
      "Accessibility": "internal",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "94",
+       "$id": "92",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "95",
+        "$id": "93",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -939,11 +907,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "96",
+       "$id": "94",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "97",
+        "$id": "95",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -958,20 +926,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "98",
+        "$id": "96",
         "Type": {
-         "$ref": "97"
+         "$ref": "95"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "99",
+       "$id": "97",
        "StatusCodes": [
         200
        ],
@@ -993,32 +961,32 @@
     }
    ],
    "Protocol": {
-    "$id": "100"
+    "$id": "98"
    },
    "Creatable": false,
    "Parent": "AccessClient"
   },
   {
-   "$id": "101",
+   "$id": "99",
    "Name": "RelativeModelInOperation",
    "Description": "",
    "Operations": [
     {
-     "$id": "102",
+     "$id": "100",
      "Name": "operation",
      "ResourceName": "RelativeModelInOperation",
      "Description": "Expected query parameter: name=<any string>\nExpected response body:\n```json\n{\n  \"name\": <any string>,\n  \"inner\":\n  {\n    \"name\": <any string>\n  }\n}\n```",
      "Accessibility": "internal",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "103",
+       "$id": "101",
        "Name": "name",
        "NameInRequest": "name",
        "Type": {
-        "$id": "104",
+        "$id": "102",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -1034,11 +1002,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "105",
+       "$id": "103",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "106",
+        "$id": "104",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1053,25 +1021,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "107",
+        "$id": "105",
         "Type": {
-         "$ref": "106"
+         "$ref": "104"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "108",
+       "$id": "106",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "28"
+        "$ref": "23"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -1087,21 +1055,21 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "109",
+     "$id": "107",
      "Name": "discriminator",
      "ResourceName": "RelativeModelInOperation",
      "Description": "Expected query parameter: kind=<any string>\nExpected response body:\n```json\n{\n  \"name\": <any string>,\n  \"kind\": \"real\"\n}\n```",
      "Accessibility": "internal",
      "Parameters": [
       {
-       "$ref": "40"
+       "$ref": "38"
       },
       {
-       "$id": "110",
+       "$id": "108",
        "Name": "kind",
        "NameInRequest": "kind",
        "Type": {
-        "$id": "111",
+        "$id": "109",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
@@ -1117,11 +1085,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "112",
+       "$id": "110",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "113",
+        "$id": "111",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1136,25 +1104,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "114",
+        "$id": "112",
         "Type": {
-         "$ref": "113"
+         "$ref": "111"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "49"
+       "$ref": "47"
       }
      ],
      "Responses": [
       {
-       "$id": "115",
+       "$id": "113",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "30"
+        "$ref": "28"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -1171,7 +1139,7 @@
     }
    ],
    "Protocol": {
-    "$id": "116"
+    "$id": "114"
    },
    "Creatable": false,
    "Parent": "AccessClient"

--- a/test/CadlRanchProjects/type/model/inheritance/enum-discriminator/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/enum-discriminator/src/Generated/tspCodeModel.json
@@ -79,25 +79,20 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "10",
-     "Name": "Golden",
-     "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
-     "Description": "Golden dog model",
-     "IsNullable": false,
-     "DiscriminatorValue": "golden",
-     "BaseModel": {
-      "$ref": "6"
-     },
-     "Usage": "RoundTrip",
-     "Properties": []
-    }
    ]
   },
   {
-   "$ref": "10"
+   "$id": "10",
+   "Name": "Golden",
+   "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
+   "Description": "Golden dog model",
+   "IsNullable": false,
+   "DiscriminatorValue": "golden",
+   "BaseModel": {
+    "$ref": "6"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   },
   {
    "$id": "11",
@@ -134,25 +129,20 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "15",
-     "Name": "Cobra",
-     "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
-     "Description": "Cobra model",
-     "IsNullable": false,
-     "DiscriminatorValue": "cobra",
-     "BaseModel": {
-      "$ref": "11"
-     },
-     "Usage": "RoundTrip",
-     "Properties": []
-    }
    ]
   },
   {
-   "$ref": "15"
+   "$id": "15",
+   "Name": "Cobra",
+   "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
+   "Description": "Cobra model",
+   "IsNullable": false,
+   "DiscriminatorValue": "cobra",
+   "BaseModel": {
+    "$ref": "11"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   }
  ],
  "Clients": [

--- a/test/CadlRanchProjects/type/model/inheritance/enum-discriminator/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/enum-discriminator/src/Generated/tspCodeModel.json
@@ -83,6 +83,43 @@
   },
   {
    "$id": "10",
+   "Name": "Snake",
+   "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
+   "Description": "Test fixed enum type for discriminator",
+   "IsNullable": false,
+   "DiscriminatorPropertyName": "kind",
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "11",
+     "Name": "kind",
+     "SerializedName": "kind",
+     "Description": "discriminator property",
+     "Type": {
+      "$ref": "4"
+     },
+     "IsRequired": true,
+     "IsReadOnly": false,
+     "IsDiscriminator": true
+    },
+    {
+     "$id": "12",
+     "Name": "length",
+     "SerializedName": "length",
+     "Description": "Length of the snake",
+     "Type": {
+      "$id": "13",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "14",
    "Name": "Golden",
    "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
    "Description": "Golden dog model",
@@ -95,43 +132,6 @@
    "Properties": []
   },
   {
-   "$id": "11",
-   "Name": "Snake",
-   "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
-   "Description": "Test fixed enum type for discriminator",
-   "IsNullable": false,
-   "DiscriminatorPropertyName": "kind",
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "12",
-     "Name": "kind",
-     "SerializedName": "kind",
-     "Description": "discriminator property",
-     "Type": {
-      "$ref": "4"
-     },
-     "IsRequired": true,
-     "IsReadOnly": false,
-     "IsDiscriminator": true
-    },
-    {
-     "$id": "13",
-     "Name": "length",
-     "SerializedName": "length",
-     "Description": "Length of the snake",
-     "Type": {
-      "$id": "14",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
    "$id": "15",
    "Name": "Cobra",
    "Namespace": "Type.Model.Inheritance.EnumDiscriminator",
@@ -139,7 +139,7 @@
    "IsNullable": false,
    "DiscriminatorValue": "cobra",
    "BaseModel": {
-    "$ref": "11"
+    "$ref": "10"
    },
    "Usage": "RoundTrip",
    "Properties": []
@@ -547,7 +547,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "11"
+        "$ref": "10"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -577,7 +577,7 @@
        "NameInRequest": "input",
        "Description": "Snake to create",
        "Type": {
-        "$ref": "11"
+        "$ref": "10"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -716,7 +716,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "11"
+        "$ref": "10"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -778,7 +778,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "11"
+        "$ref": "10"
        },
        "BodyMediaType": "Json",
        "Headers": [],

--- a/test/CadlRanchProjects/type/model/inheritance/not-discriminated/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/not-discriminated/src/Generated/tspCodeModel.json
@@ -29,68 +29,10 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "5",
-     "Name": "Cat",
-     "Namespace": "Type.Model.Inheritance.NotDiscriminated",
-     "Description": "The second level model in the normal multiple levels inheritance.",
-     "IsNullable": false,
-     "BaseModel": {
-      "$ref": "2"
-     },
-     "Usage": "None",
-     "Properties": [
-      {
-       "$id": "6",
-       "Name": "age",
-       "SerializedName": "age",
-       "Description": "",
-       "Type": {
-        "$id": "7",
-        "Name": "int32",
-        "Kind": "Int32",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ],
-     "DerivedModels": [
-      {
-       "$id": "8",
-       "Name": "Siamese",
-       "Namespace": "Type.Model.Inheritance.NotDiscriminated",
-       "Description": "The third level model in the normal multiple levels inheritance.",
-       "IsNullable": false,
-       "BaseModel": {
-        "$ref": "5"
-       },
-       "Usage": "None",
-       "Properties": [
-        {
-         "$id": "9",
-         "Name": "smart",
-         "SerializedName": "smart",
-         "Description": "",
-         "Type": {
-          "$id": "10",
-          "Name": "boolean",
-          "Kind": "Boolean",
-          "IsNullable": false
-         },
-         "IsRequired": true,
-         "IsReadOnly": false
-        }
-       ]
-      }
-     ]
-    }
    ]
   },
   {
-   "$id": "11",
+   "$id": "5",
    "Name": "Cat",
    "Namespace": "Type.Model.Inheritance.NotDiscriminated",
    "Description": "The second level model in the normal multiple levels inheritance.",
@@ -101,12 +43,12 @@
    "Usage": "None",
    "Properties": [
     {
-     "$id": "12",
+     "$id": "6",
      "Name": "age",
      "SerializedName": "age",
      "Description": "",
      "Type": {
-      "$id": "13",
+      "$id": "7",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -114,31 +56,26 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$ref": "8"
-    }
    ]
   },
   {
-   "$id": "14",
+   "$id": "8",
    "Name": "Siamese",
    "Namespace": "Type.Model.Inheritance.NotDiscriminated",
    "Description": "The third level model in the normal multiple levels inheritance.",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "11"
+    "$ref": "5"
    },
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "15",
+     "$id": "9",
      "Name": "smart",
      "SerializedName": "smart",
      "Description": "",
      "Type": {
-      "$id": "16",
+      "$id": "10",
       "Name": "boolean",
       "Kind": "Boolean",
       "IsNullable": false
@@ -151,22 +88,22 @@
  ],
  "Clients": [
   {
-   "$id": "17",
+   "$id": "11",
    "Name": "NotDiscriminatedClient",
    "Description": "Illustrates not-discriminated inheritance model.",
    "Operations": [
     {
-     "$id": "18",
+     "$id": "12",
      "Name": "postValid",
      "ResourceName": "NotDiscriminated",
      "Parameters": [
       {
-       "$id": "19",
+       "$id": "13",
        "Name": "host",
        "NameInRequest": "host",
        "Description": "TestServer endpoint",
        "Type": {
-        "$id": "20",
+        "$id": "14",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -181,9 +118,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "21",
+        "$id": "15",
         "Type": {
-         "$id": "22",
+         "$id": "16",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -192,11 +129,11 @@
        }
       },
       {
-       "$id": "23",
+       "$id": "17",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "14"
+        "$ref": "8"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -209,11 +146,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "24",
+       "$id": "18",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "25",
+        "$id": "19",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -228,19 +165,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "26",
+        "$id": "20",
         "Type": {
-         "$ref": "25"
+         "$ref": "19"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "27",
+       "$id": "21",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "28",
+        "$id": "22",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -255,20 +192,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "29",
+        "$id": "23",
         "Type": {
-         "$ref": "28"
+         "$ref": "22"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "30",
+       "$id": "24",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "31",
+        "$id": "25",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -283,9 +220,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "32",
+        "$id": "26",
         "Type": {
-         "$id": "33",
+         "$id": "27",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -296,7 +233,7 @@
      ],
      "Responses": [
       {
-       "$id": "34",
+       "$id": "28",
        "StatusCodes": [
         204
        ],
@@ -317,19 +254,19 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "35",
+     "$id": "29",
      "Name": "getValid",
      "ResourceName": "NotDiscriminated",
      "Parameters": [
       {
-       "$ref": "19"
+       "$ref": "13"
       },
       {
-       "$id": "36",
+       "$id": "30",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "37",
+        "$id": "31",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -344,25 +281,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "38",
+        "$id": "32",
         "Type": {
-         "$ref": "37"
+         "$ref": "31"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "30"
+       "$ref": "24"
       }
      ],
      "Responses": [
       {
-       "$id": "39",
+       "$id": "33",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "14"
+        "$ref": "8"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -378,19 +315,19 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "40",
+     "$id": "34",
      "Name": "putValid",
      "ResourceName": "NotDiscriminated",
      "Parameters": [
       {
-       "$ref": "19"
+       "$ref": "13"
       },
       {
-       "$id": "41",
+       "$id": "35",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "14"
+        "$ref": "8"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -403,11 +340,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "42",
+       "$id": "36",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "43",
+        "$id": "37",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -422,19 +359,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "44",
+        "$id": "38",
         "Type": {
-         "$ref": "43"
+         "$ref": "37"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "45",
+       "$id": "39",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "46",
+        "$id": "40",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -449,25 +386,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "47",
+        "$id": "41",
         "Type": {
-         "$ref": "46"
+         "$ref": "40"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "30"
+       "$ref": "24"
       }
      ],
      "Responses": [
       {
-       "$id": "48",
+       "$id": "42",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "14"
+        "$ref": "8"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -487,7 +424,7 @@
     }
    ],
    "Protocol": {
-    "$id": "49"
+    "$id": "43"
    },
    "Creatable": true
   }

--- a/test/CadlRanchProjects/type/model/inheritance/single-discriminator/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/single-discriminator/src/Generated/tspCodeModel.json
@@ -49,6 +49,47 @@
   },
   {
    "$id": "7",
+   "Name": "Dinosaur",
+   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
+   "Description": "Define a base class in the legacy way. Discriminator property is not explicitly defined in the model.",
+   "IsNullable": false,
+   "DiscriminatorPropertyName": "kind",
+   "Usage": "Output",
+   "Properties": [
+    {
+     "$id": "8",
+     "Name": "kind",
+     "SerializedName": "kind",
+     "Description": "Discriminator",
+     "IsRequired": true,
+     "IsReadOnly": false,
+     "IsNullable": false,
+     "Type": {
+      "$id": "9",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsDiscriminator": true
+    },
+    {
+     "$id": "10",
+     "Name": "size",
+     "SerializedName": "size",
+     "Description": "",
+     "Type": {
+      "$id": "11",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "12",
    "Name": "SeaGull",
    "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
    "Description": "The second level model in polymorphic single level inheritance.",
@@ -61,7 +102,7 @@
    "Properties": []
   },
   {
-   "$id": "8",
+   "$id": "13",
    "Name": "Sparrow",
    "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
    "Description": "The second level model in polymorphic single level inheritance.",
@@ -74,7 +115,7 @@
    "Properties": []
   },
   {
-   "$id": "9",
+   "$id": "14",
    "Name": "Goose",
    "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
    "Description": "The second level model in polymorphic single level inheritance.",
@@ -87,7 +128,7 @@
    "Properties": []
   },
   {
-   "$id": "10",
+   "$id": "15",
    "Name": "Eagle",
    "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
    "Description": "The second level model in polymorphic single levels inheritance which contains references to other polymorphic instances.",
@@ -99,12 +140,12 @@
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "11",
+     "$id": "16",
      "Name": "friends",
      "SerializedName": "friends",
      "Description": "",
      "Type": {
-      "$id": "12",
+      "$id": "17",
       "Name": "Array",
       "ElementType": {
        "$ref": "2"
@@ -115,15 +156,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "13",
+     "$id": "18",
      "Name": "hate",
      "SerializedName": "hate",
      "Description": "",
      "Type": {
-      "$id": "14",
+      "$id": "19",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "15",
+       "$id": "20",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -137,7 +178,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "16",
+     "$id": "21",
      "Name": "partner",
      "SerializedName": "partner",
      "Description": "",
@@ -150,47 +191,6 @@
    ]
   },
   {
-   "$id": "17",
-   "Name": "Dinosaur",
-   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
-   "Description": "Define a base class in the legacy way. Discriminator property is not explicitly defined in the model.",
-   "IsNullable": false,
-   "DiscriminatorPropertyName": "kind",
-   "Usage": "Output",
-   "Properties": [
-    {
-     "$id": "18",
-     "Name": "kind",
-     "SerializedName": "kind",
-     "Description": "Discriminator",
-     "IsRequired": true,
-     "IsReadOnly": false,
-     "IsNullable": false,
-     "Type": {
-      "$id": "19",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsDiscriminator": true
-    },
-    {
-     "$id": "20",
-     "Name": "size",
-     "SerializedName": "size",
-     "Description": "",
-     "Type": {
-      "$id": "21",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
    "$id": "22",
    "Name": "TRex",
    "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
@@ -198,7 +198,7 @@
    "IsNullable": false,
    "DiscriminatorValue": "t-rex",
    "BaseModel": {
-    "$ref": "17"
+    "$ref": "7"
    },
    "Usage": "Output",
    "Properties": []
@@ -766,7 +766,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "17"
+        "$ref": "7"
        },
        "BodyMediaType": "Json",
        "Headers": [],

--- a/test/CadlRanchProjects/type/model/inheritance/single-discriminator/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/single-discriminator/src/Generated/tspCodeModel.json
@@ -45,123 +45,109 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "7",
-     "Name": "SeaGull",
-     "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
-     "Description": "The second level model in polymorphic single level inheritance.",
-     "IsNullable": false,
-     "DiscriminatorValue": "seagull",
-     "BaseModel": {
-      "$ref": "2"
-     },
-     "Usage": "RoundTrip",
-     "Properties": []
-    },
-    {
-     "$id": "8",
-     "Name": "Sparrow",
-     "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
-     "Description": "The second level model in polymorphic single level inheritance.",
-     "IsNullable": false,
-     "DiscriminatorValue": "sparrow",
-     "BaseModel": {
-      "$ref": "2"
-     },
-     "Usage": "RoundTrip",
-     "Properties": []
-    },
-    {
-     "$id": "9",
-     "Name": "Goose",
-     "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
-     "Description": "The second level model in polymorphic single level inheritance.",
-     "IsNullable": false,
-     "DiscriminatorValue": "goose",
-     "BaseModel": {
-      "$ref": "2"
-     },
-     "Usage": "RoundTrip",
-     "Properties": []
-    },
-    {
-     "$id": "10",
-     "Name": "Eagle",
-     "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
-     "Description": "The second level model in polymorphic single levels inheritance which contains references to other polymorphic instances.",
-     "IsNullable": false,
-     "DiscriminatorValue": "eagle",
-     "BaseModel": {
-      "$ref": "2"
-     },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "11",
-       "Name": "friends",
-       "SerializedName": "friends",
-       "Description": "",
-       "Type": {
-        "$id": "12",
-        "Name": "Array",
-        "ElementType": {
-         "$ref": "2"
-        },
-        "IsNullable": false
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      },
-      {
-       "$id": "13",
-       "Name": "hate",
-       "SerializedName": "hate",
-       "Description": "",
-       "Type": {
-        "$id": "14",
-        "Name": "Dictionary",
-        "KeyType": {
-         "$id": "15",
-         "Name": "string",
-         "Kind": "String",
-         "IsNullable": false
-        },
-        "ValueType": {
-         "$ref": "2"
-        },
-        "IsNullable": false
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      },
-      {
-       "$id": "16",
-       "Name": "partner",
-       "SerializedName": "partner",
-       "Description": "",
-       "Type": {
-        "$ref": "2"
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      }
-     ]
-    }
    ]
   },
   {
-   "$ref": "7"
+   "$id": "7",
+   "Name": "SeaGull",
+   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
+   "Description": "The second level model in polymorphic single level inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "seagull",
+   "BaseModel": {
+    "$ref": "2"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   },
   {
-   "$ref": "8"
+   "$id": "8",
+   "Name": "Sparrow",
+   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
+   "Description": "The second level model in polymorphic single level inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "sparrow",
+   "BaseModel": {
+    "$ref": "2"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   },
   {
-   "$ref": "9"
+   "$id": "9",
+   "Name": "Goose",
+   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
+   "Description": "The second level model in polymorphic single level inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "goose",
+   "BaseModel": {
+    "$ref": "2"
+   },
+   "Usage": "RoundTrip",
+   "Properties": []
   },
   {
-   "$ref": "10"
+   "$id": "10",
+   "Name": "Eagle",
+   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
+   "Description": "The second level model in polymorphic single levels inheritance which contains references to other polymorphic instances.",
+   "IsNullable": false,
+   "DiscriminatorValue": "eagle",
+   "BaseModel": {
+    "$ref": "2"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "11",
+     "Name": "friends",
+     "SerializedName": "friends",
+     "Description": "",
+     "Type": {
+      "$id": "12",
+      "Name": "Array",
+      "ElementType": {
+       "$ref": "2"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "13",
+     "Name": "hate",
+     "SerializedName": "hate",
+     "Description": "",
+     "Type": {
+      "$id": "14",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "15",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "2"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "16",
+     "Name": "partner",
+     "SerializedName": "partner",
+     "Description": "",
+     "Type": {
+      "$ref": "2"
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
    "$id": "17",
@@ -202,25 +188,20 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "22",
-     "Name": "TRex",
-     "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
-     "Description": "The second level legacy model in polymorphic single level inheritance.",
-     "IsNullable": false,
-     "DiscriminatorValue": "t-rex",
-     "BaseModel": {
-      "$ref": "17"
-     },
-     "Usage": "Output",
-     "Properties": []
-    }
    ]
   },
   {
-   "$ref": "22"
+   "$id": "22",
+   "Name": "TRex",
+   "Namespace": "Type.Model.Inheritance.SingleDiscriminator",
+   "Description": "The second level legacy model in polymorphic single level inheritance.",
+   "IsNullable": false,
+   "DiscriminatorValue": "t-rex",
+   "BaseModel": {
+    "$ref": "17"
+   },
+   "Usage": "Output",
+   "Properties": []
   }
  ],
  "Clients": [

--- a/test/TestProjects/ConfidentLevels-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/ConfidentLevels-TypeSpec/src/Generated/tspCodeModel.json
@@ -479,6 +479,245 @@
   },
   {
    "$id": "63",
+   "Name": "PollutedPet",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The base Pet model polluted by union in derived type",
+   "IsNullable": false,
+   "DiscriminatorPropertyName": "kind",
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "64",
+     "Name": "kind",
+     "SerializedName": "kind",
+     "Description": "Discriminator",
+     "IsRequired": true,
+     "IsReadOnly": false,
+     "IsNullable": false,
+     "Type": {
+      "$id": "65",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsDiscriminator": true
+    },
+    {
+     "$id": "66",
+     "Name": "name",
+     "SerializedName": "name",
+     "Description": "The name of the pet",
+     "Type": {
+      "$id": "67",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "68",
+   "Name": "PollutedDog",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The dog with a union type",
+   "IsNullable": false,
+   "DiscriminatorValue": "dog",
+   "BaseModel": {
+    "$ref": "63"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "69",
+     "Name": "woof",
+     "SerializedName": "woof",
+     "Description": "Woof",
+     "Type": {
+      "$id": "70",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "71",
+     "Name": "color",
+     "SerializedName": "color",
+     "Description": "Color, could be specified by a string or by an array of int as RGB",
+     "Type": {
+      "$id": "72",
+      "Name": "Union",
+      "UnionItemTypes": [
+       {
+        "$id": "73",
+        "Name": "string",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       {
+        "$id": "74",
+        "Name": "Array",
+        "ElementType": {
+         "$id": "75",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsNullable": false
+       }
+      ],
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "76",
+   "Name": "UnpollutedCat",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The cat without a union type",
+   "IsNullable": false,
+   "DiscriminatorValue": "cat",
+   "BaseModel": {
+    "$ref": "63"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "77",
+     "Name": "meow",
+     "SerializedName": "meow",
+     "Description": "Meow",
+     "Type": {
+      "$id": "78",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "79",
+   "Name": "BaseModel",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The base model",
+   "IsNullable": false,
+   "Usage": "None",
+   "Properties": [
+    {
+     "$id": "80",
+     "Name": "name",
+     "SerializedName": "name",
+     "Description": "The name",
+     "Type": {
+      "$id": "81",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "82",
+     "Name": "size",
+     "SerializedName": "size",
+     "Description": "The size",
+     "Type": {
+      "$id": "83",
+      "Name": "float64",
+      "Kind": "Float64",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "84",
+   "Name": "DerivedModel",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The derived model",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "79"
+   },
+   "Usage": "Input",
+   "Properties": [
+    {
+     "$id": "85",
+     "Name": "age",
+     "SerializedName": "age",
+     "Description": "The age",
+     "Type": {
+      "$id": "86",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "87",
+   "Name": "DerivedModelWithUnion",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "This is a derived model with unions",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "79"
+   },
+   "Usage": "Input",
+   "Properties": [
+    {
+     "$id": "88",
+     "Name": "unionProperty",
+     "SerializedName": "unionProperty",
+     "Description": "The union property",
+     "Type": {
+      "$id": "89",
+      "Name": "Union",
+      "UnionItemTypes": [
+       {
+        "$id": "90",
+        "Name": "string",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       {
+        "$id": "91",
+        "Name": "Array",
+        "ElementType": {
+         "$id": "92",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsNullable": false
+       }
+      ],
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "93",
    "Name": "Cat",
    "Namespace": "ConfidentLevelsInTsp",
    "Description": "The cat",
@@ -490,12 +729,12 @@
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "64",
+     "$id": "94",
      "Name": "meow",
      "SerializedName": "meow",
      "Description": "Meow",
      "Type": {
-      "$id": "65",
+      "$id": "95",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -506,7 +745,7 @@
    ]
   },
   {
-   "$id": "66",
+   "$id": "96",
    "Name": "Dog",
    "Namespace": "ConfidentLevelsInTsp",
    "Description": "The dog",
@@ -518,253 +757,14 @@
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "67",
+     "$id": "97",
      "Name": "woof",
      "SerializedName": "woof",
      "Description": "Woof",
      "Type": {
-      "$id": "68",
+      "$id": "98",
       "Name": "string",
       "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "69",
-   "Name": "PollutedPet",
-   "Namespace": "ConfidentLevelsInTsp",
-   "Description": "The base Pet model polluted by union in derived type",
-   "IsNullable": false,
-   "DiscriminatorPropertyName": "kind",
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "70",
-     "Name": "kind",
-     "SerializedName": "kind",
-     "Description": "Discriminator",
-     "IsRequired": true,
-     "IsReadOnly": false,
-     "IsNullable": false,
-     "Type": {
-      "$id": "71",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsDiscriminator": true
-    },
-    {
-     "$id": "72",
-     "Name": "name",
-     "SerializedName": "name",
-     "Description": "The name of the pet",
-     "Type": {
-      "$id": "73",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "74",
-   "Name": "PollutedDog",
-   "Namespace": "ConfidentLevelsInTsp",
-   "Description": "The dog with a union type",
-   "IsNullable": false,
-   "DiscriminatorValue": "dog",
-   "BaseModel": {
-    "$ref": "69"
-   },
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "75",
-     "Name": "woof",
-     "SerializedName": "woof",
-     "Description": "Woof",
-     "Type": {
-      "$id": "76",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "77",
-     "Name": "color",
-     "SerializedName": "color",
-     "Description": "Color, could be specified by a string or by an array of int as RGB",
-     "Type": {
-      "$id": "78",
-      "Name": "Union",
-      "UnionItemTypes": [
-       {
-        "$id": "79",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       {
-        "$id": "80",
-        "Name": "Array",
-        "ElementType": {
-         "$id": "81",
-         "Name": "int32",
-         "Kind": "Int32",
-         "IsNullable": false
-        },
-        "IsNullable": false
-       }
-      ],
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "82",
-   "Name": "UnpollutedCat",
-   "Namespace": "ConfidentLevelsInTsp",
-   "Description": "The cat without a union type",
-   "IsNullable": false,
-   "DiscriminatorValue": "cat",
-   "BaseModel": {
-    "$ref": "69"
-   },
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "83",
-     "Name": "meow",
-     "SerializedName": "meow",
-     "Description": "Meow",
-     "Type": {
-      "$id": "84",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "85",
-   "Name": "BaseModel",
-   "Namespace": "ConfidentLevelsInTsp",
-   "Description": "The base model",
-   "IsNullable": false,
-   "Usage": "None",
-   "Properties": [
-    {
-     "$id": "86",
-     "Name": "name",
-     "SerializedName": "name",
-     "Description": "The name",
-     "Type": {
-      "$id": "87",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "88",
-     "Name": "size",
-     "SerializedName": "size",
-     "Description": "The size",
-     "Type": {
-      "$id": "89",
-      "Name": "float64",
-      "Kind": "Float64",
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "90",
-   "Name": "DerivedModel",
-   "Namespace": "ConfidentLevelsInTsp",
-   "Description": "The derived model",
-   "IsNullable": false,
-   "BaseModel": {
-    "$ref": "85"
-   },
-   "Usage": "Input",
-   "Properties": [
-    {
-     "$id": "91",
-     "Name": "age",
-     "SerializedName": "age",
-     "Description": "The age",
-     "Type": {
-      "$id": "92",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "93",
-   "Name": "DerivedModelWithUnion",
-   "Namespace": "ConfidentLevelsInTsp",
-   "Description": "This is a derived model with unions",
-   "IsNullable": false,
-   "BaseModel": {
-    "$ref": "85"
-   },
-   "Usage": "Input",
-   "Properties": [
-    {
-     "$id": "94",
-     "Name": "unionProperty",
-     "SerializedName": "unionProperty",
-     "Description": "The union property",
-     "Type": {
-      "$id": "95",
-      "Name": "Union",
-      "UnionItemTypes": [
-       {
-        "$id": "96",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       {
-        "$id": "97",
-        "Name": "Array",
-        "ElementType": {
-         "$id": "98",
-         "Name": "int32",
-         "Kind": "Int32",
-         "IsNullable": false
-        },
-        "IsNullable": false
-       }
-      ],
       "IsNullable": false
      },
      "IsRequired": true,
@@ -1586,7 +1586,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "69"
+        "$ref": "63"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -1663,7 +1663,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "69"
+        "$ref": "63"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -1695,7 +1695,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "74"
+        "$ref": "68"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -1772,7 +1772,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "74"
+        "$ref": "68"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -1804,7 +1804,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "82"
+        "$ref": "76"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -1881,7 +1881,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "82"
+        "$ref": "76"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -1913,7 +1913,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "90"
+        "$ref": "84"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -2019,7 +2019,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "93"
+        "$ref": "87"
        },
        "Location": "Body",
        "IsRequired": true,

--- a/test/TestProjects/ConfidentLevels-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/ConfidentLevels-TypeSpec/src/Generated/tspCodeModel.json
@@ -475,71 +475,63 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
+   ]
+  },
+  {
+   "$id": "63",
+   "Name": "Cat",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The cat",
+   "IsNullable": false,
+   "DiscriminatorValue": "cat",
+   "BaseModel": {
+    "$ref": "58"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
     {
-     "$id": "63",
-     "Name": "Cat",
-     "Namespace": "ConfidentLevelsInTsp",
-     "Description": "The cat",
-     "IsNullable": false,
-     "DiscriminatorValue": "cat",
-     "BaseModel": {
-      "$ref": "58"
+     "$id": "64",
+     "Name": "meow",
+     "SerializedName": "meow",
+     "Description": "Meow",
+     "Type": {
+      "$id": "65",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
      },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "64",
-       "Name": "meow",
-       "SerializedName": "meow",
-       "Description": "Meow",
-       "Type": {
-        "$id": "65",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
-    },
-    {
-     "$id": "66",
-     "Name": "Dog",
-     "Namespace": "ConfidentLevelsInTsp",
-     "Description": "The dog",
-     "IsNullable": false,
-     "DiscriminatorValue": "dog",
-     "BaseModel": {
-      "$ref": "58"
-     },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "67",
-       "Name": "woof",
-       "SerializedName": "woof",
-       "Description": "Woof",
-       "Type": {
-        "$id": "68",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
+     "IsRequired": true,
+     "IsReadOnly": false
     }
    ]
   },
   {
-   "$ref": "63"
-  },
-  {
-   "$ref": "66"
+   "$id": "66",
+   "Name": "Dog",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The dog",
+   "IsNullable": false,
+   "DiscriminatorValue": "dog",
+   "BaseModel": {
+    "$ref": "58"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "67",
+     "Name": "woof",
+     "SerializedName": "woof",
+     "Description": "Woof",
+     "Type": {
+      "$id": "68",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
    "$id": "69",
@@ -580,103 +572,95 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
+   ]
+  },
+  {
+   "$id": "74",
+   "Name": "PollutedDog",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The dog with a union type",
+   "IsNullable": false,
+   "DiscriminatorValue": "dog",
+   "BaseModel": {
+    "$ref": "69"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
     {
-     "$id": "74",
-     "Name": "PollutedDog",
-     "Namespace": "ConfidentLevelsInTsp",
-     "Description": "The dog with a union type",
-     "IsNullable": false,
-     "DiscriminatorValue": "dog",
-     "BaseModel": {
-      "$ref": "69"
+     "$id": "75",
+     "Name": "woof",
+     "SerializedName": "woof",
+     "Description": "Woof",
+     "Type": {
+      "$id": "76",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
      },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "75",
-       "Name": "woof",
-       "SerializedName": "woof",
-       "Description": "Woof",
-       "Type": {
-        "$id": "76",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      },
-      {
-       "$id": "77",
-       "Name": "color",
-       "SerializedName": "color",
-       "Description": "Color, could be specified by a string or by an array of int as RGB",
-       "Type": {
-        "$id": "78",
-        "Name": "Union",
-        "UnionItemTypes": [
-         {
-          "$id": "79",
-          "Name": "string",
-          "Kind": "String",
-          "IsNullable": false
-         },
-         {
-          "$id": "80",
-          "Name": "Array",
-          "ElementType": {
-           "$id": "81",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsNullable": false
-         }
-        ],
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
+     "IsRequired": true,
+     "IsReadOnly": false
     },
     {
-     "$id": "82",
-     "Name": "UnpollutedCat",
-     "Namespace": "ConfidentLevelsInTsp",
-     "Description": "The cat without a union type",
-     "IsNullable": false,
-     "DiscriminatorValue": "cat",
-     "BaseModel": {
-      "$ref": "69"
-     },
-     "Usage": "RoundTrip",
-     "Properties": [
-      {
-       "$id": "83",
-       "Name": "meow",
-       "SerializedName": "meow",
-       "Description": "Meow",
-       "Type": {
-        "$id": "84",
+     "$id": "77",
+     "Name": "color",
+     "SerializedName": "color",
+     "Description": "Color, could be specified by a string or by an array of int as RGB",
+     "Type": {
+      "$id": "78",
+      "Name": "Union",
+      "UnionItemTypes": [
+       {
+        "$id": "79",
         "Name": "string",
         "Kind": "String",
         "IsNullable": false
        },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
+       {
+        "$id": "80",
+        "Name": "Array",
+        "ElementType": {
+         "$id": "81",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsNullable": false
+       }
+      ],
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
     }
    ]
   },
   {
-   "$ref": "74"
-  },
-  {
-   "$ref": "82"
+   "$id": "82",
+   "Name": "UnpollutedCat",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "The cat without a union type",
+   "IsNullable": false,
+   "DiscriminatorValue": "cat",
+   "BaseModel": {
+    "$ref": "69"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "83",
+     "Name": "meow",
+     "SerializedName": "meow",
+     "Description": "Meow",
+     "Type": {
+      "$id": "84",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
    "$id": "85",
@@ -714,84 +698,10 @@
      "IsRequired": false,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "90",
-     "Name": "DerivedModel",
-     "Namespace": "ConfidentLevelsInTsp",
-     "Description": "The derived model",
-     "IsNullable": false,
-     "BaseModel": {
-      "$ref": "85"
-     },
-     "Usage": "None",
-     "Properties": [
-      {
-       "$id": "91",
-       "Name": "age",
-       "SerializedName": "age",
-       "Description": "The age",
-       "Type": {
-        "$id": "92",
-        "Name": "int32",
-        "Kind": "Int32",
-        "IsNullable": false
-       },
-       "IsRequired": false,
-       "IsReadOnly": false
-      }
-     ]
-    },
-    {
-     "$id": "93",
-     "Name": "DerivedModelWithUnion",
-     "Namespace": "ConfidentLevelsInTsp",
-     "Description": "This is a derived model with unions",
-     "IsNullable": false,
-     "BaseModel": {
-      "$ref": "85"
-     },
-     "Usage": "Input",
-     "Properties": [
-      {
-       "$id": "94",
-       "Name": "unionProperty",
-       "SerializedName": "unionProperty",
-       "Description": "The union property",
-       "Type": {
-        "$id": "95",
-        "Name": "Union",
-        "UnionItemTypes": [
-         {
-          "$id": "96",
-          "Name": "string",
-          "Kind": "String",
-          "IsNullable": false
-         },
-         {
-          "$id": "97",
-          "Name": "Array",
-          "ElementType": {
-           "$id": "98",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsNullable": false
-         }
-        ],
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
-    }
    ]
   },
   {
-   "$id": "99",
+   "$id": "90",
    "Name": "DerivedModel",
    "Namespace": "ConfidentLevelsInTsp",
    "Description": "The derived model",
@@ -802,12 +712,12 @@
    "Usage": "Input",
    "Properties": [
     {
-     "$id": "100",
+     "$id": "91",
      "Name": "age",
      "SerializedName": "age",
      "Description": "The age",
      "Type": {
-      "$id": "101",
+      "$id": "92",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -818,27 +728,69 @@
    ]
   },
   {
-   "$ref": "93"
+   "$id": "93",
+   "Name": "DerivedModelWithUnion",
+   "Namespace": "ConfidentLevelsInTsp",
+   "Description": "This is a derived model with unions",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "85"
+   },
+   "Usage": "Input",
+   "Properties": [
+    {
+     "$id": "94",
+     "Name": "unionProperty",
+     "SerializedName": "unionProperty",
+     "Description": "The union property",
+     "Type": {
+      "$id": "95",
+      "Name": "Union",
+      "UnionItemTypes": [
+       {
+        "$id": "96",
+        "Name": "string",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       {
+        "$id": "97",
+        "Name": "Array",
+        "ElementType": {
+         "$id": "98",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsNullable": false
+       }
+      ],
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   }
  ],
  "Clients": [
   {
-   "$id": "102",
+   "$id": "99",
    "Name": "ConfidentLevelsInTspClient",
    "Description": "CADL project to test various types of models.",
    "Operations": [
     {
-     "$id": "103",
+     "$id": "100",
      "Name": "unionInRequestProperty",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with union types in request body",
      "Parameters": [
       {
-       "$id": "104",
+       "$id": "101",
        "Name": "host",
        "NameInRequest": "host",
        "Type": {
-        "$id": "105",
+        "$id": "102",
         "Name": "Uri",
         "Kind": "Uri",
         "IsNullable": false
@@ -854,7 +806,7 @@
        "Kind": "Client"
       },
       {
-       "$id": "106",
+       "$id": "103",
        "Name": "body",
        "NameInRequest": "body",
        "Type": {
@@ -871,9 +823,36 @@
        "Kind": "Method"
       },
       {
-       "$id": "107",
+       "$id": "104",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
+       "Type": {
+        "$id": "105",
+        "Name": "String",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       "Location": "Header",
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": true,
+       "IsRequired": true,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Constant",
+       "DefaultValue": {
+        "$id": "106",
+        "Type": {
+         "$ref": "105"
+        },
+        "Value": "application/json"
+       }
+      },
+      {
+       "$id": "107",
+       "Name": "accept",
+       "NameInRequest": "Accept",
        "Type": {
         "$id": "108",
         "Name": "String",
@@ -883,7 +862,7 @@
        "Location": "Header",
        "IsApiVersion": false,
        "IsResourceParameter": false,
-       "IsContentType": true,
+       "IsContentType": false,
        "IsRequired": true,
        "IsEndpoint": false,
        "SkipUrlEncoding": false,
@@ -899,38 +878,11 @@
       },
       {
        "$id": "110",
-       "Name": "accept",
-       "NameInRequest": "Accept",
-       "Type": {
-        "$id": "111",
-        "Name": "String",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "Location": "Header",
-       "IsApiVersion": false,
-       "IsResourceParameter": false,
-       "IsContentType": false,
-       "IsRequired": true,
-       "IsEndpoint": false,
-       "SkipUrlEncoding": false,
-       "Explode": false,
-       "Kind": "Constant",
-       "DefaultValue": {
-        "$id": "112",
-        "Type": {
-         "$ref": "111"
-        },
-        "Value": "application/json"
-       }
-      },
-      {
-       "$id": "113",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "114",
+        "$id": "111",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -945,9 +897,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "115",
+        "$id": "112",
         "Type": {
-         "$id": "116",
+         "$id": "113",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -958,7 +910,7 @@
      ],
      "Responses": [
       {
-       "$id": "117",
+       "$id": "114",
        "StatusCodes": [
         204
        ],
@@ -979,16 +931,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "118",
+     "$id": "115",
      "Name": "unionInResponseProperty",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with union types as response body",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "119",
+       "$id": "116",
        "Name": "body",
        "NameInRequest": "body",
        "Type": {
@@ -1005,11 +957,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "120",
+       "$id": "117",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "121",
+        "$id": "118",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1024,19 +976,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "122",
+        "$id": "119",
         "Type": {
-         "$ref": "121"
+         "$ref": "118"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "123",
+       "$id": "120",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "124",
+        "$id": "121",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1051,20 +1003,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "125",
+        "$id": "122",
         "Type": {
-         "$ref": "124"
+         "$ref": "121"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "126",
+       "$id": "123",
        "StatusCodes": [
         200
        ],
@@ -1088,16 +1040,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "127",
+     "$id": "124",
      "Name": "unionWithSelfReference",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with union types and self reference in request body",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "128",
+       "$id": "125",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1114,11 +1066,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "129",
+       "$id": "126",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "130",
+        "$id": "127",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1133,19 +1085,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "131",
+        "$id": "128",
         "Type": {
-         "$ref": "130"
+         "$ref": "127"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "132",
+       "$id": "129",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "133",
+        "$id": "130",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1160,20 +1112,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "134",
+        "$id": "131",
         "Type": {
-         "$ref": "133"
+         "$ref": "130"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "135",
+       "$id": "132",
        "StatusCodes": [
         204
        ],
@@ -1194,16 +1146,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "136",
+     "$id": "133",
      "Name": "unionWithInderict",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with union types and indirect self reference in request body",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "137",
+       "$id": "134",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1220,11 +1172,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "138",
+       "$id": "135",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "139",
+        "$id": "136",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1239,19 +1191,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "140",
+        "$id": "137",
         "Type": {
-         "$ref": "139"
+         "$ref": "136"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "141",
+       "$id": "138",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "142",
+        "$id": "139",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1266,20 +1218,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "143",
+        "$id": "140",
         "Type": {
-         "$ref": "142"
+         "$ref": "139"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "144",
+       "$id": "141",
        "StatusCodes": [
         204
        ],
@@ -1300,16 +1252,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "145",
+     "$id": "142",
      "Name": "literalOfInteger",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with a property of literal type of numbers in request body",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "146",
+       "$id": "143",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1326,11 +1278,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "147",
+       "$id": "144",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "148",
+        "$id": "145",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1345,19 +1297,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "149",
+        "$id": "146",
         "Type": {
-         "$ref": "148"
+         "$ref": "145"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "150",
+       "$id": "147",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "151",
+        "$id": "148",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1372,20 +1324,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "152",
+        "$id": "149",
         "Type": {
-         "$ref": "151"
+         "$ref": "148"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "153",
+       "$id": "150",
        "StatusCodes": [
         204
        ],
@@ -1406,16 +1358,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "154",
+     "$id": "151",
      "Name": "literalOfFloat",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with a property of literal type of numbers in request body",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "155",
+       "$id": "152",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1432,11 +1384,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "156",
+       "$id": "153",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "157",
+        "$id": "154",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1451,19 +1403,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "158",
+        "$id": "155",
         "Type": {
-         "$ref": "157"
+         "$ref": "154"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "159",
+       "$id": "156",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "160",
+        "$id": "157",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1478,20 +1430,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "161",
+        "$id": "158",
         "Type": {
-         "$ref": "160"
+         "$ref": "157"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "162",
+       "$id": "159",
        "StatusCodes": [
         204
        ],
@@ -1512,16 +1464,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "163",
+     "$id": "160",
      "Name": "confidentOperationWithDiscriminator",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a model with discriminator in request body, this operation should be confident",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "164",
+       "$id": "161",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1538,11 +1490,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "165",
+       "$id": "162",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "166",
+        "$id": "163",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1557,19 +1509,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "167",
+        "$id": "164",
         "Type": {
-         "$ref": "166"
+         "$ref": "163"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "168",
+       "$id": "165",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "169",
+        "$id": "166",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1584,20 +1536,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "170",
+        "$id": "167",
         "Type": {
-         "$ref": "169"
+         "$ref": "166"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "171",
+       "$id": "168",
        "StatusCodes": [
         200
        ],
@@ -1621,16 +1573,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "172",
+     "$id": "169",
      "Name": "pollutedBaseMethod",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses the base type with a discriminator, but this operation is low confident because one of the derived type from the discriminated types has union types on it",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "173",
+       "$id": "170",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1647,11 +1599,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "174",
+       "$id": "171",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "175",
+        "$id": "172",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1666,19 +1618,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "176",
+        "$id": "173",
         "Type": {
-         "$ref": "175"
+         "$ref": "172"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "177",
+       "$id": "174",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "178",
+        "$id": "175",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1693,20 +1645,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "179",
+        "$id": "176",
         "Type": {
-         "$ref": "178"
+         "$ref": "175"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "180",
+       "$id": "177",
        "StatusCodes": [
         200
        ],
@@ -1730,16 +1682,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "181",
+     "$id": "178",
      "Name": "pollutedDerivedMethod",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses the model with a union type directly therefore this operation is not confident",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "182",
+       "$id": "179",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1756,11 +1708,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "183",
+       "$id": "180",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "184",
+        "$id": "181",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1775,19 +1727,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "185",
+        "$id": "182",
         "Type": {
-         "$ref": "184"
+         "$ref": "181"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "186",
+       "$id": "183",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "187",
+        "$id": "184",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1802,20 +1754,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "188",
+        "$id": "185",
         "Type": {
-         "$ref": "187"
+         "$ref": "184"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "189",
+       "$id": "186",
        "StatusCodes": [
         200
        ],
@@ -1839,16 +1791,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "190",
+     "$id": "187",
      "Name": "unpollutedDerivedMethod",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that is not using the model with a union type directly but since the base type is not confident and we would like it to be low confident, therefore this must be made internal as well",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "191",
+       "$id": "188",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -1865,11 +1817,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "192",
+       "$id": "189",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "193",
+        "$id": "190",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1884,19 +1836,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "194",
+        "$id": "191",
         "Type": {
-         "$ref": "193"
+         "$ref": "190"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "195",
+       "$id": "192",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "196",
+        "$id": "193",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1911,20 +1863,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "197",
+        "$id": "194",
         "Type": {
-         "$ref": "196"
+         "$ref": "193"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "198",
+       "$id": "195",
        "StatusCodes": [
         200
        ],
@@ -1948,20 +1900,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "199",
+     "$id": "196",
      "Name": "useDerivedModel",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation with nothing special",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "200",
+       "$id": "197",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "99"
+        "$ref": "90"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -1974,11 +1926,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "201",
+       "$id": "198",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "202",
+        "$id": "199",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -1993,19 +1945,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "203",
+        "$id": "200",
         "Type": {
-         "$ref": "202"
+         "$ref": "199"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "204",
+       "$id": "201",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "205",
+        "$id": "202",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -2020,20 +1972,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "206",
+        "$id": "203",
         "Type": {
-         "$ref": "205"
+         "$ref": "202"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "207",
+       "$id": "204",
        "StatusCodes": [
         204
        ],
@@ -2054,16 +2006,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "208",
+     "$id": "205",
      "Name": "useDerivedModelWithUnion",
      "ResourceName": "ConfidentLevelsInTsp",
      "Description": "This is an operation that uses a derived model with unions",
      "Parameters": [
       {
-       "$ref": "104"
+       "$ref": "101"
       },
       {
-       "$id": "209",
+       "$id": "206",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -2080,11 +2032,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "210",
+       "$id": "207",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "211",
+        "$id": "208",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -2099,19 +2051,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "212",
+        "$id": "209",
         "Type": {
-         "$ref": "211"
+         "$ref": "208"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "213",
+       "$id": "210",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "214",
+        "$id": "211",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -2126,20 +2078,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "215",
+        "$id": "212",
         "Type": {
-         "$ref": "214"
+         "$ref": "211"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "113"
+       "$ref": "110"
       }
      ],
      "Responses": [
       {
-       "$id": "216",
+       "$id": "213",
        "StatusCodes": [
         204
        ],
@@ -2161,7 +2113,7 @@
     }
    ],
    "Protocol": {
-    "$id": "217"
+    "$id": "214"
    },
    "Creatable": true
   }

--- a/test/TestProjects/Models-TypeSpec/src/Generated/ModelsTypeSpecModelFactory.cs
+++ b/test/TestProjects/Models-TypeSpec/src/Generated/ModelsTypeSpecModelFactory.cs
@@ -14,22 +14,6 @@ namespace ModelsTypeSpec.Models
     /// <summary> Model factory for models. </summary>
     public static partial class ModelsTypeSpecModelFactory
     {
-        /// <summary> Initializes a new instance of FirstDerivedOutputModel. </summary>
-        /// <param name="first"></param>
-        /// <returns> A new <see cref="Models.FirstDerivedOutputModel"/> instance for mocking. </returns>
-        public static FirstDerivedOutputModel FirstDerivedOutputModel(bool first = default)
-        {
-            return new FirstDerivedOutputModel("first", first);
-        }
-
-        /// <summary> Initializes a new instance of SecondDerivedOutputModel. </summary>
-        /// <param name="second"></param>
-        /// <returns> A new <see cref="Models.SecondDerivedOutputModel"/> instance for mocking. </returns>
-        public static SecondDerivedOutputModel SecondDerivedOutputModel(bool second = default)
-        {
-            return new SecondDerivedOutputModel("second", second);
-        }
-
         /// <summary> Initializes a new instance of RoundTripModel. </summary>
         /// <param name="requiredString"> Required string, illustrating a reference type property. </param>
         /// <param name="requiredInt"> Required int, illustrating a value type property. </param>
@@ -176,6 +160,22 @@ namespace ModelsTypeSpec.Models
         public static SingleBase SingleBase(string kind = null, int size = default)
         {
             return new UnknownSingleBase(kind, size);
+        }
+
+        /// <summary> Initializes a new instance of FirstDerivedOutputModel. </summary>
+        /// <param name="first"></param>
+        /// <returns> A new <see cref="Models.FirstDerivedOutputModel"/> instance for mocking. </returns>
+        public static FirstDerivedOutputModel FirstDerivedOutputModel(bool first = default)
+        {
+            return new FirstDerivedOutputModel("first", first);
+        }
+
+        /// <summary> Initializes a new instance of SecondDerivedOutputModel. </summary>
+        /// <param name="second"></param>
+        /// <returns> A new <see cref="Models.SecondDerivedOutputModel"/> instance for mocking. </returns>
+        public static SecondDerivedOutputModel SecondDerivedOutputModel(bool second = default)
+        {
+            return new SecondDerivedOutputModel("second", second);
         }
     }
 }

--- a/test/TestProjects/Models-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/Models-TypeSpec/src/Generated/tspCodeModel.json
@@ -190,71 +190,63 @@
      },
      "IsDiscriminator": true
     }
-   ],
-   "DerivedModels": [
+   ]
+  },
+  {
+   "$id": "27",
+   "Name": "FirstDerivedOutputModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "First derived model as an output",
+   "IsNullable": false,
+   "DiscriminatorValue": "first",
+   "BaseModel": {
+    "$ref": "24"
+   },
+   "Usage": "Output",
+   "Properties": [
     {
-     "$id": "27",
-     "Name": "FirstDerivedOutputModel",
-     "Namespace": "ModelsTypeSpec",
-     "Description": "First derived model as an output",
-     "IsNullable": false,
-     "DiscriminatorValue": "first",
-     "BaseModel": {
-      "$ref": "24"
+     "$id": "28",
+     "Name": "first",
+     "SerializedName": "first",
+     "Description": "",
+     "Type": {
+      "$id": "29",
+      "Name": "boolean",
+      "Kind": "Boolean",
+      "IsNullable": false
      },
-     "Usage": "Output",
-     "Properties": [
-      {
-       "$id": "28",
-       "Name": "first",
-       "SerializedName": "first",
-       "Description": "",
-       "Type": {
-        "$id": "29",
-        "Name": "boolean",
-        "Kind": "Boolean",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
-    },
-    {
-     "$id": "30",
-     "Name": "SecondDerivedOutputModel",
-     "Namespace": "ModelsTypeSpec",
-     "Description": "Second derived model as an output",
-     "IsNullable": false,
-     "DiscriminatorValue": "second",
-     "BaseModel": {
-      "$ref": "24"
-     },
-     "Usage": "Output",
-     "Properties": [
-      {
-       "$id": "31",
-       "Name": "second",
-       "SerializedName": "second",
-       "Description": "",
-       "Type": {
-        "$id": "32",
-        "Name": "boolean",
-        "Kind": "Boolean",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
+     "IsRequired": true,
+     "IsReadOnly": false
     }
    ]
   },
   {
-   "$ref": "27"
-  },
-  {
-   "$ref": "30"
+   "$id": "30",
+   "Name": "SecondDerivedOutputModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Second derived model as an output",
+   "IsNullable": false,
+   "DiscriminatorValue": "second",
+   "BaseModel": {
+    "$ref": "24"
+   },
+   "Usage": "Output",
+   "Properties": [
+    {
+     "$id": "31",
+     "Name": "second",
+     "SerializedName": "second",
+     "Description": "",
+     "Type": {
+      "$id": "32",
+      "Name": "boolean",
+      "Kind": "Boolean",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
    "$id": "33",
@@ -360,848 +352,13 @@
       "Description": "Base model",
       "IsNullable": false,
       "Usage": "Input",
-      "Properties": [],
-      "DerivedModels": [
-       {
-        "$id": "48",
-        "Name": "DerivedModel",
-        "Namespace": "ModelsTypeSpec",
-        "Description": "Derived model",
-        "IsNullable": false,
-        "BaseModel": {
-         "$ref": "47"
-        },
-        "Usage": "RoundTrip",
-        "Properties": [
-         {
-          "$id": "49",
-          "Name": "requiredList",
-          "SerializedName": "requiredList",
-          "Description": "Required collection",
-          "Type": {
-           "$id": "50",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "51",
-            "Name": "CollectionItem",
-            "Namespace": "ModelsTypeSpec",
-            "Description": "Collection item model",
-            "IsNullable": false,
-            "Usage": "RoundTrip",
-            "Properties": [
-             {
-              "$id": "52",
-              "Name": "requiredModelRecord",
-              "SerializedName": "requiredModelRecord",
-              "Description": "Required model record",
-              "Type": {
-               "$id": "53",
-               "Name": "Dictionary",
-               "KeyType": {
-                "$id": "54",
-                "Name": "string",
-                "Kind": "String",
-                "IsNullable": false
-               },
-               "ValueType": {
-                "$id": "55",
-                "Name": "RecordItem",
-                "Namespace": "ModelsTypeSpec",
-                "Description": "Record item model",
-                "IsNullable": false,
-                "BaseModel": {
-                 "$ref": "48"
-                },
-                "Usage": "RoundTrip",
-                "Properties": []
-               },
-               "IsNullable": false
-              },
-              "IsRequired": true,
-              "IsReadOnly": false
-             }
-            ]
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         }
-        ],
-        "DerivedModels": [
-         {
-          "$ref": "55"
-         }
-        ]
-       },
-       {
-        "$id": "56",
-        "Name": "RoundTripModel",
-        "Namespace": "ModelsTypeSpec",
-        "Description": "Model used both as input and output",
-        "IsNullable": false,
-        "BaseModel": {
-         "$ref": "47"
-        },
-        "Usage": "RoundTrip",
-        "Properties": [
-         {
-          "$id": "57",
-          "Name": "requiredString",
-          "SerializedName": "requiredString",
-          "Description": "Required string, illustrating a reference type property.",
-          "Type": {
-           "$id": "58",
-           "Name": "string",
-           "Kind": "String",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "59",
-          "Name": "requiredInt",
-          "SerializedName": "requiredInt",
-          "Description": "Required int, illustrating a value type property.",
-          "Type": {
-           "$id": "60",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "61",
-          "Name": "nonRequiredString",
-          "SerializedName": "nonRequiredString",
-          "Description": "Optional string",
-          "Type": {
-           "$id": "62",
-           "Name": "string",
-           "Kind": "String",
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "63",
-          "Name": "nonRequiredInt",
-          "SerializedName": "nonRequiredInt",
-          "Description": "Optional int",
-          "Type": {
-           "$id": "64",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "65",
-          "Name": "requiredNullableInt",
-          "SerializedName": "requiredNullableInt",
-          "Description": "Required nullable int",
-          "Type": {
-           "$id": "66",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": true
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "67",
-          "Name": "requiredNullableString",
-          "SerializedName": "requiredNullableString",
-          "Description": "Required nullable string",
-          "Type": {
-           "$id": "68",
-           "Name": "string",
-           "Kind": "String",
-           "IsNullable": true
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "69",
-          "Name": "nonRequiredNullableInt",
-          "SerializedName": "nonRequiredNullableInt",
-          "Description": "Optional nullable int",
-          "Type": {
-           "$id": "70",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": true
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "71",
-          "Name": "nonRequiredNullableString",
-          "SerializedName": "nonRequiredNullableString",
-          "Description": "Optional nullable string",
-          "Type": {
-           "$id": "72",
-           "Name": "string",
-           "Kind": "String",
-           "IsNullable": true
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "73",
-          "Name": "requiredReadonlyInt",
-          "SerializedName": "requiredReadonlyInt",
-          "Description": "Required readonly int",
-          "Type": {
-           "$id": "74",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": true
-         },
-         {
-          "$id": "75",
-          "Name": "nonRequiredReadonlyInt",
-          "SerializedName": "nonRequiredReadonlyInt",
-          "Description": "Optional readonly int",
-          "Type": {
-           "$id": "76",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": true
-         },
-         {
-          "$id": "77",
-          "Name": "requiredModel",
-          "SerializedName": "requiredModel",
-          "Description": "Required model with discriminator",
-          "Type": {
-           "$id": "78",
-           "Name": "BaseModelWithDiscriminator",
-           "Namespace": "ModelsTypeSpec",
-           "Description": "Base model with discriminator property.",
-           "IsNullable": false,
-           "DiscriminatorPropertyName": "discriminatorProperty",
-           "Usage": "RoundTrip",
-           "Properties": [
-            {
-             "$id": "79",
-             "Name": "discriminatorProperty",
-             "SerializedName": "discriminatorProperty",
-             "Description": "Discriminator",
-             "IsRequired": true,
-             "IsReadOnly": false,
-             "IsNullable": false,
-             "Type": {
-              "$id": "80",
-              "Name": "string",
-              "Kind": "String",
-              "IsNullable": false
-             },
-             "IsDiscriminator": true
-            },
-            {
-             "$id": "81",
-             "Name": "optionalPropertyOnBase",
-             "SerializedName": "optionalPropertyOnBase",
-             "Description": "Optional property on base",
-             "Type": {
-              "$id": "82",
-              "Name": "string",
-              "Kind": "String",
-              "IsNullable": false
-             },
-             "IsRequired": false,
-             "IsReadOnly": false
-            },
-            {
-             "$id": "83",
-             "Name": "requiredPropertyOnBase",
-             "SerializedName": "requiredPropertyOnBase",
-             "Description": "Required property on base",
-             "Type": {
-              "$id": "84",
-              "Name": "int32",
-              "Kind": "Int32",
-              "IsNullable": false
-             },
-             "IsRequired": true,
-             "IsReadOnly": false
-            }
-           ],
-           "DerivedModels": [
-            {
-             "$id": "85",
-             "Name": "DerivedModelWithDiscriminatorA",
-             "Namespace": "ModelsTypeSpec",
-             "Description": "Deriver model with discriminator property.",
-             "IsNullable": false,
-             "DiscriminatorValue": "A",
-             "BaseModel": {
-              "$ref": "78"
-             },
-             "Usage": "RoundTrip",
-             "Properties": [
-              {
-               "$id": "86",
-               "Name": "requiredString",
-               "SerializedName": "requiredString",
-               "Description": "Required string.",
-               "Type": {
-                "$id": "87",
-                "Name": "string",
-                "Kind": "String",
-                "IsNullable": false
-               },
-               "IsRequired": true,
-               "IsReadOnly": false
-              }
-             ]
-            },
-            {
-             "$id": "88",
-             "Name": "DerivedModelWithDiscriminatorB",
-             "Namespace": "ModelsTypeSpec",
-             "Description": "Deriver model with discriminator property.",
-             "IsNullable": false,
-             "DiscriminatorValue": "B",
-             "BaseModel": {
-              "$ref": "78"
-             },
-             "Usage": "RoundTrip",
-             "Properties": [
-              {
-               "$id": "89",
-               "Name": "requiredInt",
-               "SerializedName": "requiredInt",
-               "Description": "Required int.",
-               "Type": {
-                "$id": "90",
-                "Name": "int32",
-                "Kind": "Int32",
-                "IsNullable": false
-               },
-               "IsRequired": true,
-               "IsReadOnly": false
-              }
-             ]
-            }
-           ]
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "91",
-          "Name": "requiredFixedStringEnum",
-          "SerializedName": "requiredFixedStringEnum",
-          "Description": "Required fixed string enum",
-          "Type": {
-           "$ref": "2"
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "92",
-          "Name": "requiredFixedIntEnum",
-          "SerializedName": "requiredFixedIntEnum",
-          "Description": "Required fixed int enum",
-          "Type": {
-           "$ref": "6"
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "93",
-          "Name": "requiredExtensibleEnum",
-          "SerializedName": "requiredExtensibleEnum",
-          "Description": "Required extensible enum",
-          "Type": {
-           "$ref": "10"
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "94",
-          "Name": "requiredList",
-          "SerializedName": "requiredList",
-          "Description": "Required collection",
-          "Type": {
-           "$id": "95",
-           "Name": "Array",
-           "ElementType": {
-            "$ref": "51"
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "96",
-          "Name": "requiredIntRecord",
-          "SerializedName": "requiredIntRecord",
-          "Description": "Required int record",
-          "Type": {
-           "$id": "97",
-           "Name": "Dictionary",
-           "KeyType": {
-            "$id": "98",
-            "Name": "string",
-            "Kind": "String",
-            "IsNullable": false
-           },
-           "ValueType": {
-            "$id": "99",
-            "Name": "int32",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "100",
-          "Name": "requiredStringRecord",
-          "SerializedName": "requiredStringRecord",
-          "Description": "Required string record",
-          "Type": {
-           "$id": "101",
-           "Name": "Dictionary",
-           "KeyType": {
-            "$id": "102",
-            "Name": "string",
-            "Kind": "String",
-            "IsNullable": false
-           },
-           "ValueType": {
-            "$id": "103",
-            "Name": "string",
-            "Kind": "String",
-            "IsNullable": false
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "104",
-          "Name": "requiredModelRecord",
-          "SerializedName": "requiredModelRecord",
-          "Description": "Required Model Record",
-          "Type": {
-           "$id": "105",
-           "Name": "Dictionary",
-           "KeyType": {
-            "$id": "106",
-            "Name": "string",
-            "Kind": "String",
-            "IsNullable": false
-           },
-           "ValueType": {
-            "$ref": "55"
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "107",
-          "Name": "requiredBytes",
-          "SerializedName": "requiredBytes",
-          "Description": "Required bytes",
-          "Type": {
-           "$id": "108",
-           "Name": "bytes",
-           "Kind": "Bytes",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "109",
-          "Name": "optionalBytes",
-          "SerializedName": "optionalBytes",
-          "Description": "Optional bytes",
-          "Type": {
-           "$id": "110",
-           "Name": "bytes",
-           "Kind": "Bytes",
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "111",
-          "Name": "requiredUint8Array",
-          "SerializedName": "requiredUint8Array",
-          "Description": "Required uint8[]",
-          "Type": {
-           "$id": "112",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "113",
-            "Name": "uint8",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "114",
-          "Name": "optionalUint8Array",
-          "SerializedName": "optionalUint8Array",
-          "Description": "Optional uint8[]",
-          "Type": {
-           "$id": "115",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "116",
-            "Name": "uint8",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "117",
-          "Name": "requiredUnknown",
-          "SerializedName": "requiredUnknown",
-          "Description": "Required unknown",
-          "Type": {
-           "$id": "118",
-           "Name": "Intrinsic",
-           "Kind": "unknown",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "119",
-          "Name": "optionalUnknown",
-          "SerializedName": "optionalUnknown",
-          "Description": "Optional unknown",
-          "Type": {
-           "$id": "120",
-           "Name": "Intrinsic",
-           "Kind": "unknown",
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "121",
-          "Name": "requiredInt8Array",
-          "SerializedName": "requiredInt8Array",
-          "Description": "Required int8[]",
-          "Type": {
-           "$id": "122",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "123",
-            "Name": "int8",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "124",
-          "Name": "optionalInt8Array",
-          "SerializedName": "optionalInt8Array",
-          "Description": "Optional int8[]",
-          "Type": {
-           "$id": "125",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "126",
-            "Name": "int8",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": false
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "127",
-          "Name": "requiredNullableIntList",
-          "SerializedName": "requiredNullableIntList",
-          "Description": "Required nullable int list",
-          "Type": {
-           "$id": "128",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "129",
-            "Name": "int32",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": true
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "130",
-          "Name": "requiredNullableStringList",
-          "SerializedName": "requiredNullableStringList",
-          "Description": "Required nullable string list",
-          "Type": {
-           "$id": "131",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "132",
-            "Name": "string",
-            "Kind": "String",
-            "IsNullable": false
-           },
-           "IsNullable": true
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "133",
-          "Name": "nonRequiredNullableIntList",
-          "SerializedName": "nonRequiredNullableIntList",
-          "Description": "Optional nullable model list",
-          "Type": {
-           "$id": "134",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "135",
-            "Name": "int32",
-            "Kind": "Int32",
-            "IsNullable": false
-           },
-           "IsNullable": true
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "136",
-          "Name": "nonRequiredNullableStringList",
-          "SerializedName": "nonRequiredNullableStringList",
-          "Description": "Optional nullable string list",
-          "Type": {
-           "$id": "137",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "138",
-            "Name": "string",
-            "Kind": "String",
-            "IsNullable": false
-           },
-           "IsNullable": true
-          },
-          "IsRequired": false,
-          "IsReadOnly": false
-         }
-        ]
-       },
-       {
-        "$id": "139",
-        "Name": "RoundTripPrimitiveModel",
-        "Namespace": "ModelsTypeSpec",
-        "Description": "Model used both as input and output with primitive types",
-        "IsNullable": false,
-        "BaseModel": {
-         "$ref": "47"
-        },
-        "Usage": "RoundTrip",
-        "Properties": [
-         {
-          "$id": "140",
-          "Name": "requiredString",
-          "SerializedName": "requiredString",
-          "Description": "Required string, illustrating a reference type property.",
-          "Type": {
-           "$id": "141",
-           "Name": "string",
-           "Kind": "String",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "142",
-          "Name": "requiredInt",
-          "SerializedName": "requiredInt",
-          "Description": "Required int, illustrating a value type property.",
-          "Type": {
-           "$id": "143",
-           "Name": "int32",
-           "Kind": "Int32",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "144",
-          "Name": "requiredInt64",
-          "SerializedName": "requiredInt64",
-          "Description": "Required int64, illustrating a value type property.",
-          "Type": {
-           "$id": "145",
-           "Name": "int64",
-           "Kind": "Int64",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "146",
-          "Name": "requiredSafeInt",
-          "SerializedName": "requiredSafeInt",
-          "Description": "Required safeint, illustrating a value type property.",
-          "Type": {
-           "$id": "147",
-           "Name": "safeint",
-           "Kind": "Int64",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "148",
-          "Name": "requiredFloat",
-          "SerializedName": "requiredFloat",
-          "Description": "Required float, illustrating a value type property.",
-          "Type": {
-           "$id": "149",
-           "Name": "float32",
-           "Kind": "Float32",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "150",
-          "Name": "required_Double",
-          "SerializedName": "required_Double",
-          "Description": "Required double, illustrating a value type property.",
-          "Type": {
-           "$id": "151",
-           "Name": "float64",
-           "Kind": "Float64",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "152",
-          "Name": "requiredBoolean",
-          "SerializedName": "requiredBoolean",
-          "Description": "Required bolean, illustrating a value type property.",
-          "Type": {
-           "$id": "153",
-           "Name": "boolean",
-           "Kind": "Boolean",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "154",
-          "Name": "requiredDateTimeOffset",
-          "SerializedName": "requiredDateTimeOffset",
-          "Description": "Required date time offset, illustrating a reference type property.",
-          "Type": {
-           "$id": "155",
-           "Name": "utcDateTime",
-           "Kind": "DateTime",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "156",
-          "Name": "requiredTimeSpan",
-          "SerializedName": "requiredTimeSpan",
-          "Description": "Required time span, illustrating a value type property.",
-          "Type": {
-           "$id": "157",
-           "Name": "duration",
-           "Kind": "DurationISO8601",
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         },
-         {
-          "$id": "158",
-          "Name": "requiredCollectionWithNullableFloatElement",
-          "SerializedName": "requiredCollectionWithNullableFloatElement",
-          "Description": "Required collection of which the element is a nullable float",
-          "Type": {
-           "$id": "159",
-           "Name": "Array",
-           "ElementType": {
-            "$id": "160",
-            "Name": "float32",
-            "Kind": "Float32",
-            "IsNullable": true
-           },
-           "IsNullable": false
-          },
-          "IsRequired": true,
-          "IsReadOnly": false
-         }
-        ]
-       }
-      ]
+      "Properties": []
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
-     "$id": "161",
+     "$id": "48",
      "Name": "requiredModel2",
      "SerializedName": "requiredModel2",
      "Description": "Required model",
@@ -1212,15 +369,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "162",
+     "$id": "49",
      "Name": "requiredIntList",
      "SerializedName": "requiredIntList",
      "Description": "Required primitive value type collection",
      "Type": {
-      "$id": "163",
+      "$id": "50",
       "Name": "Array",
       "ElementType": {
-       "$id": "164",
+       "$id": "51",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1231,15 +388,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "165",
+     "$id": "52",
      "Name": "requiredStringList",
      "SerializedName": "requiredStringList",
      "Description": "Required primitive reference type collection",
      "Type": {
-      "$id": "166",
+      "$id": "53",
       "Name": "Array",
       "ElementType": {
-       "$id": "167",
+       "$id": "54",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1250,15 +407,79 @@
      "IsReadOnly": false
     },
     {
-     "$id": "168",
+     "$id": "55",
      "Name": "requiredModelList",
      "SerializedName": "requiredModelList",
      "Description": "Required model collection",
      "Type": {
-      "$id": "169",
+      "$id": "56",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$id": "57",
+       "Name": "CollectionItem",
+       "Namespace": "ModelsTypeSpec",
+       "Description": "Collection item model",
+       "IsNullable": false,
+       "Usage": "RoundTrip",
+       "Properties": [
+        {
+         "$id": "58",
+         "Name": "requiredModelRecord",
+         "SerializedName": "requiredModelRecord",
+         "Description": "Required model record",
+         "Type": {
+          "$id": "59",
+          "Name": "Dictionary",
+          "KeyType": {
+           "$id": "60",
+           "Name": "string",
+           "Kind": "String",
+           "IsNullable": false
+          },
+          "ValueType": {
+           "$id": "61",
+           "Name": "RecordItem",
+           "Namespace": "ModelsTypeSpec",
+           "Description": "Record item model",
+           "IsNullable": false,
+           "BaseModel": {
+            "$id": "62",
+            "Name": "DerivedModel",
+            "Namespace": "ModelsTypeSpec",
+            "Description": "Derived model",
+            "IsNullable": false,
+            "BaseModel": {
+             "$ref": "47"
+            },
+            "Usage": "RoundTrip",
+            "Properties": [
+             {
+              "$id": "63",
+              "Name": "requiredList",
+              "SerializedName": "requiredList",
+              "Description": "Required collection",
+              "Type": {
+               "$id": "64",
+               "Name": "Array",
+               "ElementType": {
+                "$ref": "57"
+               },
+               "IsNullable": false
+              },
+              "IsRequired": true,
+              "IsReadOnly": false
+             }
+            ]
+           },
+           "Usage": "RoundTrip",
+           "Properties": []
+          },
+          "IsNullable": false
+         },
+         "IsRequired": true,
+         "IsReadOnly": false
+        }
+       ]
       },
       "IsNullable": false
      },
@@ -1266,21 +487,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "170",
+     "$id": "65",
      "Name": "requiredModelRecord",
      "SerializedName": "requiredModelRecord",
      "Description": "Required model record",
      "Type": {
-      "$id": "171",
+      "$id": "66",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "172",
+       "$id": "67",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "55"
+       "$ref": "61"
       },
       "IsNullable": false
      },
@@ -1288,15 +509,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "173",
+     "$id": "68",
      "Name": "requiredCollectionWithNullableFloatElement",
      "SerializedName": "requiredCollectionWithNullableFloatElement",
      "Description": "Required collection of which the element is a nullable float",
      "Type": {
-      "$id": "174",
+      "$id": "69",
       "Name": "Array",
       "ElementType": {
-       "$id": "175",
+       "$id": "70",
        "Name": "float32",
        "Kind": "Float32",
        "IsNullable": true
@@ -1307,15 +528,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "176",
+     "$id": "71",
      "Name": "requiredCollectionWithNullableBooleanElement",
      "SerializedName": "requiredCollectionWithNullableBooleanElement",
      "Description": "Required collection of which the element is a nullable boolean",
      "Type": {
-      "$id": "177",
+      "$id": "72",
       "Name": "Array",
       "ElementType": {
-       "$id": "178",
+       "$id": "73",
        "Name": "boolean",
        "Kind": "Boolean",
        "IsNullable": true
@@ -1326,15 +547,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "179",
+     "$id": "74",
      "Name": "requiredNullableModelList",
      "SerializedName": "requiredNullableModelList",
      "Description": "Required model nullable collection",
      "Type": {
-      "$id": "180",
+      "$id": "75",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": true
      },
@@ -1342,15 +563,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "181",
+     "$id": "76",
      "Name": "requiredNullableStringList",
      "SerializedName": "requiredNullableStringList",
      "Description": "Required string nullable collection",
      "Type": {
-      "$id": "182",
+      "$id": "77",
       "Name": "Array",
       "ElementType": {
-       "$id": "183",
+       "$id": "78",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1361,15 +582,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "184",
+     "$id": "79",
      "Name": "requiredNullableIntList",
      "SerializedName": "requiredNullableIntList",
      "Description": "Required int nullable collection",
      "Type": {
-      "$id": "185",
+      "$id": "80",
       "Name": "Array",
       "ElementType": {
-       "$id": "186",
+       "$id": "81",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1380,15 +601,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "187",
+     "$id": "82",
      "Name": "nonRequiredModelList",
      "SerializedName": "nonRequiredModelList",
      "Description": "Optional model collection",
      "Type": {
-      "$id": "188",
+      "$id": "83",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": false
      },
@@ -1396,15 +617,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "189",
+     "$id": "84",
      "Name": "nonRequiredStringList",
      "SerializedName": "nonRequiredStringList",
      "Description": "Optional string collection",
      "Type": {
-      "$id": "190",
+      "$id": "85",
       "Name": "Array",
       "ElementType": {
-       "$id": "191",
+       "$id": "86",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1415,15 +636,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "192",
+     "$id": "87",
      "Name": "nonRequiredIntList",
      "SerializedName": "nonRequiredIntList",
      "Description": "Optional int collection",
      "Type": {
-      "$id": "193",
+      "$id": "88",
       "Name": "Array",
       "ElementType": {
-       "$id": "194",
+       "$id": "89",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1434,15 +655,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "195",
+     "$id": "90",
      "Name": "nonRequiredNullableModelList",
      "SerializedName": "nonRequiredNullableModelList",
      "Description": "Optional model nullable collection",
      "Type": {
-      "$id": "196",
+      "$id": "91",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": true
      },
@@ -1450,15 +671,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "197",
+     "$id": "92",
      "Name": "nonRequiredNullableStringList",
      "SerializedName": "nonRequiredNullableStringList",
      "Description": "Optional string nullable collection",
      "Type": {
-      "$id": "198",
+      "$id": "93",
       "Name": "Array",
       "ElementType": {
-       "$id": "199",
+       "$id": "94",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1469,15 +690,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "200",
+     "$id": "95",
      "Name": "nonRequiredNullableIntList",
      "SerializedName": "nonRequiredNullableIntList",
      "Description": "Optional int nullable collection",
      "Type": {
-      "$id": "201",
+      "$id": "96",
       "Name": "Array",
       "ElementType": {
-       "$id": "202",
+       "$id": "97",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1493,28 +714,775 @@
    "$ref": "47"
   },
   {
-   "$ref": "48"
+   "$ref": "57"
   },
   {
-   "$ref": "51"
+   "$ref": "62"
   },
   {
-   "$ref": "55"
+   "$ref": "61"
   },
   {
-   "$ref": "56"
+   "$id": "98",
+   "Name": "RoundTripModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Model used both as input and output",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "47"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "99",
+     "Name": "requiredString",
+     "SerializedName": "requiredString",
+     "Description": "Required string, illustrating a reference type property.",
+     "Type": {
+      "$id": "100",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "101",
+     "Name": "requiredInt",
+     "SerializedName": "requiredInt",
+     "Description": "Required int, illustrating a value type property.",
+     "Type": {
+      "$id": "102",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "103",
+     "Name": "nonRequiredString",
+     "SerializedName": "nonRequiredString",
+     "Description": "Optional string",
+     "Type": {
+      "$id": "104",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "105",
+     "Name": "nonRequiredInt",
+     "SerializedName": "nonRequiredInt",
+     "Description": "Optional int",
+     "Type": {
+      "$id": "106",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "107",
+     "Name": "requiredNullableInt",
+     "SerializedName": "requiredNullableInt",
+     "Description": "Required nullable int",
+     "Type": {
+      "$id": "108",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "109",
+     "Name": "requiredNullableString",
+     "SerializedName": "requiredNullableString",
+     "Description": "Required nullable string",
+     "Type": {
+      "$id": "110",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "111",
+     "Name": "nonRequiredNullableInt",
+     "SerializedName": "nonRequiredNullableInt",
+     "Description": "Optional nullable int",
+     "Type": {
+      "$id": "112",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": true
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "113",
+     "Name": "nonRequiredNullableString",
+     "SerializedName": "nonRequiredNullableString",
+     "Description": "Optional nullable string",
+     "Type": {
+      "$id": "114",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": true
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "115",
+     "Name": "requiredReadonlyInt",
+     "SerializedName": "requiredReadonlyInt",
+     "Description": "Required readonly int",
+     "Type": {
+      "$id": "116",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "117",
+     "Name": "nonRequiredReadonlyInt",
+     "SerializedName": "nonRequiredReadonlyInt",
+     "Description": "Optional readonly int",
+     "Type": {
+      "$id": "118",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "119",
+     "Name": "requiredModel",
+     "SerializedName": "requiredModel",
+     "Description": "Required model with discriminator",
+     "Type": {
+      "$id": "120",
+      "Name": "BaseModelWithDiscriminator",
+      "Namespace": "ModelsTypeSpec",
+      "Description": "Base model with discriminator property.",
+      "IsNullable": false,
+      "DiscriminatorPropertyName": "discriminatorProperty",
+      "Usage": "RoundTrip",
+      "Properties": [
+       {
+        "$id": "121",
+        "Name": "discriminatorProperty",
+        "SerializedName": "discriminatorProperty",
+        "Description": "Discriminator",
+        "IsRequired": true,
+        "IsReadOnly": false,
+        "IsNullable": false,
+        "Type": {
+         "$id": "122",
+         "Name": "string",
+         "Kind": "String",
+         "IsNullable": false
+        },
+        "IsDiscriminator": true
+       },
+       {
+        "$id": "123",
+        "Name": "optionalPropertyOnBase",
+        "SerializedName": "optionalPropertyOnBase",
+        "Description": "Optional property on base",
+        "Type": {
+         "$id": "124",
+         "Name": "string",
+         "Kind": "String",
+         "IsNullable": false
+        },
+        "IsRequired": false,
+        "IsReadOnly": false
+       },
+       {
+        "$id": "125",
+        "Name": "requiredPropertyOnBase",
+        "SerializedName": "requiredPropertyOnBase",
+        "Description": "Required property on base",
+        "Type": {
+         "$id": "126",
+         "Name": "int32",
+         "Kind": "Int32",
+         "IsNullable": false
+        },
+        "IsRequired": true,
+        "IsReadOnly": false
+       }
+      ]
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "127",
+     "Name": "requiredFixedStringEnum",
+     "SerializedName": "requiredFixedStringEnum",
+     "Description": "Required fixed string enum",
+     "Type": {
+      "$ref": "2"
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "128",
+     "Name": "requiredFixedIntEnum",
+     "SerializedName": "requiredFixedIntEnum",
+     "Description": "Required fixed int enum",
+     "Type": {
+      "$ref": "6"
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "129",
+     "Name": "requiredExtensibleEnum",
+     "SerializedName": "requiredExtensibleEnum",
+     "Description": "Required extensible enum",
+     "Type": {
+      "$ref": "10"
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "130",
+     "Name": "requiredList",
+     "SerializedName": "requiredList",
+     "Description": "Required collection",
+     "Type": {
+      "$id": "131",
+      "Name": "Array",
+      "ElementType": {
+       "$ref": "57"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "132",
+     "Name": "requiredIntRecord",
+     "SerializedName": "requiredIntRecord",
+     "Description": "Required int record",
+     "Type": {
+      "$id": "133",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "134",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$id": "135",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "136",
+     "Name": "requiredStringRecord",
+     "SerializedName": "requiredStringRecord",
+     "Description": "Required string record",
+     "Type": {
+      "$id": "137",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "138",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$id": "139",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "140",
+     "Name": "requiredModelRecord",
+     "SerializedName": "requiredModelRecord",
+     "Description": "Required Model Record",
+     "Type": {
+      "$id": "141",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "142",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "61"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "143",
+     "Name": "requiredBytes",
+     "SerializedName": "requiredBytes",
+     "Description": "Required bytes",
+     "Type": {
+      "$id": "144",
+      "Name": "bytes",
+      "Kind": "Bytes",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "145",
+     "Name": "optionalBytes",
+     "SerializedName": "optionalBytes",
+     "Description": "Optional bytes",
+     "Type": {
+      "$id": "146",
+      "Name": "bytes",
+      "Kind": "Bytes",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "147",
+     "Name": "requiredUint8Array",
+     "SerializedName": "requiredUint8Array",
+     "Description": "Required uint8[]",
+     "Type": {
+      "$id": "148",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "149",
+       "Name": "uint8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "150",
+     "Name": "optionalUint8Array",
+     "SerializedName": "optionalUint8Array",
+     "Description": "Optional uint8[]",
+     "Type": {
+      "$id": "151",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "152",
+       "Name": "uint8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "153",
+     "Name": "requiredUnknown",
+     "SerializedName": "requiredUnknown",
+     "Description": "Required unknown",
+     "Type": {
+      "$id": "154",
+      "Name": "Intrinsic",
+      "Kind": "unknown",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "155",
+     "Name": "optionalUnknown",
+     "SerializedName": "optionalUnknown",
+     "Description": "Optional unknown",
+     "Type": {
+      "$id": "156",
+      "Name": "Intrinsic",
+      "Kind": "unknown",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "157",
+     "Name": "requiredInt8Array",
+     "SerializedName": "requiredInt8Array",
+     "Description": "Required int8[]",
+     "Type": {
+      "$id": "158",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "159",
+       "Name": "int8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "160",
+     "Name": "optionalInt8Array",
+     "SerializedName": "optionalInt8Array",
+     "Description": "Optional int8[]",
+     "Type": {
+      "$id": "161",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "162",
+       "Name": "int8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "163",
+     "Name": "requiredNullableIntList",
+     "SerializedName": "requiredNullableIntList",
+     "Description": "Required nullable int list",
+     "Type": {
+      "$id": "164",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "165",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "166",
+     "Name": "requiredNullableStringList",
+     "SerializedName": "requiredNullableStringList",
+     "Description": "Required nullable string list",
+     "Type": {
+      "$id": "167",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "168",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "169",
+     "Name": "nonRequiredNullableIntList",
+     "SerializedName": "nonRequiredNullableIntList",
+     "Description": "Optional nullable model list",
+     "Type": {
+      "$id": "170",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "171",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": true
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "172",
+     "Name": "nonRequiredNullableStringList",
+     "SerializedName": "nonRequiredNullableStringList",
+     "Description": "Optional nullable string list",
+     "Type": {
+      "$id": "173",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "174",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": true
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
-   "$ref": "78"
+   "$ref": "120"
   },
   {
-   "$ref": "85"
+   "$id": "175",
+   "Name": "DerivedModelWithDiscriminatorA",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Deriver model with discriminator property.",
+   "IsNullable": false,
+   "DiscriminatorValue": "A",
+   "BaseModel": {
+    "$ref": "120"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "176",
+     "Name": "requiredString",
+     "SerializedName": "requiredString",
+     "Description": "Required string.",
+     "Type": {
+      "$id": "177",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
-   "$ref": "88"
+   "$id": "178",
+   "Name": "DerivedModelWithDiscriminatorB",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Deriver model with discriminator property.",
+   "IsNullable": false,
+   "DiscriminatorValue": "B",
+   "BaseModel": {
+    "$ref": "120"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "179",
+     "Name": "requiredInt",
+     "SerializedName": "requiredInt",
+     "Description": "Required int.",
+     "Type": {
+      "$id": "180",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
-   "$ref": "139"
+   "$id": "181",
+   "Name": "RoundTripPrimitiveModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Model used both as input and output with primitive types",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "47"
+   },
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "182",
+     "Name": "requiredString",
+     "SerializedName": "requiredString",
+     "Description": "Required string, illustrating a reference type property.",
+     "Type": {
+      "$id": "183",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "184",
+     "Name": "requiredInt",
+     "SerializedName": "requiredInt",
+     "Description": "Required int, illustrating a value type property.",
+     "Type": {
+      "$id": "185",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "186",
+     "Name": "requiredInt64",
+     "SerializedName": "requiredInt64",
+     "Description": "Required int64, illustrating a value type property.",
+     "Type": {
+      "$id": "187",
+      "Name": "int64",
+      "Kind": "Int64",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "188",
+     "Name": "requiredSafeInt",
+     "SerializedName": "requiredSafeInt",
+     "Description": "Required safeint, illustrating a value type property.",
+     "Type": {
+      "$id": "189",
+      "Name": "safeint",
+      "Kind": "Int64",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "190",
+     "Name": "requiredFloat",
+     "SerializedName": "requiredFloat",
+     "Description": "Required float, illustrating a value type property.",
+     "Type": {
+      "$id": "191",
+      "Name": "float32",
+      "Kind": "Float32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "192",
+     "Name": "required_Double",
+     "SerializedName": "required_Double",
+     "Description": "Required double, illustrating a value type property.",
+     "Type": {
+      "$id": "193",
+      "Name": "float64",
+      "Kind": "Float64",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "194",
+     "Name": "requiredBoolean",
+     "SerializedName": "requiredBoolean",
+     "Description": "Required bolean, illustrating a value type property.",
+     "Type": {
+      "$id": "195",
+      "Name": "boolean",
+      "Kind": "Boolean",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "196",
+     "Name": "requiredDateTimeOffset",
+     "SerializedName": "requiredDateTimeOffset",
+     "Description": "Required date time offset, illustrating a reference type property.",
+     "Type": {
+      "$id": "197",
+      "Name": "utcDateTime",
+      "Kind": "DateTime",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "198",
+     "Name": "requiredTimeSpan",
+     "SerializedName": "requiredTimeSpan",
+     "Description": "Required time span, illustrating a value type property.",
+     "Type": {
+      "$id": "199",
+      "Name": "duration",
+      "Kind": "DurationISO8601",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "200",
+     "Name": "requiredCollectionWithNullableFloatElement",
+     "SerializedName": "requiredCollectionWithNullableFloatElement",
+     "Description": "Required collection of which the element is a nullable float",
+     "Type": {
+      "$id": "201",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "202",
+       "Name": "float32",
+       "Kind": "Float32",
+       "IsNullable": true
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
    "$id": "203",
@@ -1600,7 +1568,7 @@
       "$id": "215",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": false
      },
@@ -1613,7 +1581,7 @@
      "SerializedName": "optionalModel",
      "Description": "Optional model.",
      "Type": {
-      "$ref": "48"
+      "$ref": "62"
      },
      "IsRequired": false,
      "IsReadOnly": false
@@ -1651,51 +1619,20 @@
          "IsRequired": false,
          "IsReadOnly": false
         }
-       ],
-       "DerivedModels": [
-        {
-         "$id": "222",
-         "Name": "DerivedModelWithProperties",
-         "Namespace": "ModelsTypeSpec",
-         "Description": "Derived model with properties",
-         "IsNullable": false,
-         "BaseModel": {
-          "$ref": "219"
-         },
-         "Usage": "None",
-         "Properties": [
-          {
-           "$id": "223",
-           "Name": "requiredList",
-           "SerializedName": "requiredList",
-           "Description": "Required collection",
-           "Type": {
-            "$id": "224",
-            "Name": "Array",
-            "ElementType": {
-             "$ref": "51"
-            },
-            "IsNullable": false
-           },
-           "IsRequired": true,
-           "IsReadOnly": false
-          }
-         ]
-        }
        ]
       },
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "225",
+        "$id": "222",
         "Name": "requiredList",
         "SerializedName": "requiredList",
         "Description": "Required collection",
         "Type": {
-         "$id": "226",
+         "$id": "223",
          "Name": "Array",
          "ElementType": {
-          "$ref": "51"
+          "$ref": "57"
          },
          "IsNullable": false
         },
@@ -1708,7 +1645,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "227",
+     "$id": "224",
      "Name": "optionalFixedStringEnum",
      "SerializedName": "optionalFixedStringEnum",
      "Description": "Optional fixed string enum",
@@ -1719,7 +1656,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "228",
+     "$id": "225",
      "Name": "optionalExtensibleEnum",
      "SerializedName": "optionalExtensibleEnum",
      "Description": "Optional extensible enum",
@@ -1730,21 +1667,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "229",
+     "$id": "226",
      "Name": "optionalIntRecord",
      "SerializedName": "optionalIntRecord",
      "Description": "Optional int record",
      "Type": {
-      "$id": "230",
+      "$id": "227",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "231",
+       "$id": "228",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "232",
+       "$id": "229",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1755,24 +1692,46 @@
      "IsReadOnly": false
     },
     {
-     "$id": "233",
+     "$id": "230",
      "Name": "optionalStringRecord",
      "SerializedName": "optionalStringRecord",
      "Description": "Optional string record",
      "Type": {
-      "$id": "234",
+      "$id": "231",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "235",
+       "$id": "232",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
+       "$id": "233",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "234",
+     "Name": "optionalModelRecord",
+     "SerializedName": "optionalModelRecord",
+     "Description": "Optional model record",
+     "Type": {
+      "$id": "235",
+      "Name": "Dictionary",
+      "KeyType": {
        "$id": "236",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "61"
       },
       "IsNullable": false
      },
@@ -1781,33 +1740,11 @@
     },
     {
      "$id": "237",
-     "Name": "optionalModelRecord",
-     "SerializedName": "optionalModelRecord",
-     "Description": "Optional model record",
-     "Type": {
-      "$id": "238",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "239",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "ValueType": {
-       "$ref": "55"
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "240",
      "Name": "optionalPlainDate",
      "SerializedName": "optionalPlainDate",
      "Description": "Optional plainDate",
      "Type": {
-      "$id": "241",
+      "$id": "238",
       "Name": "plainDate",
       "Kind": "Date",
       "IsNullable": false
@@ -1816,12 +1753,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "242",
+     "$id": "239",
      "Name": "optionalPlainTime",
      "SerializedName": "optionalPlainTime",
      "Description": "Optional plainTime",
      "Type": {
-      "$id": "243",
+      "$id": "240",
       "Name": "plainTime",
       "Kind": "Time",
       "IsNullable": false
@@ -1830,15 +1767,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "244",
+     "$id": "241",
      "Name": "optionalCollectionWithNullableIntElement",
      "SerializedName": "optionalCollectionWithNullableIntElement",
      "Description": "Optional collection of which the element is a nullable int",
      "Type": {
-      "$id": "245",
+      "$id": "242",
       "Name": "Array",
       "ElementType": {
-       "$id": "246",
+       "$id": "243",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": true
@@ -1857,7 +1794,7 @@
    "$ref": "218"
   },
   {
-   "$id": "247",
+   "$id": "244",
    "Name": "RoundTripReadOnlyModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Output model with readonly properties.",
@@ -1865,12 +1802,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "248",
+     "$id": "245",
      "Name": "requiredReadonlyString",
      "SerializedName": "requiredReadonlyString",
      "Description": "Required string, illustrating a readonly reference type property.",
      "Type": {
-      "$id": "249",
+      "$id": "246",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -1879,12 +1816,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "250",
+     "$id": "247",
      "Name": "requiredReadonlyInt",
      "SerializedName": "requiredReadonlyInt",
      "Description": "Required int, illustrating a readonly value type property.",
      "Type": {
-      "$id": "251",
+      "$id": "248",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -1893,12 +1830,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "252",
+     "$id": "249",
      "Name": "optionalReadonlyString",
      "SerializedName": "optionalReadonlyString",
      "Description": "Optional string, illustrating a readonly reference type property.",
      "Type": {
-      "$id": "253",
+      "$id": "250",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -1907,12 +1844,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "254",
+     "$id": "251",
      "Name": "optionalReadonlyInt",
      "SerializedName": "optionalReadonlyInt",
      "Description": "Optional int, illustrating a readonly value type property.",
      "Type": {
-      "$id": "255",
+      "$id": "252",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -1921,29 +1858,29 @@
      "IsReadOnly": true
     },
     {
-     "$id": "256",
+     "$id": "253",
      "Name": "requiredReadonlyModel",
      "SerializedName": "requiredReadonlyModel",
      "Description": "Required readonly model.",
      "Type": {
-      "$ref": "48"
+      "$ref": "62"
      },
      "IsRequired": true,
      "IsReadOnly": true
     },
     {
-     "$id": "257",
+     "$id": "254",
      "Name": "optionalReadonlyModel",
      "SerializedName": "optionalReadonlyModel",
      "Description": "Optional readonly model.",
      "Type": {
-      "$ref": "48"
+      "$ref": "62"
      },
      "IsRequired": false,
      "IsReadOnly": true
     },
     {
-     "$id": "258",
+     "$id": "255",
      "Name": "requiredReadonlyFixedStringEnum",
      "SerializedName": "requiredReadonlyFixedStringEnum",
      "Description": "Required readonly fixed string enum",
@@ -1954,7 +1891,7 @@
      "IsReadOnly": true
     },
     {
-     "$id": "259",
+     "$id": "256",
      "Name": "requiredReadonlyExtensibleEnum",
      "SerializedName": "requiredReadonlyExtensibleEnum",
      "Description": "Required readonly extensible enum",
@@ -1965,7 +1902,7 @@
      "IsReadOnly": true
     },
     {
-     "$id": "260",
+     "$id": "257",
      "Name": "optionalReadonlyFixedStringEnum",
      "SerializedName": "optionalReadonlyFixedStringEnum",
      "Description": "Optional readonly fixed string enum",
@@ -1976,7 +1913,7 @@
      "IsReadOnly": true
     },
     {
-     "$id": "261",
+     "$id": "258",
      "Name": "optionalReadonlyExtensibleEnum",
      "SerializedName": "optionalReadonlyExtensibleEnum",
      "Description": "Optional readonly extensible enum",
@@ -1987,17 +1924,36 @@
      "IsReadOnly": true
     },
     {
-     "$id": "262",
+     "$id": "259",
      "Name": "requiredReadonlyStringList",
      "SerializedName": "requiredReadonlyStringList",
      "Description": "Required readonly string collection.",
+     "Type": {
+      "$id": "260",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "261",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "262",
+     "Name": "requiredReadonlyIntList",
+     "SerializedName": "requiredReadonlyIntList",
+     "Description": "Required readonly int collection.",
      "Type": {
       "$id": "263",
       "Name": "Array",
       "ElementType": {
        "$id": "264",
-       "Name": "string",
-       "Kind": "String",
+       "Name": "int32",
+       "Kind": "Int32",
        "IsNullable": false
       },
       "IsNullable": false
@@ -2007,33 +1963,14 @@
     },
     {
      "$id": "265",
-     "Name": "requiredReadonlyIntList",
-     "SerializedName": "requiredReadonlyIntList",
-     "Description": "Required readonly int collection.",
-     "Type": {
-      "$id": "266",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "267",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "268",
      "Name": "requiredReadOnlyModelList",
      "SerializedName": "requiredReadOnlyModelList",
      "Description": "Required model collection",
      "Type": {
-      "$id": "269",
+      "$id": "266",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": false
      },
@@ -2041,21 +1978,21 @@
      "IsReadOnly": true
     },
     {
-     "$id": "270",
+     "$id": "267",
      "Name": "requiredReadOnlyIntRecord",
      "SerializedName": "requiredReadOnlyIntRecord",
      "Description": "Required int record",
      "Type": {
-      "$id": "271",
+      "$id": "268",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "272",
+       "$id": "269",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "273",
+       "$id": "270",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -2066,24 +2003,46 @@
      "IsReadOnly": true
     },
     {
-     "$id": "274",
+     "$id": "271",
      "Name": "requiredStringRecord",
      "SerializedName": "requiredStringRecord",
      "Description": "Required string record",
      "Type": {
-      "$id": "275",
+      "$id": "272",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "276",
+       "$id": "273",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
+       "$id": "274",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "275",
+     "Name": "requiredReadOnlyModelRecord",
+     "SerializedName": "requiredReadOnlyModelRecord",
+     "Description": "Required model record",
+     "Type": {
+      "$id": "276",
+      "Name": "Dictionary",
+      "KeyType": {
        "$id": "277",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "61"
       },
       "IsNullable": false
      },
@@ -2092,38 +2051,35 @@
     },
     {
      "$id": "278",
-     "Name": "requiredReadOnlyModelRecord",
-     "SerializedName": "requiredReadOnlyModelRecord",
-     "Description": "Required model record",
+     "Name": "optionalReadonlyStringList",
+     "SerializedName": "optionalReadonlyStringList",
+     "Description": "Optional readonly string collection.",
      "Type": {
       "$id": "279",
-      "Name": "Dictionary",
-      "KeyType": {
+      "Name": "Array",
+      "ElementType": {
        "$id": "280",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
-      "ValueType": {
-       "$ref": "55"
-      },
       "IsNullable": false
      },
-     "IsRequired": true,
+     "IsRequired": false,
      "IsReadOnly": true
     },
     {
      "$id": "281",
-     "Name": "optionalReadonlyStringList",
-     "SerializedName": "optionalReadonlyStringList",
-     "Description": "Optional readonly string collection.",
+     "Name": "optionalReadonlyIntList",
+     "SerializedName": "optionalReadonlyIntList",
+     "Description": "Optional readonly int collection.",
      "Type": {
       "$id": "282",
       "Name": "Array",
       "ElementType": {
        "$id": "283",
-       "Name": "string",
-       "Kind": "String",
+       "Name": "int32",
+       "Kind": "Int32",
        "IsNullable": false
       },
       "IsNullable": false
@@ -2133,33 +2089,14 @@
     },
     {
      "$id": "284",
-     "Name": "optionalReadonlyIntList",
-     "SerializedName": "optionalReadonlyIntList",
-     "Description": "Optional readonly int collection.",
-     "Type": {
-      "$id": "285",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "286",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "287",
      "Name": "optionalReadOnlyModelList",
      "SerializedName": "optionalReadOnlyModelList",
      "Description": "Optional model collection",
      "Type": {
-      "$id": "288",
+      "$id": "285",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": false
      },
@@ -2167,21 +2104,21 @@
      "IsReadOnly": true
     },
     {
-     "$id": "289",
+     "$id": "286",
      "Name": "optionalReadOnlyIntRecord",
      "SerializedName": "optionalReadOnlyIntRecord",
      "Description": "Optional int record",
      "Type": {
-      "$id": "290",
+      "$id": "287",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "291",
+       "$id": "288",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "292",
+       "$id": "289",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -2192,46 +2129,46 @@
      "IsReadOnly": false
     },
     {
-     "$id": "293",
+     "$id": "290",
      "Name": "optionalReadOnlyStringRecord",
      "SerializedName": "optionalReadOnlyStringRecord",
      "Description": "Optional string record",
      "Type": {
-      "$id": "294",
+      "$id": "291",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "295",
+       "$id": "292",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
+       "$id": "293",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "294",
+     "Name": "optionalModelRecord",
+     "SerializedName": "optionalModelRecord",
+     "Description": "Optional model record",
+     "Type": {
+      "$id": "295",
+      "Name": "Dictionary",
+      "KeyType": {
        "$id": "296",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "297",
-     "Name": "optionalModelRecord",
-     "SerializedName": "optionalModelRecord",
-     "Description": "Optional model record",
-     "Type": {
-      "$id": "298",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "299",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
       "ValueType": {
-       "$ref": "55"
+       "$ref": "61"
       },
       "IsNullable": false
      },
@@ -2239,15 +2176,15 @@
      "IsReadOnly": true
     },
     {
-     "$id": "300",
+     "$id": "297",
      "Name": "requiredCollectionWithNullableIntElement",
      "SerializedName": "requiredCollectionWithNullableIntElement",
      "Description": "Required collection of which the element is a nullable int",
      "Type": {
-      "$id": "301",
+      "$id": "298",
       "Name": "Array",
       "ElementType": {
-       "$id": "302",
+       "$id": "299",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": true
@@ -2258,15 +2195,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "303",
+     "$id": "300",
      "Name": "optionalCollectionWithNullableBooleanElement",
      "SerializedName": "optionalCollectionWithNullableBooleanElement",
      "Description": "Optional collection of which the element is a nullable boolean",
      "Type": {
-      "$id": "304",
+      "$id": "301",
       "Name": "Array",
       "ElementType": {
-       "$id": "305",
+       "$id": "302",
        "Name": "boolean",
        "Kind": "Boolean",
        "IsNullable": true
@@ -2279,7 +2216,7 @@
    ]
   },
   {
-   "$id": "306",
+   "$id": "303",
    "Name": "OutputModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Model used only as output",
@@ -2287,12 +2224,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "307",
+     "$id": "304",
      "Name": "requiredString",
      "SerializedName": "requiredString",
      "Description": "Required string",
      "Type": {
-      "$id": "308",
+      "$id": "305",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2301,12 +2238,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "309",
+     "$id": "306",
      "Name": "requiredInt",
      "SerializedName": "requiredInt",
      "Description": "Required int",
      "Type": {
-      "$id": "310",
+      "$id": "307",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -2315,26 +2252,48 @@
      "IsReadOnly": false
     },
     {
-     "$id": "311",
+     "$id": "308",
      "Name": "requiredModel",
      "SerializedName": "requiredModel",
      "Description": "Required model",
      "Type": {
-      "$ref": "48"
+      "$ref": "62"
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
-     "$id": "312",
+     "$id": "309",
      "Name": "requiredList",
      "SerializedName": "requiredList",
      "Description": "Required collection",
      "Type": {
-      "$id": "313",
+      "$id": "310",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "311",
+     "Name": "requiredModelRecord",
+     "SerializedName": "requiredModelRecord",
+     "Description": "Required model record",
+     "Type": {
+      "$id": "312",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "313",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "61"
       },
       "IsNullable": false
      },
@@ -2343,36 +2302,14 @@
     },
     {
      "$id": "314",
-     "Name": "requiredModelRecord",
-     "SerializedName": "requiredModelRecord",
-     "Description": "Required model record",
-     "Type": {
-      "$id": "315",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "316",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "ValueType": {
-       "$ref": "55"
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "317",
      "Name": "optionalList",
      "SerializedName": "optionalList",
      "Description": "Optional model collection",
      "Type": {
-      "$id": "318",
+      "$id": "315",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": false
      },
@@ -2380,15 +2317,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "319",
+     "$id": "316",
      "Name": "optionalNullableList",
      "SerializedName": "optionalNullableList",
      "Description": "Optional model nullable collection",
      "Type": {
-      "$id": "320",
+      "$id": "317",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": true
      },
@@ -2396,10 +2333,32 @@
      "IsReadOnly": false
     },
     {
-     "$id": "321",
+     "$id": "318",
      "Name": "optionalRecord",
      "SerializedName": "optionalRecord",
      "Description": "Optional model record",
+     "Type": {
+      "$id": "319",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "320",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$ref": "61"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "321",
+     "Name": "optionalNullableRecord",
+     "SerializedName": "optionalNullableRecord",
+     "Description": "Optional model nullable record",
      "Type": {
       "$id": "322",
       "Name": "Dictionary",
@@ -2410,29 +2369,7 @@
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "55"
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "324",
-     "Name": "optionalNullableRecord",
-     "SerializedName": "optionalNullableRecord",
-     "Description": "Optional model nullable record",
-     "Type": {
-      "$id": "325",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "326",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "ValueType": {
-       "$ref": "55"
+       "$ref": "61"
       },
       "IsNullable": true
      },
@@ -2442,7 +2379,7 @@
    ]
   },
   {
-   "$id": "327",
+   "$id": "324",
    "Name": "InputRecursiveModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Input model that has property of its own type",
@@ -2450,12 +2387,12 @@
    "Usage": "Input",
    "Properties": [
     {
-     "$id": "328",
+     "$id": "325",
      "Name": "message",
      "SerializedName": "message",
      "Description": "Message",
      "Type": {
-      "$id": "329",
+      "$id": "326",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2464,12 +2401,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "330",
+     "$id": "327",
      "Name": "inner",
      "SerializedName": "inner",
      "Description": "Required Record",
      "Type": {
-      "$ref": "327"
+      "$ref": "324"
      },
      "IsRequired": false,
      "IsReadOnly": false
@@ -2477,7 +2414,7 @@
    ]
   },
   {
-   "$id": "331",
+   "$id": "328",
    "Name": "RoundTripRecursiveModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Roundtrip model that has property of its own type",
@@ -2485,12 +2422,12 @@
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "332",
+     "$id": "329",
      "Name": "message",
      "SerializedName": "message",
      "Description": "Message",
      "Type": {
-      "$id": "333",
+      "$id": "330",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2499,12 +2436,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "334",
+     "$id": "331",
      "Name": "inner",
      "SerializedName": "inner",
      "Description": "Required Record",
      "Type": {
-      "$ref": "331"
+      "$ref": "328"
      },
      "IsRequired": false,
      "IsReadOnly": false
@@ -2512,7 +2449,7 @@
    ]
   },
   {
-   "$id": "335",
+   "$id": "332",
    "Name": "ErrorModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Output model that has property of its own type",
@@ -2520,12 +2457,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "336",
+     "$id": "333",
      "Name": "message",
      "SerializedName": "message",
      "Description": "Error message",
      "Type": {
-      "$id": "337",
+      "$id": "334",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2534,12 +2471,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "338",
+     "$id": "335",
      "Name": "innerError",
      "SerializedName": "innerError",
      "Description": "Required Record",
      "Type": {
-      "$ref": "335"
+      "$ref": "332"
      },
      "IsRequired": false,
      "IsReadOnly": true
@@ -2547,7 +2484,7 @@
    ]
   },
   {
-   "$id": "339",
+   "$id": "336",
    "Name": "NoUseBase",
    "Namespace": "ModelsTypeSpec",
    "Description": "Base model",
@@ -2555,12 +2492,12 @@
    "Usage": "None",
    "Properties": [
     {
-     "$id": "340",
+     "$id": "337",
      "Name": "baseModelProp",
      "SerializedName": "baseModelProp",
      "Description": "base model property",
      "Type": {
-      "$id": "341",
+      "$id": "338",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2568,60 +2505,29 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "342",
-     "Name": "RoundTripOnNoUse",
-     "Namespace": "ModelsTypeSpec",
-     "Description": "Derived model",
-     "IsNullable": false,
-     "BaseModel": {
-      "$ref": "339"
-     },
-     "Usage": "None",
-     "Properties": [
-      {
-       "$id": "343",
-       "Name": "requiredList",
-       "SerializedName": "requiredList",
-       "Description": "Required collection",
-       "Type": {
-        "$id": "344",
-        "Name": "Array",
-        "ElementType": {
-         "$ref": "51"
-        },
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
-    }
    ]
   },
   {
-   "$id": "345",
+   "$id": "339",
    "Name": "RoundTripOnNoUse",
    "Namespace": "ModelsTypeSpec",
    "Description": "Derived model",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "339"
+    "$ref": "336"
    },
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "346",
+     "$id": "340",
      "Name": "requiredList",
      "SerializedName": "requiredList",
      "Description": "Required collection",
      "Type": {
-      "$id": "347",
+      "$id": "341",
       "Name": "Array",
       "ElementType": {
-       "$ref": "51"
+       "$ref": "57"
       },
       "IsNullable": false
      },
@@ -2631,7 +2537,7 @@
    ]
   },
   {
-   "$id": "348",
+   "$id": "342",
    "Name": "SingleBase",
    "Namespace": "ModelsTypeSpec",
    "Description": "Single base model without any child model.",
@@ -2640,7 +2546,7 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "349",
+     "$id": "343",
      "Name": "kind",
      "SerializedName": "kind",
      "Description": "Discriminator",
@@ -2648,7 +2554,7 @@
      "IsReadOnly": false,
      "IsNullable": false,
      "Type": {
-      "$id": "350",
+      "$id": "344",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2656,12 +2562,12 @@
      "IsDiscriminator": true
     },
     {
-     "$id": "351",
+     "$id": "345",
      "Name": "size",
      "SerializedName": "size",
      "Description": "",
      "Type": {
-      "$id": "352",
+      "$id": "346",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -2672,7 +2578,7 @@
    ]
   },
   {
-   "$id": "353",
+   "$id": "347",
    "Name": "Facet",
    "Namespace": "ModelsTypeSpec",
    "Description": "Facet",
@@ -2680,12 +2586,12 @@
    "Usage": "None",
    "Properties": [
     {
-     "$id": "354",
+     "$id": "348",
      "Name": "field",
      "SerializedName": "field",
      "Description": "A field to facet by, where the field is attributed as 'facetable'",
      "Type": {
-      "$id": "355",
+      "$id": "349",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2693,121 +2599,28 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$id": "356",
-     "Name": "NumericValuesFacetint32",
-     "Namespace": "ModelsTypeSpec",
-     "IsNullable": false,
-     "BaseModel": {
-      "$ref": "353"
-     },
-     "Usage": "None",
-     "Properties": [
-      {
-       "$id": "357",
-       "Name": "values",
-       "SerializedName": "values",
-       "Description": "The facet ranges to produce. The values must be listed in ascending order to get the expected results. For example, values=10,20 produces three buckets: one for base rate 0 up to but not including 10, one for 10 up to but not including 20, and one for 20 and higher.",
-       "Type": {
-        "$id": "358",
-        "Name": "Array",
-        "ElementType": {
-         "$id": "359",
-         "Name": "int32",
-         "Kind": "Int32",
-         "IsNullable": false
-        },
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      },
-      {
-       "$id": "360",
-       "Name": "value",
-       "SerializedName": "value",
-       "Description": "",
-       "Type": {
-        "$id": "361",
-        "Name": "int32",
-        "Kind": "Int32",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ],
-     "DerivedModels": [
-      {
-       "$id": "362",
-       "Name": "Int32ValuesFacet",
-       "Namespace": "ModelsTypeSpec",
-       "Description": "Facets an int32 field by the specified value ranges.",
-       "IsNullable": false,
-       "BaseModel": {
-        "$ref": "356"
-       },
-       "Usage": "None",
-       "Properties": [
-        {
-         "$id": "363",
-         "Name": "kind",
-         "SerializedName": "kind",
-         "Description": "The facet type.",
-         "Type": {
-          "$id": "364",
-          "Name": "Literal",
-          "LiteralValueType": {
-           "$id": "365",
-           "Name": "Int32ValuesFacet_kind",
-           "EnumValueType": "String",
-           "AllowedValues": [
-            {
-             "$id": "366",
-             "Name": "Int32Values",
-             "Value": "Int32Values",
-             "Description": "Int32Values"
-            }
-           ],
-           "Namespace": "ModelsTypeSpec",
-           "Description": "The Int32ValuesFacet_kind",
-           "IsExtensible": true,
-           "IsNullable": false
-          },
-          "Value": "Int32Values",
-          "IsNullable": false
-         },
-         "IsRequired": true,
-         "IsReadOnly": false
-        }
-       ]
-      }
-     ]
-    }
    ]
   },
   {
-   "$id": "367",
+   "$id": "350",
    "Name": "NumericValuesFacetint32",
    "Namespace": "ModelsTypeSpec",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "353"
+    "$ref": "347"
    },
    "Usage": "None",
    "Properties": [
     {
-     "$id": "368",
+     "$id": "351",
      "Name": "values",
      "SerializedName": "values",
      "Description": "The facet ranges to produce. The values must be listed in ascending order to get the expected results. For example, values=10,20 produces three buckets: one for base rate 0 up to but not including 10, one for 10 up to but not including 20, and one for 20 and higher.",
      "Type": {
-      "$id": "369",
+      "$id": "352",
       "Name": "Array",
       "ElementType": {
-       "$id": "370",
+       "$id": "353",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -2818,12 +2631,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "371",
+     "$id": "354",
      "Name": "value",
      "SerializedName": "value",
      "Description": "",
      "Type": {
-      "$id": "372",
+      "$id": "355",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -2831,31 +2644,26 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
-    {
-     "$ref": "362"
-    }
    ]
   },
   {
-   "$id": "373",
+   "$id": "356",
    "Name": "Int32ValuesFacet",
    "Namespace": "ModelsTypeSpec",
    "Description": "Facets an int32 field by the specified value ranges.",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "367"
+    "$ref": "350"
    },
    "Usage": "Input",
    "Properties": [
     {
-     "$id": "374",
+     "$id": "357",
      "Name": "kind",
      "SerializedName": "kind",
      "Description": "The facet type.",
      "Type": {
-      "$id": "375",
+      "$id": "358",
       "Name": "Literal",
       "LiteralValueType": {
        "$ref": "22"
@@ -2869,7 +2677,7 @@
    ]
   },
   {
-   "$id": "376",
+   "$id": "359",
    "Name": "Foo",
    "Namespace": "ModelsTypeSpec",
    "Description": "This is a model.",
@@ -2877,12 +2685,12 @@
    "Usage": "None",
    "Properties": [
     {
-     "$id": "377",
+     "$id": "360",
      "Name": "id",
      "SerializedName": "id",
      "Description": "id of Foo",
      "Type": {
-      "$id": "378",
+      "$id": "361",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2891,12 +2699,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "379",
+     "$id": "362",
      "Name": "name",
      "SerializedName": "name",
      "Description": "name of Foo",
      "Type": {
-      "$id": "380",
+      "$id": "363",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2909,21 +2717,21 @@
  ],
  "Clients": [
   {
-   "$id": "381",
+   "$id": "364",
    "Name": "ModelsTypeSpecClient",
    "Description": "CADL project to test various types of models.",
    "Operations": [
     {
-     "$id": "382",
+     "$id": "365",
      "Name": "getOutputDiscriminatorModel",
      "ResourceName": "ModelsTypeSpec",
      "Parameters": [
       {
-       "$id": "383",
+       "$id": "366",
        "Name": "endpoint",
        "NameInRequest": "endpoint",
        "Type": {
-        "$id": "384",
+        "$id": "367",
         "Name": "Uri",
         "Kind": "Uri",
         "IsNullable": false
@@ -2939,11 +2747,11 @@
        "Kind": "Client"
       },
       {
-       "$id": "385",
+       "$id": "368",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "386",
+        "$id": "369",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -2958,20 +2766,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "387",
+        "$id": "370",
         "Type": {
-         "$ref": "386"
+         "$ref": "369"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "388",
+       "$id": "371",
        "Name": "apiVersion",
        "NameInRequest": "api-version",
        "Description": "",
        "Type": {
-        "$id": "389",
+        "$id": "372",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -2986,9 +2794,9 @@
        "Explode": false,
        "Kind": "Client",
        "DefaultValue": {
-        "$id": "390",
+        "$id": "373",
         "Type": {
-         "$id": "391",
+         "$id": "374",
          "Name": "String",
          "Kind": "String",
          "IsNullable": false
@@ -2999,7 +2807,7 @@
      ],
      "Responses": [
       {
-       "$id": "392",
+       "$id": "375",
        "StatusCodes": [
         200
        ],
@@ -3020,16 +2828,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "393",
+     "$id": "376",
      "Name": "inputToRoundTrip",
      "ResourceName": "ModelsTypeSpec",
      "Description": "Input model that has property of its own type",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "394",
+       "$id": "377",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -3046,11 +2854,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "395",
+       "$id": "378",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "396",
+        "$id": "379",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3065,19 +2873,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "397",
+        "$id": "380",
         "Type": {
-         "$ref": "396"
+         "$ref": "379"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "398",
+       "$id": "381",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "399",
+        "$id": "382",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3092,25 +2900,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "400",
+        "$id": "383",
         "Type": {
-         "$ref": "399"
+         "$ref": "382"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "401",
+       "$id": "384",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "56"
+        "$ref": "98"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3129,16 +2937,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "402",
+     "$id": "385",
      "Name": "inputToRoundTripPrimitive",
      "ResourceName": "ModelsTypeSpec",
      "Description": "Input to RoundTripPrimitive",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "403",
+       "$id": "386",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -3155,11 +2963,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "404",
+       "$id": "387",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "405",
+        "$id": "388",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3174,19 +2982,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "406",
+        "$id": "389",
         "Type": {
-         "$ref": "405"
+         "$ref": "388"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "407",
+       "$id": "390",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "408",
+        "$id": "391",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3201,25 +3009,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "409",
+        "$id": "392",
         "Type": {
-         "$ref": "408"
+         "$ref": "391"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "410",
+       "$id": "393",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "139"
+        "$ref": "181"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3238,16 +3046,16 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "411",
+     "$id": "394",
      "Name": "inputToRoundTripOptional",
      "ResourceName": "ModelsTypeSpec",
      "Description": "Input to RoundTripOptional",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "412",
+       "$id": "395",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -3264,11 +3072,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "413",
+       "$id": "396",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "414",
+        "$id": "397",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3283,19 +3091,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "415",
+        "$id": "398",
         "Type": {
-         "$ref": "414"
+         "$ref": "397"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "416",
+       "$id": "399",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "417",
+        "$id": "400",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3310,20 +3118,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "418",
+        "$id": "401",
         "Type": {
-         "$ref": "417"
+         "$ref": "400"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "419",
+       "$id": "402",
        "StatusCodes": [
         200
        ],
@@ -3347,17 +3155,17 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "420",
+     "$id": "403",
      "Name": "inputToRoundTripReadOnly",
      "ResourceName": "ModelsTypeSpec",
      "Deprecated": "deprecated for test",
      "Description": "Input to RoundTripReadOnly",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "421",
+       "$id": "404",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
@@ -3374,11 +3182,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "422",
+       "$id": "405",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "423",
+        "$id": "406",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3393,19 +3201,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "424",
+        "$id": "407",
         "Type": {
-         "$ref": "423"
+         "$ref": "406"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "425",
+       "$id": "408",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "426",
+        "$id": "409",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3420,25 +3228,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "427",
+        "$id": "410",
         "Type": {
-         "$ref": "426"
+         "$ref": "409"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "428",
+       "$id": "411",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "247"
+        "$ref": "244"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3457,20 +3265,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "429",
+     "$id": "412",
      "Name": "roundTripToOutput",
      "ResourceName": "ModelsTypeSpec",
      "Description": "RoundTrip to Output",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "430",
+       "$id": "413",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "56"
+        "$ref": "98"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3483,11 +3291,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "431",
+       "$id": "414",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "432",
+        "$id": "415",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3502,19 +3310,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "433",
+        "$id": "416",
         "Type": {
-         "$ref": "432"
+         "$ref": "415"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "434",
+       "$id": "417",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "435",
+        "$id": "418",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3529,25 +3337,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "436",
+        "$id": "419",
         "Type": {
-         "$ref": "435"
+         "$ref": "418"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "437",
+       "$id": "420",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "306"
+        "$ref": "303"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3566,20 +3374,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "438",
+     "$id": "421",
      "Name": "InputRecursive",
      "ResourceName": "ModelsTypeSpec",
      "Description": "Input recursive model",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "439",
+       "$id": "422",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "327"
+        "$ref": "324"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3592,11 +3400,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "440",
+       "$id": "423",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "441",
+        "$id": "424",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3611,19 +3419,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "442",
+        "$id": "425",
         "Type": {
-         "$ref": "441"
+         "$ref": "424"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "443",
+       "$id": "426",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "444",
+        "$id": "427",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3638,20 +3446,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "445",
+        "$id": "428",
         "Type": {
-         "$ref": "444"
+         "$ref": "427"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "446",
+       "$id": "429",
        "StatusCodes": [
         200
        ],
@@ -3672,20 +3480,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "447",
+     "$id": "430",
      "Name": "roundTripRecursive",
      "ResourceName": "ModelsTypeSpec",
      "Description": "RoundTrip recursive model",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "448",
+       "$id": "431",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "331"
+        "$ref": "328"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3698,11 +3506,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "449",
+       "$id": "432",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "450",
+        "$id": "433",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -3717,12 +3525,235 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "451",
+        "$id": "434",
         "Type": {
-         "$ref": "450"
+         "$ref": "433"
         },
         "Value": "application/json"
        }
+      },
+      {
+       "$id": "435",
+       "Name": "accept",
+       "NameInRequest": "Accept",
+       "Type": {
+        "$id": "436",
+        "Name": "String",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       "Location": "Header",
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsRequired": true,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Constant",
+       "DefaultValue": {
+        "$id": "437",
+        "Type": {
+         "$ref": "436"
+        },
+        "Value": "application/json"
+       }
+      },
+      {
+       "$ref": "371"
+      }
+     ],
+     "Responses": [
+      {
+       "$id": "438",
+       "StatusCodes": [
+        200
+       ],
+       "BodyType": {
+        "$ref": "328"
+       },
+       "BodyMediaType": "Json",
+       "Headers": [],
+       "IsErrorResponse": false
+      }
+     ],
+     "HttpMethod": "PUT",
+     "RequestBodyMediaType": "Json",
+     "Uri": "{endpoint}",
+     "Path": "/roundTripRecursive",
+     "RequestMediaTypes": [
+      "application/json"
+     ],
+     "BufferResponse": true,
+     "GenerateProtocolMethod": true,
+     "GenerateConvenienceMethod": true
+    },
+    {
+     "$id": "439",
+     "Name": "selfReference",
+     "ResourceName": "ModelsTypeSpec",
+     "Description": "Returns model that has property of its own type",
+     "Parameters": [
+      {
+       "$ref": "366"
+      },
+      {
+       "$id": "440",
+       "Name": "accept",
+       "NameInRequest": "Accept",
+       "Type": {
+        "$id": "441",
+        "Name": "String",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       "Location": "Header",
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsRequired": true,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Constant",
+       "DefaultValue": {
+        "$id": "442",
+        "Type": {
+         "$ref": "441"
+        },
+        "Value": "application/json"
+       }
+      },
+      {
+       "$ref": "371"
+      }
+     ],
+     "Responses": [
+      {
+       "$id": "443",
+       "StatusCodes": [
+        200
+       ],
+       "BodyType": {
+        "$ref": "332"
+       },
+       "BodyMediaType": "Json",
+       "Headers": [],
+       "IsErrorResponse": false
+      }
+     ],
+     "HttpMethod": "GET",
+     "RequestBodyMediaType": "None",
+     "Uri": "{endpoint}",
+     "Path": "/selfReference",
+     "BufferResponse": true,
+     "GenerateProtocolMethod": true,
+     "GenerateConvenienceMethod": true
+    },
+    {
+     "$id": "444",
+     "Name": "fixedFloatEnum",
+     "ResourceName": "ModelsTypeSpec",
+     "Description": "Returns model that has property of its own type",
+     "Parameters": [
+      {
+       "$ref": "366"
+      },
+      {
+       "$id": "445",
+       "Name": "input",
+       "NameInRequest": "input",
+       "Type": {
+        "$ref": "14"
+       },
+       "Location": "Query",
+       "IsRequired": true,
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Method"
+      },
+      {
+       "$id": "446",
+       "Name": "accept",
+       "NameInRequest": "Accept",
+       "Type": {
+        "$id": "447",
+        "Name": "String",
+        "Kind": "String",
+        "IsNullable": false
+       },
+       "Location": "Header",
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsRequired": true,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Constant",
+       "DefaultValue": {
+        "$id": "448",
+        "Type": {
+         "$ref": "447"
+        },
+        "Value": "application/json"
+       }
+      },
+      {
+       "$ref": "371"
+      }
+     ],
+     "Responses": [
+      {
+       "$id": "449",
+       "StatusCodes": [
+        200
+       ],
+       "BodyType": {
+        "$ref": "303"
+       },
+       "BodyMediaType": "Json",
+       "Headers": [],
+       "IsErrorResponse": false
+      }
+     ],
+     "HttpMethod": "GET",
+     "RequestBodyMediaType": "None",
+     "Uri": "{endpoint}",
+     "Path": "/fixedFloatEnum",
+     "BufferResponse": true,
+     "GenerateProtocolMethod": true,
+     "GenerateConvenienceMethod": true
+    },
+    {
+     "$id": "450",
+     "Name": "extenisbleIntEnum",
+     "ResourceName": "ModelsTypeSpec",
+     "Description": "Returns model that has property of its own type",
+     "Parameters": [
+      {
+       "$ref": "366"
+      },
+      {
+       "$id": "451",
+       "Name": "input",
+       "NameInRequest": "input",
+       "Type": {
+        "$ref": "18"
+       },
+       "Location": "Query",
+       "IsRequired": true,
+       "IsApiVersion": false,
+       "IsResourceParameter": false,
+       "IsContentType": false,
+       "IsEndpoint": false,
+       "SkipUrlEncoding": false,
+       "Explode": false,
+       "Kind": "Method"
       },
       {
        "$id": "452",
@@ -3752,7 +3783,7 @@
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
@@ -3762,230 +3793,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "331"
-       },
-       "BodyMediaType": "Json",
-       "Headers": [],
-       "IsErrorResponse": false
-      }
-     ],
-     "HttpMethod": "PUT",
-     "RequestBodyMediaType": "Json",
-     "Uri": "{endpoint}",
-     "Path": "/roundTripRecursive",
-     "RequestMediaTypes": [
-      "application/json"
-     ],
-     "BufferResponse": true,
-     "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
-    },
-    {
-     "$id": "456",
-     "Name": "selfReference",
-     "ResourceName": "ModelsTypeSpec",
-     "Description": "Returns model that has property of its own type",
-     "Parameters": [
-      {
-       "$ref": "383"
-      },
-      {
-       "$id": "457",
-       "Name": "accept",
-       "NameInRequest": "Accept",
-       "Type": {
-        "$id": "458",
-        "Name": "String",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "Location": "Header",
-       "IsApiVersion": false,
-       "IsResourceParameter": false,
-       "IsContentType": false,
-       "IsRequired": true,
-       "IsEndpoint": false,
-       "SkipUrlEncoding": false,
-       "Explode": false,
-       "Kind": "Constant",
-       "DefaultValue": {
-        "$id": "459",
-        "Type": {
-         "$ref": "458"
-        },
-        "Value": "application/json"
-       }
-      },
-      {
-       "$ref": "388"
-      }
-     ],
-     "Responses": [
-      {
-       "$id": "460",
-       "StatusCodes": [
-        200
-       ],
-       "BodyType": {
-        "$ref": "335"
-       },
-       "BodyMediaType": "Json",
-       "Headers": [],
-       "IsErrorResponse": false
-      }
-     ],
-     "HttpMethod": "GET",
-     "RequestBodyMediaType": "None",
-     "Uri": "{endpoint}",
-     "Path": "/selfReference",
-     "BufferResponse": true,
-     "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
-    },
-    {
-     "$id": "461",
-     "Name": "fixedFloatEnum",
-     "ResourceName": "ModelsTypeSpec",
-     "Description": "Returns model that has property of its own type",
-     "Parameters": [
-      {
-       "$ref": "383"
-      },
-      {
-       "$id": "462",
-       "Name": "input",
-       "NameInRequest": "input",
-       "Type": {
-        "$ref": "14"
-       },
-       "Location": "Query",
-       "IsRequired": true,
-       "IsApiVersion": false,
-       "IsResourceParameter": false,
-       "IsContentType": false,
-       "IsEndpoint": false,
-       "SkipUrlEncoding": false,
-       "Explode": false,
-       "Kind": "Method"
-      },
-      {
-       "$id": "463",
-       "Name": "accept",
-       "NameInRequest": "Accept",
-       "Type": {
-        "$id": "464",
-        "Name": "String",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "Location": "Header",
-       "IsApiVersion": false,
-       "IsResourceParameter": false,
-       "IsContentType": false,
-       "IsRequired": true,
-       "IsEndpoint": false,
-       "SkipUrlEncoding": false,
-       "Explode": false,
-       "Kind": "Constant",
-       "DefaultValue": {
-        "$id": "465",
-        "Type": {
-         "$ref": "464"
-        },
-        "Value": "application/json"
-       }
-      },
-      {
-       "$ref": "388"
-      }
-     ],
-     "Responses": [
-      {
-       "$id": "466",
-       "StatusCodes": [
-        200
-       ],
-       "BodyType": {
-        "$ref": "306"
-       },
-       "BodyMediaType": "Json",
-       "Headers": [],
-       "IsErrorResponse": false
-      }
-     ],
-     "HttpMethod": "GET",
-     "RequestBodyMediaType": "None",
-     "Uri": "{endpoint}",
-     "Path": "/fixedFloatEnum",
-     "BufferResponse": true,
-     "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
-    },
-    {
-     "$id": "467",
-     "Name": "extenisbleIntEnum",
-     "ResourceName": "ModelsTypeSpec",
-     "Description": "Returns model that has property of its own type",
-     "Parameters": [
-      {
-       "$ref": "383"
-      },
-      {
-       "$id": "468",
-       "Name": "input",
-       "NameInRequest": "input",
-       "Type": {
-        "$ref": "18"
-       },
-       "Location": "Query",
-       "IsRequired": true,
-       "IsApiVersion": false,
-       "IsResourceParameter": false,
-       "IsContentType": false,
-       "IsEndpoint": false,
-       "SkipUrlEncoding": false,
-       "Explode": false,
-       "Kind": "Method"
-      },
-      {
-       "$id": "469",
-       "Name": "accept",
-       "NameInRequest": "Accept",
-       "Type": {
-        "$id": "470",
-        "Name": "String",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "Location": "Header",
-       "IsApiVersion": false,
-       "IsResourceParameter": false,
-       "IsContentType": false,
-       "IsRequired": true,
-       "IsEndpoint": false,
-       "SkipUrlEncoding": false,
-       "Explode": false,
-       "Kind": "Constant",
-       "DefaultValue": {
-        "$id": "471",
-        "Type": {
-         "$ref": "470"
-        },
-        "Value": "application/json"
-       }
-      },
-      {
-       "$ref": "388"
-      }
-     ],
-     "Responses": [
-      {
-       "$id": "472",
-       "StatusCodes": [
-        200
-       ],
-       "BodyType": {
-        "$ref": "306"
+        "$ref": "303"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -4001,20 +3809,20 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "473",
+     "$id": "456",
      "Name": "roundTripToOutputWithNoUseBase",
      "ResourceName": "ModelsTypeSpec",
      "Description": "Returns RoundTripOnNoUse",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "474",
+       "$id": "457",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "345"
+        "$ref": "339"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -4027,11 +3835,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "475",
+       "$id": "458",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "476",
+        "$id": "459",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -4046,19 +3854,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "477",
+        "$id": "460",
         "Type": {
-         "$ref": "476"
+         "$ref": "459"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "478",
+       "$id": "461",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "479",
+        "$id": "462",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -4073,25 +3881,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "480",
+        "$id": "463",
         "Type": {
-         "$ref": "479"
+         "$ref": "462"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "481",
+       "$id": "464",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "345"
+        "$ref": "339"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -4110,23 +3918,23 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "482",
+     "$id": "465",
      "Name": "analyzeConversation",
      "ResourceName": "ModelsTypeSpec",
      "Description": "Resource collection action operation template.",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       },
       {
-       "$id": "483",
+       "$id": "466",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "484",
+        "$id": "467",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -4141,9 +3949,9 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "485",
+        "$id": "468",
         "Type": {
-         "$ref": "484"
+         "$ref": "467"
         },
         "Value": "application/json"
        }
@@ -4151,12 +3959,12 @@
      ],
      "Responses": [
       {
-       "$id": "486",
+       "$id": "469",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "78"
+        "$ref": "120"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -4172,19 +3980,19 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "487",
+     "$id": "470",
      "Name": "getSingleBase",
      "ResourceName": "ModelsTypeSpec",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "488",
+       "$id": "471",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "489",
+        "$id": "472",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -4199,25 +4007,25 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "490",
+        "$id": "473",
         "Type": {
-         "$ref": "489"
+         "$ref": "472"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "491",
+       "$id": "474",
        "StatusCodes": [
         200
        ],
        "BodyType": {
-        "$ref": "348"
+        "$ref": "342"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -4233,19 +4041,19 @@
      "GenerateConvenienceMethod": true
     },
     {
-     "$id": "492",
+     "$id": "475",
      "Name": "genericType",
      "ResourceName": "ModelsTypeSpec",
      "Parameters": [
       {
-       "$ref": "383"
+       "$ref": "366"
       },
       {
-       "$id": "493",
+       "$id": "476",
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "373"
+        "$ref": "356"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -4258,11 +4066,11 @@
        "Kind": "Method"
       },
       {
-       "$id": "494",
+       "$id": "477",
        "Name": "contentType",
        "NameInRequest": "Content-Type",
        "Type": {
-        "$id": "495",
+        "$id": "478",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -4277,19 +4085,19 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "496",
+        "$id": "479",
         "Type": {
-         "$ref": "495"
+         "$ref": "478"
         },
         "Value": "application/json"
        }
       },
       {
-       "$id": "497",
+       "$id": "480",
        "Name": "accept",
        "NameInRequest": "Accept",
        "Type": {
-        "$id": "498",
+        "$id": "481",
         "Name": "String",
         "Kind": "String",
         "IsNullable": false
@@ -4304,20 +4112,20 @@
        "Explode": false,
        "Kind": "Constant",
        "DefaultValue": {
-        "$id": "499",
+        "$id": "482",
         "Type": {
-         "$ref": "498"
+         "$ref": "481"
         },
         "Value": "application/json"
        }
       },
       {
-       "$ref": "388"
+       "$ref": "371"
       }
      ],
      "Responses": [
       {
-       "$id": "500",
+       "$id": "483",
        "StatusCodes": [
         204
        ],
@@ -4339,7 +4147,7 @@
     }
    ],
    "Protocol": {
-    "$id": "501"
+    "$id": "484"
    },
    "Creatable": true
   }

--- a/test/TestProjects/Models-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/Models-TypeSpec/src/Generated/tspCodeModel.json
@@ -194,62 +194,6 @@
   },
   {
    "$id": "27",
-   "Name": "FirstDerivedOutputModel",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "First derived model as an output",
-   "IsNullable": false,
-   "DiscriminatorValue": "first",
-   "BaseModel": {
-    "$ref": "24"
-   },
-   "Usage": "Output",
-   "Properties": [
-    {
-     "$id": "28",
-     "Name": "first",
-     "SerializedName": "first",
-     "Description": "",
-     "Type": {
-      "$id": "29",
-      "Name": "boolean",
-      "Kind": "Boolean",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "30",
-   "Name": "SecondDerivedOutputModel",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "Second derived model as an output",
-   "IsNullable": false,
-   "DiscriminatorValue": "second",
-   "BaseModel": {
-    "$ref": "24"
-   },
-   "Usage": "Output",
-   "Properties": [
-    {
-     "$id": "31",
-     "Name": "second",
-     "SerializedName": "second",
-     "Description": "",
-     "Type": {
-      "$id": "32",
-      "Name": "boolean",
-      "Kind": "Boolean",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "33",
    "Name": "InputModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Model used only as input",
@@ -257,68 +201,68 @@
    "Usage": "Input",
    "Properties": [
     {
-     "$id": "34",
+     "$id": "28",
      "Name": "requiredString",
      "SerializedName": "requiredString",
      "Description": "Required string",
      "Type": {
-      "$id": "35",
+      "$id": "29",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "30",
+     "Name": "requiredInt",
+     "SerializedName": "requiredInt",
+     "Description": "Required int",
+     "Type": {
+      "$id": "31",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "32",
+     "Name": "requiredNullableInt",
+     "SerializedName": "requiredNullableInt",
+     "Description": "Required nullable int",
+     "Type": {
+      "$id": "33",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "34",
+     "Name": "requiredNullableString",
+     "SerializedName": "requiredNullableString",
+     "Description": "Required nullable string",
+     "Type": {
+      "$id": "35",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": true
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
      "$id": "36",
-     "Name": "requiredInt",
-     "SerializedName": "requiredInt",
-     "Description": "Required int",
-     "Type": {
-      "$id": "37",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "38",
-     "Name": "requiredNullableInt",
-     "SerializedName": "requiredNullableInt",
-     "Description": "Required nullable int",
-     "Type": {
-      "$id": "39",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": true
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "40",
-     "Name": "requiredNullableString",
-     "SerializedName": "requiredNullableString",
-     "Description": "Required nullable string",
-     "Type": {
-      "$id": "41",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": true
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "42",
      "Name": "nonRequiredNullableInt",
      "SerializedName": "nonRequiredNullableInt",
      "Description": "Optional nullable int",
      "Type": {
-      "$id": "43",
+      "$id": "37",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": true
@@ -327,12 +271,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "44",
+     "$id": "38",
      "Name": "nonRequiredNullableString",
      "SerializedName": "nonRequiredNullableString",
      "Description": "Optional nullable string",
      "Type": {
-      "$id": "45",
+      "$id": "39",
       "Name": "string",
       "Kind": "String",
       "IsNullable": true
@@ -341,12 +285,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "46",
+     "$id": "40",
      "Name": "requiredModel",
      "SerializedName": "requiredModel",
      "Description": "Required model",
      "Type": {
-      "$id": "47",
+      "$id": "41",
       "Name": "BaseModel",
       "Namespace": "ModelsTypeSpec",
       "Description": "Base model",
@@ -358,26 +302,26 @@
      "IsReadOnly": false
     },
     {
-     "$id": "48",
+     "$id": "42",
      "Name": "requiredModel2",
      "SerializedName": "requiredModel2",
      "Description": "Required model",
      "Type": {
-      "$ref": "47"
+      "$ref": "41"
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
-     "$id": "49",
+     "$id": "43",
      "Name": "requiredIntList",
      "SerializedName": "requiredIntList",
      "Description": "Required primitive value type collection",
      "Type": {
-      "$id": "50",
+      "$id": "44",
       "Name": "Array",
       "ElementType": {
-       "$id": "51",
+       "$id": "45",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -388,15 +332,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "52",
+     "$id": "46",
      "Name": "requiredStringList",
      "SerializedName": "requiredStringList",
      "Description": "Required primitive reference type collection",
      "Type": {
-      "$id": "53",
+      "$id": "47",
       "Name": "Array",
       "ElementType": {
-       "$id": "54",
+       "$id": "48",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -407,15 +351,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "55",
+     "$id": "49",
      "Name": "requiredModelList",
      "SerializedName": "requiredModelList",
      "Description": "Required model collection",
      "Type": {
-      "$id": "56",
+      "$id": "50",
       "Name": "Array",
       "ElementType": {
-       "$id": "57",
+       "$id": "51",
        "Name": "CollectionItem",
        "Namespace": "ModelsTypeSpec",
        "Description": "Collection item model",
@@ -423,46 +367,46 @@
        "Usage": "RoundTrip",
        "Properties": [
         {
-         "$id": "58",
+         "$id": "52",
          "Name": "requiredModelRecord",
          "SerializedName": "requiredModelRecord",
          "Description": "Required model record",
          "Type": {
-          "$id": "59",
+          "$id": "53",
           "Name": "Dictionary",
           "KeyType": {
-           "$id": "60",
+           "$id": "54",
            "Name": "string",
            "Kind": "String",
            "IsNullable": false
           },
           "ValueType": {
-           "$id": "61",
+           "$id": "55",
            "Name": "RecordItem",
            "Namespace": "ModelsTypeSpec",
            "Description": "Record item model",
            "IsNullable": false,
            "BaseModel": {
-            "$id": "62",
+            "$id": "56",
             "Name": "DerivedModel",
             "Namespace": "ModelsTypeSpec",
             "Description": "Derived model",
             "IsNullable": false,
             "BaseModel": {
-             "$ref": "47"
+             "$ref": "41"
             },
             "Usage": "RoundTrip",
             "Properties": [
              {
-              "$id": "63",
+              "$id": "57",
               "Name": "requiredList",
               "SerializedName": "requiredList",
               "Description": "Required collection",
               "Type": {
-               "$id": "64",
+               "$id": "58",
                "Name": "Array",
                "ElementType": {
-                "$ref": "57"
+                "$ref": "51"
                },
                "IsNullable": false
               },
@@ -487,21 +431,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "65",
+     "$id": "59",
      "Name": "requiredModelRecord",
      "SerializedName": "requiredModelRecord",
      "Description": "Required model record",
      "Type": {
-      "$id": "66",
+      "$id": "60",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "67",
+       "$id": "61",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -509,15 +453,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "68",
+     "$id": "62",
      "Name": "requiredCollectionWithNullableFloatElement",
      "SerializedName": "requiredCollectionWithNullableFloatElement",
      "Description": "Required collection of which the element is a nullable float",
      "Type": {
-      "$id": "69",
+      "$id": "63",
       "Name": "Array",
       "ElementType": {
-       "$id": "70",
+       "$id": "64",
        "Name": "float32",
        "Kind": "Float32",
        "IsNullable": true
@@ -528,15 +472,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "71",
+     "$id": "65",
      "Name": "requiredCollectionWithNullableBooleanElement",
      "SerializedName": "requiredCollectionWithNullableBooleanElement",
      "Description": "Required collection of which the element is a nullable boolean",
      "Type": {
-      "$id": "72",
+      "$id": "66",
       "Name": "Array",
       "ElementType": {
-       "$id": "73",
+       "$id": "67",
        "Name": "boolean",
        "Kind": "Boolean",
        "IsNullable": true
@@ -547,15 +491,53 @@
      "IsReadOnly": false
     },
     {
-     "$id": "74",
+     "$id": "68",
      "Name": "requiredNullableModelList",
      "SerializedName": "requiredNullableModelList",
      "Description": "Required model nullable collection",
      "Type": {
-      "$id": "75",
+      "$id": "69",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
+      },
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "70",
+     "Name": "requiredNullableStringList",
+     "SerializedName": "requiredNullableStringList",
+     "Description": "Required string nullable collection",
+     "Type": {
+      "$id": "71",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "72",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": true
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "73",
+     "Name": "requiredNullableIntList",
+     "SerializedName": "requiredNullableIntList",
+     "Description": "Required int nullable collection",
+     "Type": {
+      "$id": "74",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "75",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
       },
       "IsNullable": true
      },
@@ -564,52 +546,52 @@
     },
     {
      "$id": "76",
-     "Name": "requiredNullableStringList",
-     "SerializedName": "requiredNullableStringList",
-     "Description": "Required string nullable collection",
-     "Type": {
-      "$id": "77",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "78",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "IsNullable": true
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "79",
-     "Name": "requiredNullableIntList",
-     "SerializedName": "requiredNullableIntList",
-     "Description": "Required int nullable collection",
-     "Type": {
-      "$id": "80",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "81",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": true
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "82",
      "Name": "nonRequiredModelList",
      "SerializedName": "nonRequiredModelList",
      "Description": "Optional model collection",
      "Type": {
-      "$id": "83",
+      "$id": "77",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "78",
+     "Name": "nonRequiredStringList",
+     "SerializedName": "nonRequiredStringList",
+     "Description": "Optional string collection",
+     "Type": {
+      "$id": "79",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "80",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "81",
+     "Name": "nonRequiredIntList",
+     "SerializedName": "nonRequiredIntList",
+     "Description": "Optional int collection",
+     "Type": {
+      "$id": "82",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "83",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
       },
       "IsNullable": false
      },
@@ -618,52 +600,14 @@
     },
     {
      "$id": "84",
-     "Name": "nonRequiredStringList",
-     "SerializedName": "nonRequiredStringList",
-     "Description": "Optional string collection",
-     "Type": {
-      "$id": "85",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "86",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "87",
-     "Name": "nonRequiredIntList",
-     "SerializedName": "nonRequiredIntList",
-     "Description": "Optional int collection",
-     "Type": {
-      "$id": "88",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "89",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "90",
      "Name": "nonRequiredNullableModelList",
      "SerializedName": "nonRequiredNullableModelList",
      "Description": "Optional model nullable collection",
      "Type": {
-      "$id": "91",
+      "$id": "85",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": true
      },
@@ -671,15 +615,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "92",
+     "$id": "86",
      "Name": "nonRequiredNullableStringList",
      "SerializedName": "nonRequiredNullableStringList",
      "Description": "Optional string nullable collection",
      "Type": {
-      "$id": "93",
+      "$id": "87",
       "Name": "Array",
       "ElementType": {
-       "$id": "94",
+       "$id": "88",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -690,15 +634,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "95",
+     "$id": "89",
      "Name": "nonRequiredNullableIntList",
      "SerializedName": "nonRequiredNullableIntList",
      "Description": "Optional int nullable collection",
      "Type": {
-      "$id": "96",
+      "$id": "90",
       "Name": "Array",
       "ElementType": {
-       "$id": "97",
+       "$id": "91",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -711,35 +655,35 @@
    ]
   },
   {
-   "$ref": "47"
+   "$ref": "41"
   },
   {
-   "$ref": "57"
+   "$ref": "51"
   },
   {
-   "$ref": "62"
+   "$ref": "56"
   },
   {
-   "$ref": "61"
+   "$ref": "55"
   },
   {
-   "$id": "98",
+   "$id": "92",
    "Name": "RoundTripModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Model used both as input and output",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "47"
+    "$ref": "41"
    },
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "99",
+     "$id": "93",
      "Name": "requiredString",
      "SerializedName": "requiredString",
      "Description": "Required string, illustrating a reference type property.",
      "Type": {
-      "$id": "100",
+      "$id": "94",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -748,96 +692,96 @@
      "IsReadOnly": false
     },
     {
-     "$id": "101",
+     "$id": "95",
      "Name": "requiredInt",
      "SerializedName": "requiredInt",
      "Description": "Required int, illustrating a value type property.",
      "Type": {
-      "$id": "102",
+      "$id": "96",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "97",
+     "Name": "nonRequiredString",
+     "SerializedName": "nonRequiredString",
+     "Description": "Optional string",
+     "Type": {
+      "$id": "98",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "99",
+     "Name": "nonRequiredInt",
+     "SerializedName": "nonRequiredInt",
+     "Description": "Optional int",
+     "Type": {
+      "$id": "100",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "101",
+     "Name": "requiredNullableInt",
+     "SerializedName": "requiredNullableInt",
+     "Description": "Required nullable int",
+     "Type": {
+      "$id": "102",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": true
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
      "$id": "103",
-     "Name": "nonRequiredString",
-     "SerializedName": "nonRequiredString",
-     "Description": "Optional string",
+     "Name": "requiredNullableString",
+     "SerializedName": "requiredNullableString",
+     "Description": "Required nullable string",
      "Type": {
       "$id": "104",
       "Name": "string",
       "Kind": "String",
-      "IsNullable": false
+      "IsNullable": true
      },
-     "IsRequired": false,
+     "IsRequired": true,
      "IsReadOnly": false
     },
     {
      "$id": "105",
-     "Name": "nonRequiredInt",
-     "SerializedName": "nonRequiredInt",
-     "Description": "Optional int",
+     "Name": "nonRequiredNullableInt",
+     "SerializedName": "nonRequiredNullableInt",
+     "Description": "Optional nullable int",
      "Type": {
       "$id": "106",
       "Name": "int32",
       "Kind": "Int32",
-      "IsNullable": false
+      "IsNullable": true
      },
      "IsRequired": false,
      "IsReadOnly": false
     },
     {
      "$id": "107",
-     "Name": "requiredNullableInt",
-     "SerializedName": "requiredNullableInt",
-     "Description": "Required nullable int",
-     "Type": {
-      "$id": "108",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": true
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "109",
-     "Name": "requiredNullableString",
-     "SerializedName": "requiredNullableString",
-     "Description": "Required nullable string",
-     "Type": {
-      "$id": "110",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": true
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "111",
-     "Name": "nonRequiredNullableInt",
-     "SerializedName": "nonRequiredNullableInt",
-     "Description": "Optional nullable int",
-     "Type": {
-      "$id": "112",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": true
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "113",
      "Name": "nonRequiredNullableString",
      "SerializedName": "nonRequiredNullableString",
      "Description": "Optional nullable string",
      "Type": {
-      "$id": "114",
+      "$id": "108",
       "Name": "string",
       "Kind": "String",
       "IsNullable": true
@@ -846,12 +790,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "115",
+     "$id": "109",
      "Name": "requiredReadonlyInt",
      "SerializedName": "requiredReadonlyInt",
      "Description": "Required readonly int",
      "Type": {
-      "$id": "116",
+      "$id": "110",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -860,12 +804,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "117",
+     "$id": "111",
      "Name": "nonRequiredReadonlyInt",
      "SerializedName": "nonRequiredReadonlyInt",
      "Description": "Optional readonly int",
      "Type": {
-      "$id": "118",
+      "$id": "112",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -874,12 +818,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "119",
+     "$id": "113",
      "Name": "requiredModel",
      "SerializedName": "requiredModel",
      "Description": "Required model with discriminator",
      "Type": {
-      "$id": "120",
+      "$id": "114",
       "Name": "BaseModelWithDiscriminator",
       "Namespace": "ModelsTypeSpec",
       "Description": "Base model with discriminator property.",
@@ -888,7 +832,7 @@
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "121",
+        "$id": "115",
         "Name": "discriminatorProperty",
         "SerializedName": "discriminatorProperty",
         "Description": "Discriminator",
@@ -896,7 +840,7 @@
         "IsReadOnly": false,
         "IsNullable": false,
         "Type": {
-         "$id": "122",
+         "$id": "116",
          "Name": "string",
          "Kind": "String",
          "IsNullable": false
@@ -904,12 +848,12 @@
         "IsDiscriminator": true
        },
        {
-        "$id": "123",
+        "$id": "117",
         "Name": "optionalPropertyOnBase",
         "SerializedName": "optionalPropertyOnBase",
         "Description": "Optional property on base",
         "Type": {
-         "$id": "124",
+         "$id": "118",
          "Name": "string",
          "Kind": "String",
          "IsNullable": false
@@ -918,12 +862,12 @@
         "IsReadOnly": false
        },
        {
-        "$id": "125",
+        "$id": "119",
         "Name": "requiredPropertyOnBase",
         "SerializedName": "requiredPropertyOnBase",
         "Description": "Required property on base",
         "Type": {
-         "$id": "126",
+         "$id": "120",
          "Name": "int32",
          "Kind": "Int32",
          "IsNullable": false
@@ -937,7 +881,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "127",
+     "$id": "121",
      "Name": "requiredFixedStringEnum",
      "SerializedName": "requiredFixedStringEnum",
      "Description": "Required fixed string enum",
@@ -948,7 +892,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "128",
+     "$id": "122",
      "Name": "requiredFixedIntEnum",
      "SerializedName": "requiredFixedIntEnum",
      "Description": "Required fixed int enum",
@@ -959,7 +903,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "129",
+     "$id": "123",
      "Name": "requiredExtensibleEnum",
      "SerializedName": "requiredExtensibleEnum",
      "Description": "Required extensible enum",
@@ -970,15 +914,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "130",
+     "$id": "124",
      "Name": "requiredList",
      "SerializedName": "requiredList",
      "Description": "Required collection",
      "Type": {
-      "$id": "131",
+      "$id": "125",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": false
      },
@@ -986,21 +930,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "132",
+     "$id": "126",
      "Name": "requiredIntRecord",
      "SerializedName": "requiredIntRecord",
      "Description": "Required int record",
      "Type": {
-      "$id": "133",
+      "$id": "127",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "134",
+       "$id": "128",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "135",
+       "$id": "129",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1011,21 +955,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "136",
+     "$id": "130",
      "Name": "requiredStringRecord",
      "SerializedName": "requiredStringRecord",
      "Description": "Required string record",
      "Type": {
-      "$id": "137",
+      "$id": "131",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "138",
+       "$id": "132",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "139",
+       "$id": "133",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1036,21 +980,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "140",
+     "$id": "134",
      "Name": "requiredModelRecord",
      "SerializedName": "requiredModelRecord",
      "Description": "Required Model Record",
      "Type": {
-      "$id": "141",
+      "$id": "135",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "142",
+       "$id": "136",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -1058,12 +1002,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "143",
+     "$id": "137",
      "Name": "requiredBytes",
      "SerializedName": "requiredBytes",
      "Description": "Required bytes",
      "Type": {
-      "$id": "144",
+      "$id": "138",
       "Name": "bytes",
       "Kind": "Bytes",
       "IsNullable": false
@@ -1072,14 +1016,52 @@
      "IsReadOnly": false
     },
     {
-     "$id": "145",
+     "$id": "139",
      "Name": "optionalBytes",
      "SerializedName": "optionalBytes",
      "Description": "Optional bytes",
      "Type": {
-      "$id": "146",
+      "$id": "140",
       "Name": "bytes",
       "Kind": "Bytes",
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "141",
+     "Name": "requiredUint8Array",
+     "SerializedName": "requiredUint8Array",
+     "Description": "Required uint8[]",
+     "Type": {
+      "$id": "142",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "143",
+       "Name": "uint8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "144",
+     "Name": "optionalUint8Array",
+     "SerializedName": "optionalUint8Array",
+     "Description": "Optional uint8[]",
+     "Type": {
+      "$id": "145",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "146",
+       "Name": "uint8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
       "IsNullable": false
      },
      "IsRequired": false,
@@ -1087,65 +1069,65 @@
     },
     {
      "$id": "147",
-     "Name": "requiredUint8Array",
-     "SerializedName": "requiredUint8Array",
-     "Description": "Required uint8[]",
+     "Name": "requiredUnknown",
+     "SerializedName": "requiredUnknown",
+     "Description": "Required unknown",
      "Type": {
       "$id": "148",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "149",
-       "Name": "uint8",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
+      "Name": "Intrinsic",
+      "Kind": "unknown",
       "IsNullable": false
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
-     "$id": "150",
-     "Name": "optionalUint8Array",
-     "SerializedName": "optionalUint8Array",
-     "Description": "Optional uint8[]",
+     "$id": "149",
+     "Name": "optionalUnknown",
+     "SerializedName": "optionalUnknown",
+     "Description": "Optional unknown",
      "Type": {
-      "$id": "151",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "152",
-       "Name": "uint8",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
+      "$id": "150",
+      "Name": "Intrinsic",
+      "Kind": "unknown",
       "IsNullable": false
      },
      "IsRequired": false,
      "IsReadOnly": false
     },
     {
-     "$id": "153",
-     "Name": "requiredUnknown",
-     "SerializedName": "requiredUnknown",
-     "Description": "Required unknown",
+     "$id": "151",
+     "Name": "requiredInt8Array",
+     "SerializedName": "requiredInt8Array",
+     "Description": "Required int8[]",
      "Type": {
-      "$id": "154",
-      "Name": "Intrinsic",
-      "Kind": "unknown",
+      "$id": "152",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "153",
+       "Name": "int8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
       "IsNullable": false
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
-     "$id": "155",
-     "Name": "optionalUnknown",
-     "SerializedName": "optionalUnknown",
-     "Description": "Optional unknown",
+     "$id": "154",
+     "Name": "optionalInt8Array",
+     "SerializedName": "optionalInt8Array",
+     "Description": "Optional int8[]",
      "Type": {
-      "$id": "156",
-      "Name": "Intrinsic",
-      "Kind": "unknown",
+      "$id": "155",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "156",
+       "Name": "int8",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
       "IsNullable": false
      },
      "IsRequired": false,
@@ -1153,47 +1135,47 @@
     },
     {
      "$id": "157",
-     "Name": "requiredInt8Array",
-     "SerializedName": "requiredInt8Array",
-     "Description": "Required int8[]",
+     "Name": "requiredNullableIntList",
+     "SerializedName": "requiredNullableIntList",
+     "Description": "Required nullable int list",
      "Type": {
       "$id": "158",
       "Name": "Array",
       "ElementType": {
        "$id": "159",
-       "Name": "int8",
+       "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
       },
-      "IsNullable": false
+      "IsNullable": true
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
      "$id": "160",
-     "Name": "optionalInt8Array",
-     "SerializedName": "optionalInt8Array",
-     "Description": "Optional int8[]",
+     "Name": "requiredNullableStringList",
+     "SerializedName": "requiredNullableStringList",
+     "Description": "Required nullable string list",
      "Type": {
       "$id": "161",
       "Name": "Array",
       "ElementType": {
        "$id": "162",
-       "Name": "int8",
-       "Kind": "Int32",
+       "Name": "string",
+       "Kind": "String",
        "IsNullable": false
       },
-      "IsNullable": false
+      "IsNullable": true
      },
-     "IsRequired": false,
+     "IsRequired": true,
      "IsReadOnly": false
     },
     {
      "$id": "163",
-     "Name": "requiredNullableIntList",
-     "SerializedName": "requiredNullableIntList",
-     "Description": "Required nullable int list",
+     "Name": "nonRequiredNullableIntList",
+     "SerializedName": "nonRequiredNullableIntList",
+     "Description": "Optional nullable model list",
      "Type": {
       "$id": "164",
       "Name": "Array",
@@ -1205,14 +1187,14 @@
       },
       "IsNullable": true
      },
-     "IsRequired": true,
+     "IsRequired": false,
      "IsReadOnly": false
     },
     {
      "$id": "166",
-     "Name": "requiredNullableStringList",
-     "SerializedName": "requiredNullableStringList",
-     "Description": "Required nullable string list",
+     "Name": "nonRequiredNullableStringList",
+     "SerializedName": "nonRequiredNullableStringList",
+     "Description": "Optional nullable string list",
      "Type": {
       "$id": "167",
       "Name": "Array",
@@ -1224,126 +1206,32 @@
       },
       "IsNullable": true
      },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "169",
-     "Name": "nonRequiredNullableIntList",
-     "SerializedName": "nonRequiredNullableIntList",
-     "Description": "Optional nullable model list",
-     "Type": {
-      "$id": "170",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "171",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": true
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "172",
-     "Name": "nonRequiredNullableStringList",
-     "SerializedName": "nonRequiredNullableStringList",
-     "Description": "Optional nullable string list",
-     "Type": {
-      "$id": "173",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "174",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "IsNullable": true
-     },
      "IsRequired": false,
      "IsReadOnly": false
     }
    ]
   },
   {
-   "$ref": "120"
+   "$ref": "114"
   },
   {
-   "$id": "175",
-   "Name": "DerivedModelWithDiscriminatorA",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "Deriver model with discriminator property.",
-   "IsNullable": false,
-   "DiscriminatorValue": "A",
-   "BaseModel": {
-    "$ref": "120"
-   },
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "176",
-     "Name": "requiredString",
-     "SerializedName": "requiredString",
-     "Description": "Required string.",
-     "Type": {
-      "$id": "177",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "178",
-   "Name": "DerivedModelWithDiscriminatorB",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "Deriver model with discriminator property.",
-   "IsNullable": false,
-   "DiscriminatorValue": "B",
-   "BaseModel": {
-    "$ref": "120"
-   },
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "179",
-     "Name": "requiredInt",
-     "SerializedName": "requiredInt",
-     "Description": "Required int.",
-     "Type": {
-      "$id": "180",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "181",
+   "$id": "169",
    "Name": "RoundTripPrimitiveModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Model used both as input and output with primitive types",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "47"
+    "$ref": "41"
    },
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "182",
+     "$id": "170",
      "Name": "requiredString",
      "SerializedName": "requiredString",
      "Description": "Required string, illustrating a reference type property.",
      "Type": {
-      "$id": "183",
+      "$id": "171",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -1352,12 +1240,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "184",
+     "$id": "172",
      "Name": "requiredInt",
      "SerializedName": "requiredInt",
      "Description": "Required int, illustrating a value type property.",
      "Type": {
-      "$id": "185",
+      "$id": "173",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -1366,12 +1254,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "186",
+     "$id": "174",
      "Name": "requiredInt64",
      "SerializedName": "requiredInt64",
      "Description": "Required int64, illustrating a value type property.",
      "Type": {
-      "$id": "187",
+      "$id": "175",
       "Name": "int64",
       "Kind": "Int64",
       "IsNullable": false
@@ -1380,12 +1268,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "188",
+     "$id": "176",
      "Name": "requiredSafeInt",
      "SerializedName": "requiredSafeInt",
      "Description": "Required safeint, illustrating a value type property.",
      "Type": {
-      "$id": "189",
+      "$id": "177",
       "Name": "safeint",
       "Kind": "Int64",
       "IsNullable": false
@@ -1394,12 +1282,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "190",
+     "$id": "178",
      "Name": "requiredFloat",
      "SerializedName": "requiredFloat",
      "Description": "Required float, illustrating a value type property.",
      "Type": {
-      "$id": "191",
+      "$id": "179",
       "Name": "float32",
       "Kind": "Float32",
       "IsNullable": false
@@ -1408,12 +1296,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "192",
+     "$id": "180",
      "Name": "required_Double",
      "SerializedName": "required_Double",
      "Description": "Required double, illustrating a value type property.",
      "Type": {
-      "$id": "193",
+      "$id": "181",
       "Name": "float64",
       "Kind": "Float64",
       "IsNullable": false
@@ -1422,12 +1310,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "194",
+     "$id": "182",
      "Name": "requiredBoolean",
      "SerializedName": "requiredBoolean",
      "Description": "Required bolean, illustrating a value type property.",
      "Type": {
-      "$id": "195",
+      "$id": "183",
       "Name": "boolean",
       "Kind": "Boolean",
       "IsNullable": false
@@ -1436,12 +1324,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "196",
+     "$id": "184",
      "Name": "requiredDateTimeOffset",
      "SerializedName": "requiredDateTimeOffset",
      "Description": "Required date time offset, illustrating a reference type property.",
      "Type": {
-      "$id": "197",
+      "$id": "185",
       "Name": "utcDateTime",
       "Kind": "DateTime",
       "IsNullable": false
@@ -1450,12 +1338,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "198",
+     "$id": "186",
      "Name": "requiredTimeSpan",
      "SerializedName": "requiredTimeSpan",
      "Description": "Required time span, illustrating a value type property.",
      "Type": {
-      "$id": "199",
+      "$id": "187",
       "Name": "duration",
       "Kind": "DurationISO8601",
       "IsNullable": false
@@ -1464,15 +1352,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "200",
+     "$id": "188",
      "Name": "requiredCollectionWithNullableFloatElement",
      "SerializedName": "requiredCollectionWithNullableFloatElement",
      "Description": "Required collection of which the element is a nullable float",
      "Type": {
-      "$id": "201",
+      "$id": "189",
       "Name": "Array",
       "ElementType": {
-       "$id": "202",
+       "$id": "190",
        "Name": "float32",
        "Kind": "Float32",
        "IsNullable": true
@@ -1485,7 +1373,7 @@
    ]
   },
   {
-   "$id": "203",
+   "$id": "191",
    "Name": "RoundTripOptionalModel",
    "Namespace": "ModelsTypeSpec",
    "Deprecated": "deprecated for test",
@@ -1494,12 +1382,12 @@
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "204",
+     "$id": "192",
      "Name": "optionalString",
      "SerializedName": "optionalString",
      "Description": "Optional string, illustrating an optional reference type property.",
      "Type": {
-      "$id": "205",
+      "$id": "193",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -1508,12 +1396,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "206",
+     "$id": "194",
      "Name": "optionalInt",
      "SerializedName": "optionalInt",
      "Description": "Optional int, illustrating an optional value type property.",
      "Type": {
-      "$id": "207",
+      "$id": "195",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -1522,15 +1410,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "208",
+     "$id": "196",
      "Name": "optionalStringList",
      "SerializedName": "optionalStringList",
      "Description": "Optional string collection.",
      "Type": {
-      "$id": "209",
+      "$id": "197",
       "Name": "Array",
       "ElementType": {
-       "$id": "210",
+       "$id": "198",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1541,15 +1429,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "211",
+     "$id": "199",
      "Name": "optionalIntList",
      "SerializedName": "optionalIntList",
      "Description": "Optional int collection.",
      "Type": {
-      "$id": "212",
+      "$id": "200",
       "Name": "Array",
       "ElementType": {
-       "$id": "213",
+       "$id": "201",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1560,15 +1448,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "214",
+     "$id": "202",
      "Name": "optionalModelList",
      "SerializedName": "optionalModelList",
      "Description": "Optional model collection",
      "Type": {
-      "$id": "215",
+      "$id": "203",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": false
      },
@@ -1576,29 +1464,29 @@
      "IsReadOnly": false
     },
     {
-     "$id": "216",
+     "$id": "204",
      "Name": "optionalModel",
      "SerializedName": "optionalModel",
      "Description": "Optional model.",
      "Type": {
-      "$ref": "62"
+      "$ref": "56"
      },
      "IsRequired": false,
      "IsReadOnly": false
     },
     {
-     "$id": "217",
+     "$id": "205",
      "Name": "optionalModelWithPropertiesOnBase",
      "SerializedName": "optionalModelWithPropertiesOnBase",
      "Description": "Optional model with properties on base",
      "Type": {
-      "$id": "218",
+      "$id": "206",
       "Name": "DerivedModelWithProperties",
       "Namespace": "ModelsTypeSpec",
       "Description": "Derived model with properties",
       "IsNullable": false,
       "BaseModel": {
-       "$id": "219",
+       "$id": "207",
        "Name": "BaseModelWithProperties",
        "Namespace": "ModelsTypeSpec",
        "Description": "Base model with properties",
@@ -1606,12 +1494,12 @@
        "Usage": "None",
        "Properties": [
         {
-         "$id": "220",
+         "$id": "208",
          "Name": "optionalPropertyOnBase",
          "SerializedName": "optionalPropertyOnBase",
          "Description": "Optional properties on base",
          "Type": {
-          "$id": "221",
+          "$id": "209",
           "Name": "string",
           "Kind": "String",
           "IsNullable": false
@@ -1624,15 +1512,15 @@
       "Usage": "RoundTrip",
       "Properties": [
        {
-        "$id": "222",
+        "$id": "210",
         "Name": "requiredList",
         "SerializedName": "requiredList",
         "Description": "Required collection",
         "Type": {
-         "$id": "223",
+         "$id": "211",
          "Name": "Array",
          "ElementType": {
-          "$ref": "57"
+          "$ref": "51"
          },
          "IsNullable": false
         },
@@ -1645,7 +1533,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "224",
+     "$id": "212",
      "Name": "optionalFixedStringEnum",
      "SerializedName": "optionalFixedStringEnum",
      "Description": "Optional fixed string enum",
@@ -1656,7 +1544,7 @@
      "IsReadOnly": false
     },
     {
-     "$id": "225",
+     "$id": "213",
      "Name": "optionalExtensibleEnum",
      "SerializedName": "optionalExtensibleEnum",
      "Description": "Optional extensible enum",
@@ -1667,21 +1555,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "226",
+     "$id": "214",
      "Name": "optionalIntRecord",
      "SerializedName": "optionalIntRecord",
      "Description": "Optional int record",
      "Type": {
-      "$id": "227",
+      "$id": "215",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "228",
+       "$id": "216",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "229",
+       "$id": "217",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": false
@@ -1692,21 +1580,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "230",
+     "$id": "218",
      "Name": "optionalStringRecord",
      "SerializedName": "optionalStringRecord",
      "Description": "Optional string record",
      "Type": {
-      "$id": "231",
+      "$id": "219",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "232",
+       "$id": "220",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$id": "233",
+       "$id": "221",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -1717,21 +1605,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "234",
+     "$id": "222",
      "Name": "optionalModelRecord",
      "SerializedName": "optionalModelRecord",
      "Description": "Optional model record",
      "Type": {
-      "$id": "235",
+      "$id": "223",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "236",
+       "$id": "224",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -1739,12 +1627,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "237",
+     "$id": "225",
      "Name": "optionalPlainDate",
      "SerializedName": "optionalPlainDate",
      "Description": "Optional plainDate",
      "Type": {
-      "$id": "238",
+      "$id": "226",
       "Name": "plainDate",
       "Kind": "Date",
       "IsNullable": false
@@ -1753,12 +1641,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "239",
+     "$id": "227",
      "Name": "optionalPlainTime",
      "SerializedName": "optionalPlainTime",
      "Description": "Optional plainTime",
      "Type": {
-      "$id": "240",
+      "$id": "228",
       "Name": "plainTime",
       "Kind": "Time",
       "IsNullable": false
@@ -1767,15 +1655,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "241",
+     "$id": "229",
      "Name": "optionalCollectionWithNullableIntElement",
      "SerializedName": "optionalCollectionWithNullableIntElement",
      "Description": "Optional collection of which the element is a nullable int",
      "Type": {
-      "$id": "242",
+      "$id": "230",
       "Name": "Array",
       "ElementType": {
-       "$id": "243",
+       "$id": "231",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": true
@@ -1788,13 +1676,13 @@
    ]
   },
   {
-   "$ref": "219"
+   "$ref": "207"
   },
   {
-   "$ref": "218"
+   "$ref": "206"
   },
   {
-   "$id": "244",
+   "$id": "232",
    "Name": "RoundTripReadOnlyModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Output model with readonly properties.",
@@ -1802,12 +1690,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "245",
+     "$id": "233",
      "Name": "requiredReadonlyString",
      "SerializedName": "requiredReadonlyString",
      "Description": "Required string, illustrating a readonly reference type property.",
      "Type": {
-      "$id": "246",
+      "$id": "234",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -1816,12 +1704,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "247",
+     "$id": "235",
      "Name": "requiredReadonlyInt",
      "SerializedName": "requiredReadonlyInt",
      "Description": "Required int, illustrating a readonly value type property.",
      "Type": {
-      "$id": "248",
+      "$id": "236",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -1830,12 +1718,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "249",
+     "$id": "237",
      "Name": "optionalReadonlyString",
      "SerializedName": "optionalReadonlyString",
      "Description": "Optional string, illustrating a readonly reference type property.",
      "Type": {
-      "$id": "250",
+      "$id": "238",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -1844,12 +1732,12 @@
      "IsReadOnly": true
     },
     {
-     "$id": "251",
+     "$id": "239",
      "Name": "optionalReadonlyInt",
      "SerializedName": "optionalReadonlyInt",
      "Description": "Optional int, illustrating a readonly value type property.",
      "Type": {
-      "$id": "252",
+      "$id": "240",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -1858,29 +1746,29 @@
      "IsReadOnly": true
     },
     {
-     "$id": "253",
+     "$id": "241",
      "Name": "requiredReadonlyModel",
      "SerializedName": "requiredReadonlyModel",
      "Description": "Required readonly model.",
      "Type": {
-      "$ref": "62"
+      "$ref": "56"
      },
      "IsRequired": true,
      "IsReadOnly": true
     },
     {
-     "$id": "254",
+     "$id": "242",
      "Name": "optionalReadonlyModel",
      "SerializedName": "optionalReadonlyModel",
      "Description": "Optional readonly model.",
      "Type": {
-      "$ref": "62"
+      "$ref": "56"
      },
      "IsRequired": false,
      "IsReadOnly": true
     },
     {
-     "$id": "255",
+     "$id": "243",
      "Name": "requiredReadonlyFixedStringEnum",
      "SerializedName": "requiredReadonlyFixedStringEnum",
      "Description": "Required readonly fixed string enum",
@@ -1891,7 +1779,7 @@
      "IsReadOnly": true
     },
     {
-     "$id": "256",
+     "$id": "244",
      "Name": "requiredReadonlyExtensibleEnum",
      "SerializedName": "requiredReadonlyExtensibleEnum",
      "Description": "Required readonly extensible enum",
@@ -1902,7 +1790,7 @@
      "IsReadOnly": true
     },
     {
-     "$id": "257",
+     "$id": "245",
      "Name": "optionalReadonlyFixedStringEnum",
      "SerializedName": "optionalReadonlyFixedStringEnum",
      "Description": "Optional readonly fixed string enum",
@@ -1913,7 +1801,7 @@
      "IsReadOnly": true
     },
     {
-     "$id": "258",
+     "$id": "246",
      "Name": "optionalReadonlyExtensibleEnum",
      "SerializedName": "optionalReadonlyExtensibleEnum",
      "Description": "Optional readonly extensible enum",
@@ -1924,100 +1812,100 @@
      "IsReadOnly": true
     },
     {
-     "$id": "259",
+     "$id": "247",
      "Name": "requiredReadonlyStringList",
      "SerializedName": "requiredReadonlyStringList",
      "Description": "Required readonly string collection.",
      "Type": {
-      "$id": "260",
+      "$id": "248",
       "Name": "Array",
       "ElementType": {
+       "$id": "249",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "250",
+     "Name": "requiredReadonlyIntList",
+     "SerializedName": "requiredReadonlyIntList",
+     "Description": "Required readonly int collection.",
+     "Type": {
+      "$id": "251",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "252",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "253",
+     "Name": "requiredReadOnlyModelList",
+     "SerializedName": "requiredReadOnlyModelList",
+     "Description": "Required model collection",
+     "Type": {
+      "$id": "254",
+      "Name": "Array",
+      "ElementType": {
+       "$ref": "51"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "255",
+     "Name": "requiredReadOnlyIntRecord",
+     "SerializedName": "requiredReadOnlyIntRecord",
+     "Description": "Required int record",
+     "Type": {
+      "$id": "256",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "257",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$id": "258",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "259",
+     "Name": "requiredStringRecord",
+     "SerializedName": "requiredStringRecord",
+     "Description": "Required string record",
+     "Type": {
+      "$id": "260",
+      "Name": "Dictionary",
+      "KeyType": {
        "$id": "261",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "262",
-     "Name": "requiredReadonlyIntList",
-     "SerializedName": "requiredReadonlyIntList",
-     "Description": "Required readonly int collection.",
-     "Type": {
-      "$id": "263",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "264",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "265",
-     "Name": "requiredReadOnlyModelList",
-     "SerializedName": "requiredReadOnlyModelList",
-     "Description": "Required model collection",
-     "Type": {
-      "$id": "266",
-      "Name": "Array",
-      "ElementType": {
-       "$ref": "57"
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "267",
-     "Name": "requiredReadOnlyIntRecord",
-     "SerializedName": "requiredReadOnlyIntRecord",
-     "Description": "Required int record",
-     "Type": {
-      "$id": "268",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "269",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
       "ValueType": {
-       "$id": "270",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "271",
-     "Name": "requiredStringRecord",
-     "SerializedName": "requiredStringRecord",
-     "Description": "Required string record",
-     "Type": {
-      "$id": "272",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "273",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "ValueType": {
-       "$id": "274",
+       "$id": "262",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -2028,21 +1916,21 @@
      "IsReadOnly": true
     },
     {
-     "$id": "275",
+     "$id": "263",
      "Name": "requiredReadOnlyModelRecord",
      "SerializedName": "requiredReadOnlyModelRecord",
      "Description": "Required model record",
      "Type": {
-      "$id": "276",
+      "$id": "264",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "277",
+       "$id": "265",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -2050,100 +1938,100 @@
      "IsReadOnly": true
     },
     {
-     "$id": "278",
+     "$id": "266",
      "Name": "optionalReadonlyStringList",
      "SerializedName": "optionalReadonlyStringList",
      "Description": "Optional readonly string collection.",
      "Type": {
-      "$id": "279",
+      "$id": "267",
       "Name": "Array",
       "ElementType": {
+       "$id": "268",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "269",
+     "Name": "optionalReadonlyIntList",
+     "SerializedName": "optionalReadonlyIntList",
+     "Description": "Optional readonly int collection.",
+     "Type": {
+      "$id": "270",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "271",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "272",
+     "Name": "optionalReadOnlyModelList",
+     "SerializedName": "optionalReadOnlyModelList",
+     "Description": "Optional model collection",
+     "Type": {
+      "$id": "273",
+      "Name": "Array",
+      "ElementType": {
+       "$ref": "51"
+      },
+      "IsNullable": false
+     },
+     "IsRequired": false,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "274",
+     "Name": "optionalReadOnlyIntRecord",
+     "SerializedName": "optionalReadOnlyIntRecord",
+     "Description": "Optional int record",
+     "Type": {
+      "$id": "275",
+      "Name": "Dictionary",
+      "KeyType": {
+       "$id": "276",
+       "Name": "string",
+       "Kind": "String",
+       "IsNullable": false
+      },
+      "ValueType": {
+       "$id": "277",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "278",
+     "Name": "optionalReadOnlyStringRecord",
+     "SerializedName": "optionalReadOnlyStringRecord",
+     "Description": "Optional string record",
+     "Type": {
+      "$id": "279",
+      "Name": "Dictionary",
+      "KeyType": {
        "$id": "280",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "281",
-     "Name": "optionalReadonlyIntList",
-     "SerializedName": "optionalReadonlyIntList",
-     "Description": "Optional readonly int collection.",
-     "Type": {
-      "$id": "282",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "283",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "284",
-     "Name": "optionalReadOnlyModelList",
-     "SerializedName": "optionalReadOnlyModelList",
-     "Description": "Optional model collection",
-     "Type": {
-      "$id": "285",
-      "Name": "Array",
-      "ElementType": {
-       "$ref": "57"
-      },
-      "IsNullable": false
-     },
-     "IsRequired": false,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "286",
-     "Name": "optionalReadOnlyIntRecord",
-     "SerializedName": "optionalReadOnlyIntRecord",
-     "Description": "Optional int record",
-     "Type": {
-      "$id": "287",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "288",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
       "ValueType": {
-       "$id": "289",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "290",
-     "Name": "optionalReadOnlyStringRecord",
-     "SerializedName": "optionalReadOnlyStringRecord",
-     "Description": "Optional string record",
-     "Type": {
-      "$id": "291",
-      "Name": "Dictionary",
-      "KeyType": {
-       "$id": "292",
-       "Name": "string",
-       "Kind": "String",
-       "IsNullable": false
-      },
-      "ValueType": {
-       "$id": "293",
+       "$id": "281",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
@@ -2154,21 +2042,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "294",
+     "$id": "282",
      "Name": "optionalModelRecord",
      "SerializedName": "optionalModelRecord",
      "Description": "Optional model record",
      "Type": {
-      "$id": "295",
+      "$id": "283",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "296",
+       "$id": "284",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -2176,15 +2064,15 @@
      "IsReadOnly": true
     },
     {
-     "$id": "297",
+     "$id": "285",
      "Name": "requiredCollectionWithNullableIntElement",
      "SerializedName": "requiredCollectionWithNullableIntElement",
      "Description": "Required collection of which the element is a nullable int",
      "Type": {
-      "$id": "298",
+      "$id": "286",
       "Name": "Array",
       "ElementType": {
-       "$id": "299",
+       "$id": "287",
        "Name": "int32",
        "Kind": "Int32",
        "IsNullable": true
@@ -2195,15 +2083,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "300",
+     "$id": "288",
      "Name": "optionalCollectionWithNullableBooleanElement",
      "SerializedName": "optionalCollectionWithNullableBooleanElement",
      "Description": "Optional collection of which the element is a nullable boolean",
      "Type": {
-      "$id": "301",
+      "$id": "289",
       "Name": "Array",
       "ElementType": {
-       "$id": "302",
+       "$id": "290",
        "Name": "boolean",
        "Kind": "Boolean",
        "IsNullable": true
@@ -2216,7 +2104,7 @@
    ]
   },
   {
-   "$id": "303",
+   "$id": "291",
    "Name": "OutputModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Model used only as output",
@@ -2224,12 +2112,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "304",
+     "$id": "292",
      "Name": "requiredString",
      "SerializedName": "requiredString",
      "Description": "Required string",
      "Type": {
-      "$id": "305",
+      "$id": "293",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2238,12 +2126,12 @@
      "IsReadOnly": false
     },
     {
-     "$id": "306",
+     "$id": "294",
      "Name": "requiredInt",
      "SerializedName": "requiredInt",
      "Description": "Required int",
      "Type": {
-      "$id": "307",
+      "$id": "295",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -2252,26 +2140,26 @@
      "IsReadOnly": false
     },
     {
-     "$id": "308",
+     "$id": "296",
      "Name": "requiredModel",
      "SerializedName": "requiredModel",
      "Description": "Required model",
      "Type": {
-      "$ref": "62"
+      "$ref": "56"
      },
      "IsRequired": true,
      "IsReadOnly": false
     },
     {
-     "$id": "309",
+     "$id": "297",
      "Name": "requiredList",
      "SerializedName": "requiredList",
      "Description": "Required collection",
      "Type": {
-      "$id": "310",
+      "$id": "298",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": false
      },
@@ -2279,21 +2167,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "311",
+     "$id": "299",
      "Name": "requiredModelRecord",
      "SerializedName": "requiredModelRecord",
      "Description": "Required model record",
      "Type": {
-      "$id": "312",
+      "$id": "300",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "313",
+       "$id": "301",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -2301,15 +2189,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "314",
+     "$id": "302",
      "Name": "optionalList",
      "SerializedName": "optionalList",
      "Description": "Optional model collection",
      "Type": {
-      "$id": "315",
+      "$id": "303",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": false
      },
@@ -2317,15 +2205,15 @@
      "IsReadOnly": false
     },
     {
-     "$id": "316",
+     "$id": "304",
      "Name": "optionalNullableList",
      "SerializedName": "optionalNullableList",
      "Description": "Optional model nullable collection",
      "Type": {
-      "$id": "317",
+      "$id": "305",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": true
      },
@@ -2333,21 +2221,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "318",
+     "$id": "306",
      "Name": "optionalRecord",
      "SerializedName": "optionalRecord",
      "Description": "Optional model record",
      "Type": {
-      "$id": "319",
+      "$id": "307",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "320",
+       "$id": "308",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": false
      },
@@ -2355,21 +2243,21 @@
      "IsReadOnly": false
     },
     {
-     "$id": "321",
+     "$id": "309",
      "Name": "optionalNullableRecord",
      "SerializedName": "optionalNullableRecord",
      "Description": "Optional model nullable record",
      "Type": {
-      "$id": "322",
+      "$id": "310",
       "Name": "Dictionary",
       "KeyType": {
-       "$id": "323",
+       "$id": "311",
        "Name": "string",
        "Kind": "String",
        "IsNullable": false
       },
       "ValueType": {
-       "$ref": "61"
+       "$ref": "55"
       },
       "IsNullable": true
      },
@@ -2379,7 +2267,7 @@
    ]
   },
   {
-   "$id": "324",
+   "$id": "312",
    "Name": "InputRecursiveModel",
    "Namespace": "ModelsTypeSpec",
    "Description": "Input model that has property of its own type",
@@ -2387,10 +2275,115 @@
    "Usage": "Input",
    "Properties": [
     {
-     "$id": "325",
+     "$id": "313",
      "Name": "message",
      "SerializedName": "message",
      "Description": "Message",
+     "Type": {
+      "$id": "314",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "315",
+     "Name": "inner",
+     "SerializedName": "inner",
+     "Description": "Required Record",
+     "Type": {
+      "$ref": "312"
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "316",
+   "Name": "RoundTripRecursiveModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Roundtrip model that has property of its own type",
+   "IsNullable": false,
+   "Usage": "RoundTrip",
+   "Properties": [
+    {
+     "$id": "317",
+     "Name": "message",
+     "SerializedName": "message",
+     "Description": "Message",
+     "Type": {
+      "$id": "318",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "319",
+     "Name": "inner",
+     "SerializedName": "inner",
+     "Description": "Required Record",
+     "Type": {
+      "$ref": "316"
+     },
+     "IsRequired": false,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "320",
+   "Name": "ErrorModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Output model that has property of its own type",
+   "IsNullable": false,
+   "Usage": "Output",
+   "Properties": [
+    {
+     "$id": "321",
+     "Name": "message",
+     "SerializedName": "message",
+     "Description": "Error message",
+     "Type": {
+      "$id": "322",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": true
+    },
+    {
+     "$id": "323",
+     "Name": "innerError",
+     "SerializedName": "innerError",
+     "Description": "Required Record",
+     "Type": {
+      "$ref": "320"
+     },
+     "IsRequired": false,
+     "IsReadOnly": true
+    }
+   ]
+  },
+  {
+   "$id": "324",
+   "Name": "NoUseBase",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Base model",
+   "IsNullable": false,
+   "Usage": "None",
+   "Properties": [
+    {
+     "$id": "325",
+     "Name": "baseModelProp",
+     "SerializedName": "baseModelProp",
+     "Description": "base model property",
      "Type": {
       "$id": "326",
       "Name": "string",
@@ -2399,135 +2392,30 @@
      },
      "IsRequired": true,
      "IsReadOnly": false
-    },
-    {
-     "$id": "327",
-     "Name": "inner",
-     "SerializedName": "inner",
-     "Description": "Required Record",
-     "Type": {
-      "$ref": "324"
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
     }
    ]
   },
   {
-   "$id": "328",
-   "Name": "RoundTripRecursiveModel",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "Roundtrip model that has property of its own type",
-   "IsNullable": false,
-   "Usage": "RoundTrip",
-   "Properties": [
-    {
-     "$id": "329",
-     "Name": "message",
-     "SerializedName": "message",
-     "Description": "Message",
-     "Type": {
-      "$id": "330",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "331",
-     "Name": "inner",
-     "SerializedName": "inner",
-     "Description": "Required Record",
-     "Type": {
-      "$ref": "328"
-     },
-     "IsRequired": false,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "332",
-   "Name": "ErrorModel",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "Output model that has property of its own type",
-   "IsNullable": false,
-   "Usage": "Output",
-   "Properties": [
-    {
-     "$id": "333",
-     "Name": "message",
-     "SerializedName": "message",
-     "Description": "Error message",
-     "Type": {
-      "$id": "334",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": true
-    },
-    {
-     "$id": "335",
-     "Name": "innerError",
-     "SerializedName": "innerError",
-     "Description": "Required Record",
-     "Type": {
-      "$ref": "332"
-     },
-     "IsRequired": false,
-     "IsReadOnly": true
-    }
-   ]
-  },
-  {
-   "$id": "336",
-   "Name": "NoUseBase",
-   "Namespace": "ModelsTypeSpec",
-   "Description": "Base model",
-   "IsNullable": false,
-   "Usage": "None",
-   "Properties": [
-    {
-     "$id": "337",
-     "Name": "baseModelProp",
-     "SerializedName": "baseModelProp",
-     "Description": "base model property",
-     "Type": {
-      "$id": "338",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "339",
+   "$id": "327",
    "Name": "RoundTripOnNoUse",
    "Namespace": "ModelsTypeSpec",
    "Description": "Derived model",
    "IsNullable": false,
    "BaseModel": {
-    "$ref": "336"
+    "$ref": "324"
    },
    "Usage": "RoundTrip",
    "Properties": [
     {
-     "$id": "340",
+     "$id": "328",
      "Name": "requiredList",
      "SerializedName": "requiredList",
      "Description": "Required collection",
      "Type": {
-      "$id": "341",
+      "$id": "329",
       "Name": "Array",
       "ElementType": {
-       "$ref": "57"
+       "$ref": "51"
       },
       "IsNullable": false
      },
@@ -2537,7 +2425,7 @@
    ]
   },
   {
-   "$id": "342",
+   "$id": "330",
    "Name": "SingleBase",
    "Namespace": "ModelsTypeSpec",
    "Description": "Single base model without any child model.",
@@ -2546,7 +2434,7 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "343",
+     "$id": "331",
      "Name": "kind",
      "SerializedName": "kind",
      "Description": "Discriminator",
@@ -2554,7 +2442,7 @@
      "IsReadOnly": false,
      "IsNullable": false,
      "Type": {
-      "$id": "344",
+      "$id": "332",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -2562,14 +2450,113 @@
      "IsDiscriminator": true
     },
     {
-     "$id": "345",
+     "$id": "333",
      "Name": "size",
      "SerializedName": "size",
      "Description": "",
      "Type": {
-      "$id": "346",
+      "$id": "334",
       "Name": "int32",
       "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "335",
+   "Name": "Facet",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Facet",
+   "IsNullable": false,
+   "Usage": "None",
+   "Properties": [
+    {
+     "$id": "336",
+     "Name": "field",
+     "SerializedName": "field",
+     "Description": "A field to facet by, where the field is attributed as 'facetable'",
+     "Type": {
+      "$id": "337",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "338",
+   "Name": "NumericValuesFacetint32",
+   "Namespace": "ModelsTypeSpec",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "335"
+   },
+   "Usage": "None",
+   "Properties": [
+    {
+     "$id": "339",
+     "Name": "values",
+     "SerializedName": "values",
+     "Description": "The facet ranges to produce. The values must be listed in ascending order to get the expected results. For example, values=10,20 produces three buckets: one for base rate 0 up to but not including 10, one for 10 up to but not including 20, and one for 20 and higher.",
+     "Type": {
+      "$id": "340",
+      "Name": "Array",
+      "ElementType": {
+       "$id": "341",
+       "Name": "int32",
+       "Kind": "Int32",
+       "IsNullable": false
+      },
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "342",
+     "Name": "value",
+     "SerializedName": "value",
+     "Description": "",
+     "Type": {
+      "$id": "343",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "344",
+   "Name": "Int32ValuesFacet",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Facets an int32 field by the specified value ranges.",
+   "IsNullable": false,
+   "BaseModel": {
+    "$ref": "338"
+   },
+   "Usage": "Input",
+   "Properties": [
+    {
+     "$id": "345",
+     "Name": "kind",
+     "SerializedName": "kind",
+     "Description": "The facet type.",
+     "Type": {
+      "$id": "346",
+      "Name": "Literal",
+      "LiteralValueType": {
+       "$ref": "22"
+      },
+      "Value": "Int32Values",
       "IsNullable": false
      },
      "IsRequired": true,
@@ -2579,17 +2566,21 @@
   },
   {
    "$id": "347",
-   "Name": "Facet",
+   "Name": "DerivedModelWithDiscriminatorA",
    "Namespace": "ModelsTypeSpec",
-   "Description": "Facet",
+   "Description": "Deriver model with discriminator property.",
    "IsNullable": false,
-   "Usage": "None",
+   "DiscriminatorValue": "A",
+   "BaseModel": {
+    "$ref": "114"
+   },
+   "Usage": "RoundTrip",
    "Properties": [
     {
      "$id": "348",
-     "Name": "field",
-     "SerializedName": "field",
-     "Description": "A field to facet by, where the field is attributed as 'facetable'",
+     "Name": "requiredString",
+     "SerializedName": "requiredString",
+     "Description": "Required string.",
      "Type": {
       "$id": "349",
       "Name": "string",
@@ -2603,40 +2594,23 @@
   },
   {
    "$id": "350",
-   "Name": "NumericValuesFacetint32",
+   "Name": "DerivedModelWithDiscriminatorB",
    "Namespace": "ModelsTypeSpec",
+   "Description": "Deriver model with discriminator property.",
    "IsNullable": false,
+   "DiscriminatorValue": "B",
    "BaseModel": {
-    "$ref": "347"
+    "$ref": "114"
    },
-   "Usage": "None",
+   "Usage": "RoundTrip",
    "Properties": [
     {
      "$id": "351",
-     "Name": "values",
-     "SerializedName": "values",
-     "Description": "The facet ranges to produce. The values must be listed in ascending order to get the expected results. For example, values=10,20 produces three buckets: one for base rate 0 up to but not including 10, one for 10 up to but not including 20, and one for 20 and higher.",
+     "Name": "requiredInt",
+     "SerializedName": "requiredInt",
+     "Description": "Required int.",
      "Type": {
       "$id": "352",
-      "Name": "Array",
-      "ElementType": {
-       "$id": "353",
-       "Name": "int32",
-       "Kind": "Int32",
-       "IsNullable": false
-      },
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "354",
-     "Name": "value",
-     "SerializedName": "value",
-     "Description": "",
-     "Type": {
-      "$id": "355",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -2647,28 +2621,54 @@
    ]
   },
   {
-   "$id": "356",
-   "Name": "Int32ValuesFacet",
+   "$id": "353",
+   "Name": "FirstDerivedOutputModel",
    "Namespace": "ModelsTypeSpec",
-   "Description": "Facets an int32 field by the specified value ranges.",
+   "Description": "First derived model as an output",
    "IsNullable": false,
+   "DiscriminatorValue": "first",
    "BaseModel": {
-    "$ref": "350"
+    "$ref": "24"
    },
-   "Usage": "Input",
+   "Usage": "Output",
+   "Properties": [
+    {
+     "$id": "354",
+     "Name": "first",
+     "SerializedName": "first",
+     "Description": "",
+     "Type": {
+      "$id": "355",
+      "Name": "boolean",
+      "Kind": "Boolean",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "356",
+   "Name": "SecondDerivedOutputModel",
+   "Namespace": "ModelsTypeSpec",
+   "Description": "Second derived model as an output",
+   "IsNullable": false,
+   "DiscriminatorValue": "second",
+   "BaseModel": {
+    "$ref": "24"
+   },
+   "Usage": "Output",
    "Properties": [
     {
      "$id": "357",
-     "Name": "kind",
-     "SerializedName": "kind",
-     "Description": "The facet type.",
+     "Name": "second",
+     "SerializedName": "second",
+     "Description": "",
      "Type": {
       "$id": "358",
-      "Name": "Literal",
-      "LiteralValueType": {
-       "$ref": "22"
-      },
-      "Value": "Int32Values",
+      "Name": "boolean",
+      "Kind": "Boolean",
       "IsNullable": false
      },
      "IsRequired": true,
@@ -2841,7 +2841,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "33"
+        "$ref": "27"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -2918,7 +2918,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "98"
+        "$ref": "92"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -2950,7 +2950,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "33"
+        "$ref": "27"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3027,7 +3027,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "181"
+        "$ref": "169"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3059,7 +3059,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "203"
+        "$ref": "191"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3136,7 +3136,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "203"
+        "$ref": "191"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3169,7 +3169,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "33"
+        "$ref": "27"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3246,7 +3246,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "244"
+        "$ref": "232"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3278,7 +3278,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "98"
+        "$ref": "92"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3355,7 +3355,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "303"
+        "$ref": "291"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3387,7 +3387,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "324"
+        "$ref": "312"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3493,7 +3493,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "328"
+        "$ref": "316"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3570,7 +3570,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "328"
+        "$ref": "316"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3635,7 +3635,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "332"
+        "$ref": "320"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3714,7 +3714,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "303"
+        "$ref": "291"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3793,7 +3793,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "303"
+        "$ref": "291"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3822,7 +3822,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "339"
+        "$ref": "327"
        },
        "Location": "Body",
        "IsRequired": true,
@@ -3899,7 +3899,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "339"
+        "$ref": "327"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -3964,7 +3964,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "120"
+        "$ref": "114"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -4025,7 +4025,7 @@
         200
        ],
        "BodyType": {
-        "$ref": "342"
+        "$ref": "330"
        },
        "BodyMediaType": "Json",
        "Headers": [],
@@ -4053,7 +4053,7 @@
        "Name": "input",
        "NameInRequest": "input",
        "Type": {
-        "$ref": "356"
+        "$ref": "344"
        },
        "Location": "Body",
        "IsRequired": true,

--- a/test/TestProjects/PetStore-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/PetStore-TypeSpec/src/Generated/tspCodeModel.json
@@ -120,71 +120,63 @@
      "IsRequired": true,
      "IsReadOnly": false
     }
-   ],
-   "DerivedModels": [
+   ]
+  },
+  {
+   "$id": "17",
+   "Name": "Shark",
+   "Namespace": "PetStore",
+   "Description": "Shark is a fish",
+   "IsNullable": false,
+   "DiscriminatorValue": "shark",
+   "BaseModel": {
+    "$ref": "12"
+   },
+   "Usage": "Output",
+   "Properties": [
     {
-     "$id": "17",
-     "Name": "Shark",
-     "Namespace": "PetStore",
-     "Description": "Shark is a fish",
-     "IsNullable": false,
-     "DiscriminatorValue": "shark",
-     "BaseModel": {
-      "$ref": "12"
+     "$id": "18",
+     "Name": "bite",
+     "SerializedName": "bite",
+     "Description": "The bite of the shark",
+     "Type": {
+      "$id": "19",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
      },
-     "Usage": "Output",
-     "Properties": [
-      {
-       "$id": "18",
-       "Name": "bite",
-       "SerializedName": "bite",
-       "Description": "The bite of the shark",
-       "Type": {
-        "$id": "19",
-        "Name": "string",
-        "Kind": "String",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
-    },
-    {
-     "$id": "20",
-     "Name": "Tuna",
-     "Namespace": "PetStore",
-     "Description": "Tuna is a fish",
-     "IsNullable": false,
-     "DiscriminatorValue": "tuna",
-     "BaseModel": {
-      "$ref": "12"
-     },
-     "Usage": "Output",
-     "Properties": [
-      {
-       "$id": "21",
-       "Name": "fat",
-       "SerializedName": "fat",
-       "Description": "The amount of fat of the tuna",
-       "Type": {
-        "$id": "22",
-        "Name": "int32",
-        "Kind": "Int32",
-        "IsNullable": false
-       },
-       "IsRequired": true,
-       "IsReadOnly": false
-      }
-     ]
+     "IsRequired": true,
+     "IsReadOnly": false
     }
    ]
   },
   {
-   "$ref": "17"
-  },
-  {
-   "$ref": "20"
+   "$id": "20",
+   "Name": "Tuna",
+   "Namespace": "PetStore",
+   "Description": "Tuna is a fish",
+   "IsNullable": false,
+   "DiscriminatorValue": "tuna",
+   "BaseModel": {
+    "$ref": "12"
+   },
+   "Usage": "Output",
+   "Properties": [
+    {
+     "$id": "21",
+     "Name": "fat",
+     "SerializedName": "fat",
+     "Description": "The amount of fat of the tuna",
+     "Type": {
+      "$id": "22",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
   },
   {
    "$id": "23",

--- a/test/TestProjects/PetStore-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/PetStore-TypeSpec/src/Generated/tspCodeModel.json
@@ -124,6 +124,103 @@
   },
   {
    "$id": "17",
+   "Name": "Toy",
+   "Namespace": "PetStore",
+   "IsNullable": false,
+   "Usage": "None",
+   "Properties": [
+    {
+     "$id": "18",
+     "Name": "id",
+     "SerializedName": "id",
+     "Description": "",
+     "Type": {
+      "$id": "19",
+      "Name": "int64",
+      "Kind": "Int64",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "20",
+     "Name": "petId",
+     "SerializedName": "petId",
+     "Description": "",
+     "Type": {
+      "$id": "21",
+      "Name": "int64",
+      "Kind": "Int64",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "22",
+     "Name": "name",
+     "SerializedName": "name",
+     "Description": "",
+     "Type": {
+      "$id": "23",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "24",
+   "Name": "Error",
+   "Namespace": "PetStore",
+   "Description": "Error",
+   "IsNullable": false,
+   "Usage": "Output",
+   "Properties": [
+    {
+     "$id": "25",
+     "Name": "code",
+     "SerializedName": "code",
+     "Description": "",
+     "Type": {
+      "$id": "26",
+      "Name": "int32",
+      "Kind": "Int32",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    },
+    {
+     "$id": "27",
+     "Name": "message",
+     "SerializedName": "message",
+     "Description": "",
+     "Type": {
+      "$id": "28",
+      "Name": "string",
+      "Kind": "String",
+      "IsNullable": false
+     },
+     "IsRequired": true,
+     "IsReadOnly": false
+    }
+   ]
+  },
+  {
+   "$id": "29",
+   "Name": "PetId",
+   "Namespace": "PetStore",
+   "IsNullable": false,
+   "Usage": "None",
+   "Properties": []
+  },
+  {
+   "$id": "30",
    "Name": "Shark",
    "Namespace": "PetStore",
    "Description": "Shark is a fish",
@@ -135,12 +232,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "18",
+     "$id": "31",
      "Name": "bite",
      "SerializedName": "bite",
      "Description": "The bite of the shark",
      "Type": {
-      "$id": "19",
+      "$id": "32",
       "Name": "string",
       "Kind": "String",
       "IsNullable": false
@@ -151,7 +248,7 @@
    ]
   },
   {
-   "$id": "20",
+   "$id": "33",
    "Name": "Tuna",
    "Namespace": "PetStore",
    "Description": "Tuna is a fish",
@@ -163,12 +260,12 @@
    "Usage": "Output",
    "Properties": [
     {
-     "$id": "21",
+     "$id": "34",
      "Name": "fat",
      "SerializedName": "fat",
      "Description": "The amount of fat of the tuna",
      "Type": {
-      "$id": "22",
+      "$id": "35",
       "Name": "int32",
       "Kind": "Int32",
       "IsNullable": false
@@ -177,103 +274,6 @@
      "IsReadOnly": false
     }
    ]
-  },
-  {
-   "$id": "23",
-   "Name": "Toy",
-   "Namespace": "PetStore",
-   "IsNullable": false,
-   "Usage": "None",
-   "Properties": [
-    {
-     "$id": "24",
-     "Name": "id",
-     "SerializedName": "id",
-     "Description": "",
-     "Type": {
-      "$id": "25",
-      "Name": "int64",
-      "Kind": "Int64",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "26",
-     "Name": "petId",
-     "SerializedName": "petId",
-     "Description": "",
-     "Type": {
-      "$id": "27",
-      "Name": "int64",
-      "Kind": "Int64",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "28",
-     "Name": "name",
-     "SerializedName": "name",
-     "Description": "",
-     "Type": {
-      "$id": "29",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "30",
-   "Name": "Error",
-   "Namespace": "PetStore",
-   "Description": "Error",
-   "IsNullable": false,
-   "Usage": "Output",
-   "Properties": [
-    {
-     "$id": "31",
-     "Name": "code",
-     "SerializedName": "code",
-     "Description": "",
-     "Type": {
-      "$id": "32",
-      "Name": "int32",
-      "Kind": "Int32",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    },
-    {
-     "$id": "33",
-     "Name": "message",
-     "SerializedName": "message",
-     "Description": "",
-     "Type": {
-      "$id": "34",
-      "Name": "string",
-      "Kind": "String",
-      "IsNullable": false
-     },
-     "IsRequired": true,
-     "IsReadOnly": false
-    }
-   ]
-  },
-  {
-   "$id": "35",
-   "Name": "PetId",
-   "Namespace": "PetStore",
-   "IsNullable": false,
-   "Usage": "None",
-   "Properties": []
   }
  ],
  "Clients": [


### PR DESCRIPTION
Derived types are resolved in the `TypeSpecInputModelTypeConverter`
Regen preview: https://github.com/Azure/azure-sdk-for-net/pull/40179