### PR TITLE
Refine type replacing in MPG

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
@@ -129,7 +129,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 await AutoRestLogger.Fatal(e.ErrorText);
                 return false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 try
                 {
@@ -144,8 +144,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 {
                     // Ignore any errors while trying to output crash information
                 }
-                await AutoRestLogger.Fatal($"Internal error in AutoRest.CSharp{ErrorHelpers.FileIssueText}\nException: {e.Message}\n{e.StackTrace}");
-                return false;
+                throw;
             }
 
             return true;

--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -198,7 +198,7 @@ namespace AutoRest.CSharp.Generation.Types
             return name != null;
         }
 
-        internal static CSharpType FromSystemType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel, ObjectType? backingObjectType)
+        internal static CSharpType FromSystemType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel, ObjectType? backingObjectType = null)
         {
             var genericTypes = type.GetGenericArguments().Select(t => new CSharpType(t));
             var systemObjectType = SystemObjectType.Create(type, defaultNamespace, sourceInputModel, backingObjectType);

--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -198,10 +198,10 @@ namespace AutoRest.CSharp.Generation.Types
             return name != null;
         }
 
-        internal static CSharpType FromSystemType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel, ObjectType? backingObjectType = null)
+        internal static CSharpType FromSystemType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel, IEnumerable<ObjectTypeProperty>? backingProperties = null)
         {
             var genericTypes = type.GetGenericArguments().Select(t => new CSharpType(t));
-            var systemObjectType = SystemObjectType.Create(type, defaultNamespace, sourceInputModel, backingObjectType);
+            var systemObjectType = SystemObjectType.Create(type, defaultNamespace, sourceInputModel, backingProperties);
             // TODO -- why we do not just return systemObjectType.Type here? because of the generic types?
             return new CSharpType(
                 systemObjectType,
@@ -245,8 +245,8 @@ namespace AutoRest.CSharp.Generation.Types
             return type;
         }
 
-        internal static CSharpType FromSystemType(BuildContext context, Type type, ObjectType? backingObjectType = null)
-            => FromSystemType(type, context.DefaultNamespace, context.SourceInputModel, backingObjectType);
+        internal static CSharpType FromSystemType(BuildContext context, Type type, IEnumerable<ObjectTypeProperty>? backingProperties = null)
+            => FromSystemType(type, context.DefaultNamespace, context.SourceInputModel, backingProperties);
 
         public bool TryCast<T>([MaybeNullWhen(false)] out T provider) where T : TypeProvider
         {

--- a/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/CSharpType.cs
@@ -198,10 +198,10 @@ namespace AutoRest.CSharp.Generation.Types
             return name != null;
         }
 
-        internal static CSharpType FromSystemType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel)
+        internal static CSharpType FromSystemType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel, ObjectType? backingObjectType)
         {
             var genericTypes = type.GetGenericArguments().Select(t => new CSharpType(t));
-            var systemObjectType = SystemObjectType.Create(type, defaultNamespace, sourceInputModel);
+            var systemObjectType = SystemObjectType.Create(type, defaultNamespace, sourceInputModel, backingObjectType);
             // TODO -- why we do not just return systemObjectType.Type here? because of the generic types?
             return new CSharpType(
                 systemObjectType,
@@ -245,8 +245,8 @@ namespace AutoRest.CSharp.Generation.Types
             return type;
         }
 
-        internal static CSharpType FromSystemType(BuildContext context, Type type)
-            => FromSystemType(type, context.DefaultNamespace, context.SourceInputModel);
+        internal static CSharpType FromSystemType(BuildContext context, Type type, ObjectType? backingObjectType = null)
+            => FromSystemType(type, context.DefaultNamespace, context.SourceInputModel, backingObjectType);
 
         public bool TryCast<T>([MaybeNullWhen(false)] out T provider) where T : TypeProvider
         {

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelFactoryTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelFactoryTypeProvider.cs
@@ -173,7 +173,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                 if (property == null)
                 {
                     // if the property is not found, in order not to introduce compilation errors, we need to add a `default` into the argument list
-                    methodArguments.Add(Default);
+                    methodArguments.Add(new PositionalParameterReference(ctorParameter.Name, Default));
                     continue;
                 }
 

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectType.cs
@@ -77,7 +77,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         protected abstract IEnumerable<ObjectTypeConstructor> BuildConstructors();
 
-        protected internal ObjectType? GetBaseObjectType()
+        protected ObjectType? GetBaseObjectType()
             => Inherits is { IsFrameworkType: false, Implementation: ObjectType objectType } ? objectType : null;
 
         protected virtual ObjectTypeDiscriminator? BuildDiscriminator()

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectType.cs
@@ -77,7 +77,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         protected abstract IEnumerable<ObjectTypeConstructor> BuildConstructors();
 
-        protected ObjectType? GetBaseObjectType()
+        protected internal ObjectType? GetBaseObjectType()
             => Inherits is { IsFrameworkType: false, Implementation: ObjectType objectType } ? objectType : null;
 
         protected virtual ObjectTypeDiscriminator? BuildDiscriminator()

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectTypeConstructor.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ObjectTypeConstructor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Output.Models.Shared;
@@ -10,14 +11,14 @@ namespace AutoRest.CSharp.Output.Models.Types
 {
     internal class ObjectTypeConstructor
     {
-        public ObjectTypeConstructor(ConstructorSignature signature, ObjectPropertyInitializer[] initializers, ObjectTypeConstructor? baseConstructor = null)
+        public ObjectTypeConstructor(ConstructorSignature signature, IReadOnlyList<ObjectPropertyInitializer> initializers, ObjectTypeConstructor? baseConstructor = null)
         {
             Signature = signature;
             Initializers = initializers;
             BaseConstructor = baseConstructor;
         }
 
-        public ObjectTypeConstructor(CSharpType type, MethodSignatureModifiers modifiers, Parameter[] parameters, ObjectPropertyInitializer[] initializers, ObjectTypeConstructor? baseConstructor = null)
+        public ObjectTypeConstructor(CSharpType type, MethodSignatureModifiers modifiers, IReadOnlyList<Parameter> parameters, IReadOnlyList<ObjectPropertyInitializer> initializers, ObjectTypeConstructor? baseConstructor = null)
             : this(
                  new ConstructorSignature(
                      type,
@@ -32,7 +33,7 @@ namespace AutoRest.CSharp.Output.Models.Types
         }
 
         public ConstructorSignature Signature { get; }
-        public ObjectPropertyInitializer[] Initializers { get; }
+        public IReadOnlyList<ObjectPropertyInitializer> Initializers { get; }
         public ObjectTypeConstructor? BaseConstructor { get; }
 
         public ObjectTypeProperty? FindPropertyInitializedByParameter(Parameter constructorParameter)

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
@@ -215,8 +215,8 @@ namespace AutoRest.CSharp.Output.Models.Types
             {
                 if (type == null)
                     return true; // obvious
-                if (!type.IsValueType)
-                    return true; // ref-type
+                if (type.IsClass)
+                    return true; // classes are nullable
                 if (Nullable.GetUnderlyingType(type) != null)
                     return true; // Nullable<T>
                 return false; // value-type

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
@@ -55,20 +55,6 @@ namespace AutoRest.CSharp.Output.Models.Types
 
             protected override ObjectTypeConstructor BuildSerializationConstructor()
                 => _backingObjectType.SerializationConstructor;
-
-            protected override IEnumerable<ObjectTypeProperty> BuildProperties()
-                => _backingObjectType.Properties;
-
-            protected override CSharpType? CreateInheritedType()
-            {
-                if (_type.BaseType == null || _type.BaseType == typeof(object))
-                {
-                    return null;
-                }
-
-                var backingBaseObjectType = _backingObjectType?.GetBaseObjectType();
-                return CSharpType.FromSystemType(_type.BaseType, base.DefaultNamespace, _sourceInputModel, backingBaseObjectType);
-            }
         }
 
         private readonly Type _type;

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
@@ -254,7 +254,7 @@ namespace AutoRest.CSharp.Output.Models.Types
                 return null;
             }
 
-            var backingBaseObjectType = _backingObjectType?.Inherits is { IsFrameworkType: false, Implementation: ObjectType baseType } ? baseType : null;
+            var backingBaseObjectType = _backingObjectType?.GetBaseObjectType();
             return CSharpType.FromSystemType(_type.BaseType, base.DefaultNamespace, _sourceInputModel, backingBaseObjectType);
         }
 

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
@@ -49,13 +49,6 @@ namespace AutoRest.CSharp.Output.Models.Types
             _backingObjectType = backingObjectType;
         }
 
-        private SystemObjectType(Type type, string defaultNamespace, SourceInputModel? sourceInputModel) : base(defaultNamespace, sourceInputModel)
-        {
-            _type = type;
-            _sourceInputModel = sourceInputModel;
-            DefaultName = GetNameWithoutGeneric(type);
-        }
-
         protected override string DefaultName { get; }
         protected override string DefaultNamespace => _type.Namespace ?? base.DefaultNamespace;
 

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SystemObjectType.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using AutoRest.CSharp.Common.Utilities;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
@@ -181,9 +182,9 @@ namespace AutoRest.CSharp.Output.Models.Types
                 {
                     Nullable = isNullable,
                     ReadOnly = property.IsReadOnly(),
-                    SerializedName = GetSerializedName(property.Name),
-                    Summary = $"Gets{GetPropertySummary(setter)} {property.Name}",
-                    Required = IsRequired(property),
+                    SerializedName = GetSerializedName(property.Name, SystemType),
+                    Summary = GetPropertySummary(setter != null, property.Name),
+                    Required = IsRequired(property, SystemType),
                     Language = new Languages()
                     {
                         Default = new Language() { Name = property.Name },
@@ -222,24 +223,28 @@ namespace AutoRest.CSharp.Output.Models.Types
                 return false; // value-type
             }
 
-            bool IsRequired(PropertyInfo property)
+            static bool IsRequired(PropertyInfo property, Type systemType)
             {
-                var dict = ReferenceClassFinder.GetPropertyMetadata(SystemType);
+                var dict = ReferenceClassFinder.GetPropertyMetadata(systemType);
 
                 return dict[property.Name].Required;
             }
 
-            static string GetPropertySummary(MethodInfo? setter)
+            static string GetPropertySummary(bool hasSetter, string name)
             {
-                return setter != null ? " or sets" : string.Empty;
+                var builder = new StringBuilder("Gets ");
+                if (hasSetter)
+                    builder.Append("or sets ");
+                builder.Append(name);
+                return builder.ToString();
             }
-        }
 
-        private string GetSerializedName(string name)
-        {
-            var dict = ReferenceClassFinder.GetPropertyMetadata(SystemType);
+            static string GetSerializedName(string name, Type systemType)
+            {
+                var dict = ReferenceClassFinder.GetPropertyMetadata(systemType);
 
-            return dict[name].SerializedName;
+                return dict[name].SerializedName;
+            }
         }
 
         protected override IEnumerable<ObjectTypeConstructor> BuildConstructors()

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -303,19 +303,6 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
                         var csharpType = TypeReferenceTypeChooser.GetExactMatch(mgmtObjectType);
                         if (csharpType != null)
                         {
-                            //// re-construct the model with replaced csharp type (e.g. the type in Resource Manager)
-                            //switch (mgmtObjectType)
-                            //{
-                            //    case ResourceData resourceData:
-                            //        replacedTypes.Add(new ResourceData(schema, csharpType.Name, csharpType.Namespace));
-                            //        break;
-                            //    case MgmtReferenceType referenceType:
-                            //        replacedTypes.Add(new MgmtReferenceType(schema, csharpType.Name, csharpType.Namespace));
-                            //        break;
-                            //    default:
-                            //        replacedTypes.Add(new MgmtObjectType(schema, csharpType.Name, csharpType.Namespace));
-                            //        break;
-                            //}
                             replacedTypes.Add(schema, csharpType.Implementation);
                         }
                     }

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -290,7 +290,8 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
             }
 
             // second, collect any model which can be replaced as whole (not as a property or as a base class)
-            var replacedTypes = new List<MgmtObjectType>();
+            var replacedTypes = new Dictionary<ObjectSchema, TypeProvider>();
+            //var replacedTypes = new List<MgmtObjectType>();
             foreach (var schema in MgmtContext.CodeModel.Schemas.Objects)
             {
                 TypeProvider? type;
@@ -302,33 +303,34 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
                         var csharpType = TypeReferenceTypeChooser.GetExactMatch(mgmtObjectType);
                         if (csharpType != null)
                         {
-                            // re-construct the model with replaced csharp type (e.g. the type in Resource Manager)
-                            switch (mgmtObjectType)
-                            {
-                                case ResourceData resourceData:
-                                    replacedTypes.Add(new ResourceData(schema, csharpType.Name, csharpType.Namespace));
-                                    break;
-                                case MgmtReferenceType referenceType:
-                                    replacedTypes.Add(new MgmtReferenceType(schema, csharpType.Name, csharpType.Namespace));
-                                    break;
-                                default:
-                                    replacedTypes.Add(new MgmtObjectType(schema, csharpType.Name, csharpType.Namespace));
-                                    break;
-                            }
+                            //// re-construct the model with replaced csharp type (e.g. the type in Resource Manager)
+                            //switch (mgmtObjectType)
+                            //{
+                            //    case ResourceData resourceData:
+                            //        replacedTypes.Add(new ResourceData(schema, csharpType.Name, csharpType.Namespace));
+                            //        break;
+                            //    case MgmtReferenceType referenceType:
+                            //        replacedTypes.Add(new MgmtReferenceType(schema, csharpType.Name, csharpType.Namespace));
+                            //        break;
+                            //    default:
+                            //        replacedTypes.Add(new MgmtObjectType(schema, csharpType.Name, csharpType.Namespace));
+                            //        break;
+                            //}
+                            replacedTypes.Add(schema, csharpType.Implementation);
                         }
                     }
                 }
             }
 
             // third, update the entries in cache maps with the new model instances
-            foreach (var replacedType in replacedTypes)
+            foreach (var (schema, replacedType) in replacedTypes)
             {
-                var oriModel = _schemaOrNameToModels[replacedType.ObjectSchema];
-                _schemaOrNameToModels[replacedType.ObjectSchema] = replacedType;
+                var originalModel = _schemaOrNameToModels[schema];
+                _schemaOrNameToModels[schema] = replacedType;
                 MgmtReport.Instance.TransformSection.AddTransformLogForApplyChange(
-                    new TransformItem(TransformTypeName.ReplaceTypeWhenInitializingModel, replacedType.ObjectSchema.GetFullSerializedName()),
-                    replacedType.ObjectSchema.GetFullSerializedName(),
-                    "ReplaceType", oriModel.Declaration.FullName, replacedType.Declaration.FullName);
+                    new TransformItem(TransformTypeName.ReplaceTypeWhenInitializingModel, schema.GetFullSerializedName()),
+                    schema.GetFullSerializedName(),
+                    "ReplaceType", originalModel.Declaration.FullName, replacedType.Declaration.FullName);
             }
 
             return _schemaOrNameToModels;

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -291,7 +291,6 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
 
             // second, collect any model which can be replaced as whole (not as a property or as a base class)
             var replacedTypes = new Dictionary<ObjectSchema, TypeProvider>();
-            //var replacedTypes = new List<MgmtObjectType>();
             foreach (var schema in MgmtContext.CodeModel.Schemas.Objects)
             {
                 if (_schemaOrNameToModels.TryGetValue(schema, out var type))

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -286,7 +286,11 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         {
             var codeWriter = new CodeWriter();
 
-            ReferenceTypeWriter.GetWriter(model).WriteModel(codeWriter, model);
+            var modelWriter = ReferenceTypeWriter.GetWriter(model);
+            if (modelWriter == null)
+                return;
+
+            modelWriter.WriteModel(codeWriter, model);
 
             AddGeneratedFile(project, modelFileName, codeWriter.ToString());
 

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtTarget.cs
@@ -286,7 +286,13 @@ namespace AutoRest.CSharp.AutoRest.Plugins
         {
             var codeWriter = new CodeWriter();
 
-            var modelWriter = ReferenceTypeWriter.GetWriter(model);
+            var modelWriter = model switch
+            {
+                MgmtReferenceType => new ReferenceTypeWriter(),
+                ResourceData data => new ResourceDataWriter(data),
+                SystemObjectType => null,
+                _ => new ModelWriter()
+            };
             if (modelWriter == null)
                 return;
 

--- a/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
@@ -34,7 +34,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             var replacedType = BuildExactMatchType(typeToReplace);
 
             _valueCache.TryAdd(typeToReplace.ObjectSchema, replacedType);
-            return null;
+            return replacedType;
         }
 
         private static CSharpType? BuildExactMatchType(MgmtObjectType typeToReplace)

--- a/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
@@ -43,7 +43,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             {
                 if (PropertyMatchDetection.IsEqual(replacementType, typeToReplace))
                 {
-                    var csharpType = CSharpType.FromSystemType(MgmtContext.Context, replacementType, typeToReplace);
+                    var csharpType = CSharpType.FromSystemType(MgmtContext.Context, replacementType, typeToReplace.MyProperties);
                     _valueCache.TryAdd(typeToReplace.ObjectSchema, csharpType);
                     return csharpType;
                 }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
@@ -1,21 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using AutoRest.CSharp.AutoRest.Plugins;
 using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
-using AutoRest.CSharp.Mgmt.Generation;
 using AutoRest.CSharp.Mgmt.Output;
-using AutoRest.CSharp.Output.Builders;
-using AutoRest.CSharp.Output.Models.Types;
-using Azure.ResourceManager;
-using Azure.ResourceManager.Resources.Models;
 
 namespace AutoRest.CSharp.Mgmt.Decorator
 {
@@ -44,7 +35,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             {
                 if (PropertyMatchDetection.IsEqual(replacementType, typeToReplace))
                 {
-                    var csharpType = CSharpType.FromSystemType(MgmtContext.Context, replacementType);
+                    var csharpType = CSharpType.FromSystemType(MgmtContext.Context, replacementType, typeToReplace);
                     _valueCache.TryAdd(typeToReplace.ObjectSchema, csharpType);
                     return csharpType;
                 }

--- a/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/TypeReferenceTypeChooser.cs
@@ -31,6 +31,14 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             if (_valueCache.TryGetValue(typeToReplace.ObjectSchema, out var result))
                 return result;
 
+            var replacedType = BuildExactMatchType(typeToReplace);
+
+            _valueCache.TryAdd(typeToReplace.ObjectSchema, replacedType);
+            return null;
+        }
+
+        private static CSharpType? BuildExactMatchType(MgmtObjectType typeToReplace)
+        {
             foreach (System.Type replacementType in TypeReferenceTypes)
             {
                 if (PropertyMatchDetection.IsEqual(replacementType, typeToReplace))
@@ -41,7 +49,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                 }
             }
 
-            _valueCache.TryAdd(typeToReplace.ObjectSchema, null);
+            // nothing matches, return null
             return null;
         }
 

--- a/src/AutoRest.CSharp/Mgmt/Generation/ReferenceTypeWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ReferenceTypeWriter.cs
@@ -11,14 +11,6 @@ namespace AutoRest.CSharp.Mgmt.Generation
 {
     internal class ReferenceTypeWriter : ModelWriter
     {
-        public static ModelWriter? GetWriter(TypeProvider typeProvider) => typeProvider switch
-        {
-            MgmtReferenceType => new ReferenceTypeWriter(),
-            ResourceData data => new ResourceDataWriter(data),
-            SystemObjectType => null,
-            _ => new ModelWriter()
-        };
-
         protected override void AddClassAttributes(CodeWriter writer, ObjectType objectType)
         {
             if (objectType is not SchemaObjectType schema)

--- a/src/AutoRest.CSharp/Mgmt/Generation/ReferenceTypeWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/ReferenceTypeWriter.cs
@@ -11,10 +11,11 @@ namespace AutoRest.CSharp.Mgmt.Generation
 {
     internal class ReferenceTypeWriter : ModelWriter
     {
-        public static ModelWriter GetWriter(TypeProvider typeProvider) => typeProvider switch
+        public static ModelWriter? GetWriter(TypeProvider typeProvider) => typeProvider switch
         {
             MgmtReferenceType => new ReferenceTypeWriter(),
             ResourceData data => new ResourceDataWriter(data),
+            SystemObjectType => null,
             _ => new ModelWriter()
         };
 

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -138,7 +138,7 @@ namespace AutoRest.CSharp.Mgmt.Output
                             string fullSerializedName = this.GetFullSerializedName(objectTypeProperty, i);
                             MgmtReport.Instance.TransformSection.AddTransformLogForApplyChange(
                                 new TransformItem(TransformTypeName.ReplacePropertyType, fullSerializedName),
-                               fullSerializedName,
+                                fullSerializedName,
                                 "ReplacePropertyType", typeToReplace.Declaration.FullName, $"{match.Namespace}.{match.Name}");
                             objectTypeProperty.ValueType.Arguments[i] = match;
                         }

--- a/test/TestProjects/MgmtReferenceTypes/Generated/Models/ErrorResponse.Serialization.cs
+++ b/test/TestProjects/MgmtReferenceTypes/Generated/Models/ErrorResponse.Serialization.cs
@@ -22,7 +22,7 @@ namespace Azure.ResourceManager.Fake.Models
             if (Optional.IsDefined(Error))
             {
                 writer.WritePropertyName("error"u8);
-                writer.WriteObjectValue(Error);
+                JsonSerializer.Serialize(writer, Error);
             }
             writer.WriteEndObject();
         }


### PR DESCRIPTION
Partially fix https://github.com/Azure/autorest.csharp/issues/3970

# Description

We should never wrap the "replaced types" into our type providers other than `SystemObjectType`.

For instance, if we replaced a model `XXXOperationStatus` with the `OperationStatus` in resourcemanager, in the generator's outputlibrary, `XXXOperationStatus` is modeled in type of `MgmtObjectType`, we should not wrap the replaced `OperationStatus` in resourcemanager any more, instead we should wrap it into `SystemObjectType` because the new model IS a system object type.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first