### PR TITLE
add internal ctors to models

### DIFF
--- a/samples/Azure.AI.FormRecognizer/Generated/Models/SourcePath.cs
+++ b/samples/Azure.AI.FormRecognizer/Generated/Models/SourcePath.cs
@@ -15,6 +15,13 @@ namespace Azure.AI.FormRecognizer.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="SourcePath"/>. </summary>
+        /// <param name="source"> File source path. </param>
+        internal SourcePath(string source)
+        {
+            Source = source;
+        }
+
         /// <summary> File source path. </summary>
         public string Source { get; set; }
     }

--- a/samples/Azure.AI.FormRecognizer/Generated/Models/TrainContent.cs
+++ b/samples/Azure.AI.FormRecognizer/Generated/Models/TrainContent.cs
@@ -23,6 +23,17 @@ namespace Azure.AI.FormRecognizer.Models
             Source = source;
         }
 
+        /// <summary> Initializes a new instance of <see cref="TrainContent"/>. </summary>
+        /// <param name="source"> Source path containing the training documents. </param>
+        /// <param name="sourceFilter"> Filter to apply to the documents in the source path for training. </param>
+        /// <param name="useLabelFile"> Use label file for training a model. </param>
+        internal TrainContent(string source, TrainSourceFilter sourceFilter, bool? useLabelFile)
+        {
+            Source = source;
+            SourceFilter = sourceFilter;
+            UseLabelFile = useLabelFile;
+        }
+
         /// <summary> Source path containing the training documents. </summary>
         public string Source { get; }
         /// <summary> Filter to apply to the documents in the source path for training. </summary>

--- a/samples/Azure.AI.FormRecognizer/Generated/Models/TrainSourceFilter.cs
+++ b/samples/Azure.AI.FormRecognizer/Generated/Models/TrainSourceFilter.cs
@@ -15,6 +15,15 @@ namespace Azure.AI.FormRecognizer.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="TrainSourceFilter"/>. </summary>
+        /// <param name="prefix"> A case-sensitive prefix string to filter documents in the source path for training. For example, when using a Azure storage blob Uri, use the prefix to restrict sub folders for training. </param>
+        /// <param name="includeSubFolders"> A flag to indicate if sub folders within the set of prefix folders will also need to be included when searching for content to be preprocessed. </param>
+        internal TrainSourceFilter(string prefix, bool? includeSubFolders)
+        {
+            Prefix = prefix;
+            IncludeSubFolders = includeSubFolders;
+        }
+
         /// <summary> A case-sensitive prefix string to filter documents in the source path for training. For example, when using a Azure storage blob Uri, use the prefix to restrict sub folders for training. </summary>
         public string Prefix { get; set; }
         /// <summary> A flag to indicate if sub folders within the set of prefix folders will also need to be included when searching for content to be preprocessed. </summary>

--- a/samples/Azure.Network.Management.Interface/Generated/Models/TagsObject.cs
+++ b/samples/Azure.Network.Management.Interface/Generated/Models/TagsObject.cs
@@ -19,6 +19,13 @@ namespace Azure.Network.Management.Interface.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="TagsObject"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal TagsObject(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/AvailabilitySetPatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/AvailabilitySetPatch.cs
@@ -24,6 +24,45 @@ namespace Azure.ResourceManager.Sample.Models
             Statuses = new ChangeTrackingList<InstanceViewStatus>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="AvailabilitySetPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="sku">
+        /// Sku of the availability set
+        /// Serialized Name: AvailabilitySetUpdate.sku
+        /// </param>
+        /// <param name="platformUpdateDomainCount">
+        /// Update Domain count.
+        /// Serialized Name: AvailabilitySetUpdate.properties.platformUpdateDomainCount
+        /// </param>
+        /// <param name="platformFaultDomainCount">
+        /// Fault Domain count.
+        /// Serialized Name: AvailabilitySetUpdate.properties.platformFaultDomainCount
+        /// </param>
+        /// <param name="virtualMachines">
+        /// A list of references to all virtual machines in the availability set.
+        /// Serialized Name: AvailabilitySetUpdate.properties.virtualMachines
+        /// </param>
+        /// <param name="proximityPlacementGroup">
+        /// Specifies information about the proximity placement group that the availability set should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01.
+        /// Serialized Name: AvailabilitySetUpdate.properties.proximityPlacementGroup
+        /// </param>
+        /// <param name="statuses">
+        /// The resource status information.
+        /// Serialized Name: AvailabilitySetUpdate.properties.statuses
+        /// </param>
+        internal AvailabilitySetPatch(IDictionary<string, string> tags, SampleSku sku, int? platformUpdateDomainCount, int? platformFaultDomainCount, IList<WritableSubResource> virtualMachines, WritableSubResource proximityPlacementGroup, IReadOnlyList<InstanceViewStatus> statuses) : base(tags)
+        {
+            Sku = sku;
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
+            VirtualMachines = virtualMachines;
+            ProximityPlacementGroup = proximityPlacementGroup;
+            Statuses = statuses;
+        }
+
         /// <summary>
         /// Sku of the availability set
         /// Serialized Name: AvailabilitySetUpdate.sku

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/DedicatedHostGroupPatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/DedicatedHostGroupPatch.cs
@@ -24,6 +24,40 @@ namespace Azure.ResourceManager.Sample.Models
             Hosts = new ChangeTrackingList<Resources.Models.SubResource>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="DedicatedHostGroupPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="zones">
+        /// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone.
+        /// Serialized Name: DedicatedHostGroupUpdate.zones
+        /// </param>
+        /// <param name="platformFaultDomainCount">
+        /// Number of fault domains that the host group can span.
+        /// Serialized Name: DedicatedHostGroupUpdate.properties.platformFaultDomainCount
+        /// </param>
+        /// <param name="hosts">
+        /// A list of references to all dedicated hosts in the dedicated host group.
+        /// Serialized Name: DedicatedHostGroupUpdate.properties.hosts
+        /// </param>
+        /// <param name="instanceView">
+        /// The dedicated host group instance view, which has the list of instance view of the dedicated hosts under the dedicated host group.
+        /// Serialized Name: DedicatedHostGroupUpdate.properties.instanceView
+        /// </param>
+        /// <param name="supportAutomaticPlacement">
+        /// Specifies whether virtual machines or virtual machine scale sets can be placed automatically on the dedicated host group. Automatic placement means resources are allocated on dedicated hosts, that are chosen by Azure, under the dedicated host group. The value is defaulted to 'true' when not provided. &lt;br&gt;&lt;br&gt;Minimum api-version: 2020-06-01.
+        /// Serialized Name: DedicatedHostGroupUpdate.properties.supportAutomaticPlacement
+        /// </param>
+        internal DedicatedHostGroupPatch(IDictionary<string, string> tags, IList<string> zones, int? platformFaultDomainCount, IReadOnlyList<Resources.Models.SubResource> hosts, DedicatedHostGroupInstanceView instanceView, bool? supportAutomaticPlacement) : base(tags)
+        {
+            Zones = zones;
+            PlatformFaultDomainCount = platformFaultDomainCount;
+            Hosts = hosts;
+            InstanceView = instanceView;
+            SupportAutomaticPlacement = supportAutomaticPlacement;
+        }
+
         /// <summary>
         /// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone.
         /// Serialized Name: DedicatedHostGroupUpdate.zones

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/DedicatedHostPatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/DedicatedHostPatch.cs
@@ -24,6 +24,55 @@ namespace Azure.ResourceManager.Sample.Models
             VirtualMachines = new ChangeTrackingList<Resources.Models.SubResource>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="DedicatedHostPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="platformFaultDomain">
+        /// Fault domain of the dedicated host within a dedicated host group.
+        /// Serialized Name: DedicatedHostUpdate.properties.platformFaultDomain
+        /// </param>
+        /// <param name="autoReplaceOnFailure">
+        /// Specifies whether the dedicated host should be replaced automatically in case of a failure. The value is defaulted to 'true' when not provided.
+        /// Serialized Name: DedicatedHostUpdate.properties.autoReplaceOnFailure
+        /// </param>
+        /// <param name="hostId">
+        /// A unique id generated and assigned to the dedicated host by the platform. &lt;br&gt;&lt;br&gt; Does not change throughout the lifetime of the host.
+        /// Serialized Name: DedicatedHostUpdate.properties.hostId
+        /// </param>
+        /// <param name="virtualMachines">
+        /// A list of references to all virtual machines in the Dedicated Host.
+        /// Serialized Name: DedicatedHostUpdate.properties.virtualMachines
+        /// </param>
+        /// <param name="licenseType">
+        /// Specifies the software license type that will be applied to the VMs deployed on the dedicated host. &lt;br&gt;&lt;br&gt; Possible values are: &lt;br&gt;&lt;br&gt; **None** &lt;br&gt;&lt;br&gt; **Windows_Server_Hybrid** &lt;br&gt;&lt;br&gt; **Windows_Server_Perpetual** &lt;br&gt;&lt;br&gt; Default: **None**
+        /// Serialized Name: DedicatedHostUpdate.properties.licenseType
+        /// </param>
+        /// <param name="provisioningOn">
+        /// The date when the host was first provisioned.
+        /// Serialized Name: DedicatedHostUpdate.properties.provisioningTime
+        /// </param>
+        /// <param name="provisioningState">
+        /// The provisioning state, which only appears in the response.
+        /// Serialized Name: DedicatedHostUpdate.properties.provisioningState
+        /// </param>
+        /// <param name="instanceView">
+        /// The dedicated host instance view.
+        /// Serialized Name: DedicatedHostUpdate.properties.instanceView
+        /// </param>
+        internal DedicatedHostPatch(IDictionary<string, string> tags, int? platformFaultDomain, bool? autoReplaceOnFailure, string hostId, IReadOnlyList<Resources.Models.SubResource> virtualMachines, DedicatedHostLicenseType? licenseType, DateTimeOffset? provisioningOn, string provisioningState, DedicatedHostInstanceView instanceView) : base(tags)
+        {
+            PlatformFaultDomain = platformFaultDomain;
+            AutoReplaceOnFailure = autoReplaceOnFailure;
+            HostId = hostId;
+            VirtualMachines = virtualMachines;
+            LicenseType = licenseType;
+            ProvisioningOn = provisioningOn;
+            ProvisioningState = provisioningState;
+            InstanceView = instanceView;
+        }
+
         /// <summary>
         /// Fault domain of the dedicated host within a dedicated host group.
         /// Serialized Name: DedicatedHostUpdate.properties.platformFaultDomain

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/ImagePatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/ImagePatch.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using Azure.Core;
 using Azure.ResourceManager.Resources.Models;
 
@@ -19,6 +20,35 @@ namespace Azure.ResourceManager.Sample.Models
         /// <summary> Initializes a new instance of <see cref="ImagePatch"/>. </summary>
         public ImagePatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="ImagePatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="sourceVirtualMachine">
+        /// The source virtual machine from which Image is created.
+        /// Serialized Name: ImageUpdate.properties.sourceVirtualMachine
+        /// </param>
+        /// <param name="storageProfile">
+        /// Specifies the storage settings for the virtual machine disks.
+        /// Serialized Name: ImageUpdate.properties.storageProfile
+        /// </param>
+        /// <param name="provisioningState">
+        /// The provisioning state.
+        /// Serialized Name: ImageUpdate.properties.provisioningState
+        /// </param>
+        /// <param name="hyperVGeneration">
+        /// Gets the HyperVGenerationType of the VirtualMachine created from the image
+        /// Serialized Name: ImageUpdate.properties.hyperVGeneration
+        /// </param>
+        internal ImagePatch(IDictionary<string, string> tags, WritableSubResource sourceVirtualMachine, ImageStorageProfile storageProfile, string provisioningState, HyperVGeneration? hyperVGeneration) : base(tags)
+        {
+            SourceVirtualMachine = sourceVirtualMachine;
+            StorageProfile = storageProfile;
+            ProvisioningState = provisioningState;
+            HyperVGeneration = hyperVGeneration;
         }
 
         /// <summary>

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/LogAnalyticsInputBase.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/LogAnalyticsInputBase.cs
@@ -39,6 +39,41 @@ namespace Azure.ResourceManager.Sample.Models
             ToTime = toTime;
         }
 
+        /// <summary> Initializes a new instance of <see cref="LogAnalyticsInputBase"/>. </summary>
+        /// <param name="blobContainerSasUri">
+        /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
+        /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri
+        /// </param>
+        /// <param name="fromTime">
+        /// From time of the query
+        /// Serialized Name: LogAnalyticsInputBase.fromTime
+        /// </param>
+        /// <param name="toTime">
+        /// To time of the query
+        /// Serialized Name: LogAnalyticsInputBase.toTime
+        /// </param>
+        /// <param name="groupByThrottlePolicy">
+        /// Group query result by Throttle Policy applied.
+        /// Serialized Name: LogAnalyticsInputBase.groupByThrottlePolicy
+        /// </param>
+        /// <param name="groupByOperationName">
+        /// Group query result by Operation Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByOperationName
+        /// </param>
+        /// <param name="groupByResourceName">
+        /// Group query result by Resource Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByResourceName
+        /// </param>
+        internal LogAnalyticsInputBase(Uri blobContainerSasUri, DateTimeOffset fromTime, DateTimeOffset toTime, bool? groupByThrottlePolicy, bool? groupByOperationName, bool? groupByResourceName)
+        {
+            BlobContainerSasUri = blobContainerSasUri;
+            FromTime = fromTime;
+            ToTime = toTime;
+            GroupByThrottlePolicy = groupByThrottlePolicy;
+            GroupByOperationName = groupByOperationName;
+            GroupByResourceName = groupByResourceName;
+        }
+
         /// <summary>
         /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
         /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/ProximityPlacementGroupPatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/ProximityPlacementGroupPatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace Azure.ResourceManager.Sample.Models
 {
     /// <summary>
@@ -15,6 +17,15 @@ namespace Azure.ResourceManager.Sample.Models
     {
         /// <summary> Initializes a new instance of <see cref="ProximityPlacementGroupPatch"/>. </summary>
         public ProximityPlacementGroupPatch()
+        {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="ProximityPlacementGroupPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        internal ProximityPlacementGroupPatch(IDictionary<string, string> tags) : base(tags)
         {
         }
     }

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/RequestRateByIntervalContent.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/RequestRateByIntervalContent.cs
@@ -41,6 +41,40 @@ namespace Azure.ResourceManager.Sample.Models
             IntervalLength = intervalLength;
         }
 
+        /// <summary> Initializes a new instance of <see cref="RequestRateByIntervalContent"/>. </summary>
+        /// <param name="blobContainerSasUri">
+        /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
+        /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri
+        /// </param>
+        /// <param name="fromTime">
+        /// From time of the query
+        /// Serialized Name: LogAnalyticsInputBase.fromTime
+        /// </param>
+        /// <param name="toTime">
+        /// To time of the query
+        /// Serialized Name: LogAnalyticsInputBase.toTime
+        /// </param>
+        /// <param name="groupByThrottlePolicy">
+        /// Group query result by Throttle Policy applied.
+        /// Serialized Name: LogAnalyticsInputBase.groupByThrottlePolicy
+        /// </param>
+        /// <param name="groupByOperationName">
+        /// Group query result by Operation Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByOperationName
+        /// </param>
+        /// <param name="groupByResourceName">
+        /// Group query result by Resource Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByResourceName
+        /// </param>
+        /// <param name="intervalLength">
+        /// Interval value in minutes used to create LogAnalytics call rate logs.
+        /// Serialized Name: RequestRateByIntervalInput.intervalLength
+        /// </param>
+        internal RequestRateByIntervalContent(Uri blobContainerSasUri, DateTimeOffset fromTime, DateTimeOffset toTime, bool? groupByThrottlePolicy, bool? groupByOperationName, bool? groupByResourceName, IntervalInMin intervalLength) : base(blobContainerSasUri, fromTime, toTime, groupByThrottlePolicy, groupByOperationName, groupByResourceName)
+        {
+            IntervalLength = intervalLength;
+        }
+
         /// <summary>
         /// Interval value in minutes used to create LogAnalytics call rate logs.
         /// Serialized Name: RequestRateByIntervalInput.intervalLength

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/SshPublicKeyPatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/SshPublicKeyPatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace Azure.ResourceManager.Sample.Models
 {
     /// <summary>
@@ -16,6 +18,20 @@ namespace Azure.ResourceManager.Sample.Models
         /// <summary> Initializes a new instance of <see cref="SshPublicKeyPatch"/>. </summary>
         public SshPublicKeyPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="SshPublicKeyPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="publicKey">
+        /// SSH public key used to authenticate to a virtual machine through ssh. If this property is not initially provided when the resource is created, the publicKey property will be populated when generateKeyPair is called. If the public key is provided upon resource creation, the provided public key needs to be at least 2048-bit and in ssh-rsa format.
+        /// Serialized Name: SshPublicKeyUpdateResource.properties.publicKey
+        /// </param>
+        internal SshPublicKeyPatch(IDictionary<string, string> tags, string publicKey) : base(tags)
+        {
+            PublicKey = publicKey;
         }
 
         /// <summary>

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/ThrottledRequestsContent.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/ThrottledRequestsContent.cs
@@ -34,5 +34,34 @@ namespace Azure.ResourceManager.Sample.Models
         {
             Argument.AssertNotNull(blobContainerSasUri, nameof(blobContainerSasUri));
         }
+
+        /// <summary> Initializes a new instance of <see cref="ThrottledRequestsContent"/>. </summary>
+        /// <param name="blobContainerSasUri">
+        /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
+        /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri
+        /// </param>
+        /// <param name="fromTime">
+        /// From time of the query
+        /// Serialized Name: LogAnalyticsInputBase.fromTime
+        /// </param>
+        /// <param name="toTime">
+        /// To time of the query
+        /// Serialized Name: LogAnalyticsInputBase.toTime
+        /// </param>
+        /// <param name="groupByThrottlePolicy">
+        /// Group query result by Throttle Policy applied.
+        /// Serialized Name: LogAnalyticsInputBase.groupByThrottlePolicy
+        /// </param>
+        /// <param name="groupByOperationName">
+        /// Group query result by Operation Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByOperationName
+        /// </param>
+        /// <param name="groupByResourceName">
+        /// Group query result by Resource Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByResourceName
+        /// </param>
+        internal ThrottledRequestsContent(Uri blobContainerSasUri, DateTimeOffset fromTime, DateTimeOffset toTime, bool? groupByThrottlePolicy, bool? groupByOperationName, bool? groupByResourceName) : base(blobContainerSasUri, fromTime, toTime, groupByThrottlePolicy, groupByOperationName, groupByResourceName)
+        {
+        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/UpdateResource.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/UpdateResource.cs
@@ -22,6 +22,16 @@ namespace Azure.ResourceManager.Sample.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary>
         /// Resource tags
         /// Serialized Name: UpdateResource.tags

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineExtensionUpdate.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineExtensionUpdate.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace Azure.ResourceManager.Sample.Models
 {
@@ -18,6 +19,55 @@ namespace Azure.ResourceManager.Sample.Models
         /// <summary> Initializes a new instance of <see cref="VirtualMachineExtensionUpdate"/>. </summary>
         public VirtualMachineExtensionUpdate()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineExtensionUpdate"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="forceUpdateTag">
+        /// How the extension handler should be forced to update even if the extension configuration has not changed.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.forceUpdateTag
+        /// </param>
+        /// <param name="publisher">
+        /// The name of the extension handler publisher.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.publisher
+        /// </param>
+        /// <param name="extensionType">
+        /// Specifies the type of the extension; an example is "CustomScriptExtension".
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.type
+        /// </param>
+        /// <param name="typeHandlerVersion">
+        /// Specifies the version of the script handler.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.typeHandlerVersion
+        /// </param>
+        /// <param name="autoUpgradeMinorVersion">
+        /// Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.autoUpgradeMinorVersion
+        /// </param>
+        /// <param name="enableAutomaticUpgrade">
+        /// Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.enableAutomaticUpgrade
+        /// </param>
+        /// <param name="settings">
+        /// Json formatted public settings for the extension.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.settings
+        /// </param>
+        /// <param name="protectedSettings">
+        /// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
+        /// Serialized Name: VirtualMachineExtensionUpdate.properties.protectedSettings
+        /// </param>
+        internal VirtualMachineExtensionUpdate(IDictionary<string, string> tags, string forceUpdateTag, string publisher, string extensionType, string typeHandlerVersion, bool? autoUpgradeMinorVersion, bool? enableAutomaticUpgrade, BinaryData settings, BinaryData protectedSettings) : base(tags)
+        {
+            ForceUpdateTag = forceUpdateTag;
+            Publisher = publisher;
+            ExtensionType = extensionType;
+            TypeHandlerVersion = typeHandlerVersion;
+            AutoUpgradeMinorVersion = autoUpgradeMinorVersion;
+            EnableAutomaticUpgrade = enableAutomaticUpgrade;
+            Settings = settings;
+            ProtectedSettings = protectedSettings;
         }
 
         /// <summary>

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachinePatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachinePatch.cs
@@ -24,6 +24,130 @@ namespace Azure.ResourceManager.Sample.Models
             Zones = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachinePatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="plan">
+        /// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -&gt;**. Enter any required information and then click **Save**.
+        /// Serialized Name: VirtualMachineUpdate.plan
+        /// </param>
+        /// <param name="identity">
+        /// The identity of the virtual machine, if configured.
+        /// Serialized Name: VirtualMachineUpdate.identity
+        /// </param>
+        /// <param name="zones">
+        /// The virtual machine zones.
+        /// Serialized Name: VirtualMachineUpdate.zones
+        /// </param>
+        /// <param name="hardwareProfile">
+        /// Specifies the hardware settings for the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.hardwareProfile
+        /// </param>
+        /// <param name="storageProfile">
+        /// Specifies the storage settings for the virtual machine disks.
+        /// Serialized Name: VirtualMachineUpdate.properties.storageProfile
+        /// </param>
+        /// <param name="additionalCapabilities">
+        /// Specifies additional capabilities enabled or disabled on the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.additionalCapabilities
+        /// </param>
+        /// <param name="osProfile">
+        /// Specifies the operating system settings used while creating the virtual machine. Some of the settings cannot be changed once VM is provisioned.
+        /// Serialized Name: VirtualMachineUpdate.properties.osProfile
+        /// </param>
+        /// <param name="networkProfile">
+        /// Specifies the network interfaces of the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.networkProfile
+        /// </param>
+        /// <param name="securityProfile">
+        /// Specifies the Security related profile settings for the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.securityProfile
+        /// </param>
+        /// <param name="diagnosticsProfile">
+        /// Specifies the boot diagnostic settings state. &lt;br&gt;&lt;br&gt;Minimum api-version: 2015-06-15.
+        /// Serialized Name: VirtualMachineUpdate.properties.diagnosticsProfile
+        /// </param>
+        /// <param name="availabilitySet">
+        /// Specifies information about the availability set that the virtual machine should be assigned to. Virtual machines specified in the same availability set are allocated to different nodes to maximize availability. For more information about availability sets, see [Manage the availability of virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-manage-availability?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). &lt;br&gt;&lt;br&gt; For more information on Azure planned maintenance, see [Planned maintenance for virtual machines in Azure](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-planned-maintenance?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json) &lt;br&gt;&lt;br&gt; Currently, a VM can only be added to availability set at creation time. The availability set to which the VM is being added should be under the same resource group as the availability set resource. An existing VM cannot be added to an availability set. &lt;br&gt;&lt;br&gt;This property cannot exist along with a non-null properties.virtualMachineScaleSet reference.
+        /// Serialized Name: VirtualMachineUpdate.properties.availabilitySet
+        /// </param>
+        /// <param name="virtualMachineScaleSet">
+        /// Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. &lt;br&gt;&lt;br&gt;This property cannot exist along with a non-null properties.availabilitySet reference. &lt;br&gt;&lt;br&gt;Minimum api‐version: 2019‐03‐01
+        /// Serialized Name: VirtualMachineUpdate.properties.virtualMachineScaleSet
+        /// </param>
+        /// <param name="proximityPlacementGroup">
+        /// Specifies information about the proximity placement group that the virtual machine should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01.
+        /// Serialized Name: VirtualMachineUpdate.properties.proximityPlacementGroup
+        /// </param>
+        /// <param name="priority">
+        /// Specifies the priority for the virtual machine. &lt;br&gt;&lt;br&gt;Minimum api-version: 2019-03-01
+        /// Serialized Name: VirtualMachineUpdate.properties.priority
+        /// </param>
+        /// <param name="evictionPolicy">
+        /// Specifies the eviction policy for the Azure Spot virtual machine and Azure Spot scale set. &lt;br&gt;&lt;br&gt;For Azure Spot virtual machines, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2019-03-01. &lt;br&gt;&lt;br&gt;For Azure Spot scale sets, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2017-10-30-preview.
+        /// Serialized Name: VirtualMachineUpdate.properties.evictionPolicy
+        /// </param>
+        /// <param name="billingProfile">
+        /// Specifies the billing related details of a Azure Spot virtual machine. &lt;br&gt;&lt;br&gt;Minimum api-version: 2019-03-01.
+        /// Serialized Name: VirtualMachineUpdate.properties.billingProfile
+        /// </param>
+        /// <param name="host">
+        /// Specifies information about the dedicated host that the virtual machine resides in. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-10-01.
+        /// Serialized Name: VirtualMachineUpdate.properties.host
+        /// </param>
+        /// <param name="hostGroup">
+        /// Specifies information about the dedicated host group that the virtual machine resides in. &lt;br&gt;&lt;br&gt;Minimum api-version: 2020-06-01. &lt;br&gt;&lt;br&gt;NOTE: User cannot specify both host and hostGroup properties.
+        /// Serialized Name: VirtualMachineUpdate.properties.hostGroup
+        /// </param>
+        /// <param name="provisioningState">
+        /// The provisioning state, which only appears in the response.
+        /// Serialized Name: VirtualMachineUpdate.properties.provisioningState
+        /// </param>
+        /// <param name="instanceView">
+        /// The virtual machine instance view.
+        /// Serialized Name: VirtualMachineUpdate.properties.instanceView
+        /// </param>
+        /// <param name="licenseType">
+        /// Specifies that the image or disk that is being used was licensed on-premises. This element is only used for images that contain the Windows Server operating system. &lt;br&gt;&lt;br&gt; Possible values are: &lt;br&gt;&lt;br&gt; Windows_Client &lt;br&gt;&lt;br&gt; Windows_Server &lt;br&gt;&lt;br&gt; If this element is included in a request for an update, the value must match the initial value. This value cannot be updated. &lt;br&gt;&lt;br&gt; For more information, see [Azure Hybrid Use Benefit for Windows Server](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json) &lt;br&gt;&lt;br&gt; Minimum api-version: 2015-06-15
+        /// Serialized Name: VirtualMachineUpdate.properties.licenseType
+        /// </param>
+        /// <param name="vmId">
+        /// Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.
+        /// Serialized Name: VirtualMachineUpdate.properties.vmId
+        /// </param>
+        /// <param name="extensionsTimeBudget">
+        /// Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). &lt;br&gt;&lt;br&gt; Minimum api-version: 2020-06-01
+        /// Serialized Name: VirtualMachineUpdate.properties.extensionsTimeBudget
+        /// </param>
+        internal VirtualMachinePatch(IDictionary<string, string> tags, SamplePlan plan, ManagedServiceIdentity identity, IList<string> zones, HardwareProfile hardwareProfile, StorageProfile storageProfile, AdditionalCapabilities additionalCapabilities, OSProfile osProfile, NetworkProfile networkProfile, SecurityProfile securityProfile, DiagnosticsProfile diagnosticsProfile, WritableSubResource availabilitySet, WritableSubResource virtualMachineScaleSet, WritableSubResource proximityPlacementGroup, VirtualMachinePriorityType? priority, VirtualMachineEvictionPolicyType? evictionPolicy, BillingProfile billingProfile, WritableSubResource host, WritableSubResource hostGroup, string provisioningState, VirtualMachineInstanceView instanceView, string licenseType, string vmId, string extensionsTimeBudget) : base(tags)
+        {
+            Plan = plan;
+            Identity = identity;
+            Zones = zones;
+            HardwareProfile = hardwareProfile;
+            StorageProfile = storageProfile;
+            AdditionalCapabilities = additionalCapabilities;
+            OSProfile = osProfile;
+            NetworkProfile = networkProfile;
+            SecurityProfile = securityProfile;
+            DiagnosticsProfile = diagnosticsProfile;
+            AvailabilitySet = availabilitySet;
+            VirtualMachineScaleSet = virtualMachineScaleSet;
+            ProximityPlacementGroup = proximityPlacementGroup;
+            Priority = priority;
+            EvictionPolicy = evictionPolicy;
+            BillingProfile = billingProfile;
+            Host = host;
+            HostGroup = hostGroup;
+            ProvisioningState = provisioningState;
+            InstanceView = instanceView;
+            LicenseType = licenseType;
+            VmId = vmId;
+            ExtensionsTimeBudget = extensionsTimeBudget;
+        }
+
         /// <summary>
         /// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -&gt;**. Enter any required information and then click **Save**.
         /// Serialized Name: VirtualMachineUpdate.plan

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineReimageContent.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineReimageContent.cs
@@ -18,6 +18,16 @@ namespace Azure.ResourceManager.Sample.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineReimageContent"/>. </summary>
+        /// <param name="tempDisk">
+        /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
+        /// Serialized Name: VirtualMachineReimageParameters.tempDisk
+        /// </param>
+        internal VirtualMachineReimageContent(bool? tempDisk)
+        {
+            TempDisk = tempDisk;
+        }
+
         /// <summary>
         /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
         /// Serialized Name: VirtualMachineReimageParameters.tempDisk

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetPatch.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetPatch.cs
@@ -23,6 +23,75 @@ namespace Azure.ResourceManager.Sample.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="sku">
+        /// The virtual machine scale set sku.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.sku
+        /// </param>
+        /// <param name="plan">
+        /// The purchase plan when deploying a virtual machine scale set from VM Marketplace images.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.plan
+        /// </param>
+        /// <param name="identity">
+        /// The identity of the virtual machine scale set, if configured.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.identity
+        /// </param>
+        /// <param name="upgradePolicy">
+        /// The upgrade policy.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.upgradePolicy
+        /// </param>
+        /// <param name="automaticRepairsPolicy">
+        /// Policy for automatic repairs.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.automaticRepairsPolicy
+        /// </param>
+        /// <param name="virtualMachineProfile">
+        /// The virtual machine profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.virtualMachineProfile
+        /// </param>
+        /// <param name="overprovision">
+        /// Specifies whether the Virtual Machine Scale Set should be overprovisioned.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.overprovision
+        /// </param>
+        /// <param name="doNotRunExtensionsOnOverprovisionedVms">
+        /// When Overprovision is enabled, extensions are launched only on the requested number of VMs which are finally kept. This property will hence ensure that the extensions do not run on the extra overprovisioned VMs.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.doNotRunExtensionsOnOverprovisionedVMs
+        /// </param>
+        /// <param name="singlePlacementGroup">
+        /// When true this limits the scale set to a single placement group, of max size 100 virtual machines. NOTE: If singlePlacementGroup is true, it may be modified to false. However, if singlePlacementGroup is false, it may not be modified to true.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.singlePlacementGroup
+        /// </param>
+        /// <param name="additionalCapabilities">
+        /// Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the Virtual Machines have the capability to support attaching managed data disks with UltraSSD_LRS storage account type.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.additionalCapabilities
+        /// </param>
+        /// <param name="scaleInPolicy">
+        /// Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.scaleInPolicy
+        /// </param>
+        /// <param name="proximityPlacementGroup">
+        /// Specifies information about the proximity placement group that the virtual machine scale set should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.proximityPlacementGroup
+        /// </param>
+        internal VirtualMachineScaleSetPatch(IDictionary<string, string> tags, SampleSku sku, SamplePlan plan, ManagedServiceIdentity identity, UpgradePolicy upgradePolicy, AutomaticRepairsPolicy automaticRepairsPolicy, VirtualMachineScaleSetUpdateVmProfile virtualMachineProfile, bool? overprovision, bool? doNotRunExtensionsOnOverprovisionedVms, bool? singlePlacementGroup, AdditionalCapabilities additionalCapabilities, ScaleInPolicy scaleInPolicy, WritableSubResource proximityPlacementGroup) : base(tags)
+        {
+            Sku = sku;
+            Plan = plan;
+            Identity = identity;
+            UpgradePolicy = upgradePolicy;
+            AutomaticRepairsPolicy = automaticRepairsPolicy;
+            VirtualMachineProfile = virtualMachineProfile;
+            Overprovision = overprovision;
+            DoNotRunExtensionsOnOverprovisionedVms = doNotRunExtensionsOnOverprovisionedVms;
+            SinglePlacementGroup = singlePlacementGroup;
+            AdditionalCapabilities = additionalCapabilities;
+            ScaleInPolicy = scaleInPolicy;
+            ProximityPlacementGroup = proximityPlacementGroup;
+        }
+
         /// <summary>
         /// The virtual machine scale set sku.
         /// Serialized Name: VirtualMachineScaleSetUpdate.sku

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetReimageContent.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetReimageContent.cs
@@ -22,6 +22,20 @@ namespace Azure.ResourceManager.Sample.Models
             InstanceIds = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetReimageContent"/>. </summary>
+        /// <param name="tempDisk">
+        /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
+        /// Serialized Name: VirtualMachineReimageParameters.tempDisk
+        /// </param>
+        /// <param name="instanceIds">
+        /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
+        /// Serialized Name: VirtualMachineScaleSetReimageParameters.instanceIds
+        /// </param>
+        internal VirtualMachineScaleSetReimageContent(bool? tempDisk, IList<string> instanceIds) : base(tempDisk)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary>
         /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
         /// Serialized Name: VirtualMachineScaleSetReimageParameters.instanceIds

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateNetworkProfile.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateNetworkProfile.cs
@@ -23,6 +23,21 @@ namespace Azure.ResourceManager.Sample.Models
             NetworkInterfaceConfigurations = new ChangeTrackingList<VirtualMachineScaleSetUpdateNetworkConfiguration>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateNetworkProfile"/>. </summary>
+        /// <param name="healthProbe">
+        /// A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The reference will be in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'.
+        /// Serialized Name: VirtualMachineScaleSetUpdateNetworkProfile.healthProbe
+        /// </param>
+        /// <param name="networkInterfaceConfigurations">
+        /// The list of network configurations.
+        /// Serialized Name: VirtualMachineScaleSetUpdateNetworkProfile.networkInterfaceConfigurations
+        /// </param>
+        internal VirtualMachineScaleSetUpdateNetworkProfile(WritableSubResource healthProbe, IList<VirtualMachineScaleSetUpdateNetworkConfiguration> networkInterfaceConfigurations)
+        {
+            HealthProbe = healthProbe;
+            NetworkInterfaceConfigurations = networkInterfaceConfigurations;
+        }
+
         /// <summary>
         /// A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The reference will be in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'.
         /// Serialized Name: VirtualMachineScaleSetUpdateNetworkProfile.healthProbe

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateOSDisk.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateOSDisk.cs
@@ -23,6 +23,41 @@ namespace Azure.ResourceManager.Sample.Models
             VhdContainers = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateOSDisk"/>. </summary>
+        /// <param name="caching">
+        /// The caching type.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.caching
+        /// </param>
+        /// <param name="writeAcceleratorEnabled">
+        /// Specifies whether writeAccelerator should be enabled or disabled on the disk.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.writeAcceleratorEnabled
+        /// </param>
+        /// <param name="diskSizeGB">
+        /// Specifies the size of the operating system disk in gigabytes. This element can be used to overwrite the size of the disk in a virtual machine image. &lt;br&gt;&lt;br&gt; This value cannot be larger than 1023 GB
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.diskSizeGB
+        /// </param>
+        /// <param name="image">
+        /// The Source User Image VirtualHardDisk. This VirtualHardDisk will be copied before using it to attach to the Virtual Machine. If SourceImage is provided, the destination VirtualHardDisk should not exist.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.image
+        /// </param>
+        /// <param name="vhdContainers">
+        /// The list of virtual hard disk container uris.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.vhdContainers
+        /// </param>
+        /// <param name="managedDisk">
+        /// The managed disk parameters.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.managedDisk
+        /// </param>
+        internal VirtualMachineScaleSetUpdateOSDisk(CachingType? caching, bool? writeAcceleratorEnabled, int? diskSizeGB, VirtualHardDisk image, IList<string> vhdContainers, VirtualMachineScaleSetManagedDiskParameters managedDisk)
+        {
+            Caching = caching;
+            WriteAcceleratorEnabled = writeAcceleratorEnabled;
+            DiskSizeGB = diskSizeGB;
+            Image = image;
+            VhdContainers = vhdContainers;
+            ManagedDisk = managedDisk;
+        }
+
         /// <summary>
         /// The caching type.
         /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.caching

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateOSProfile.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateOSProfile.cs
@@ -22,6 +22,31 @@ namespace Azure.ResourceManager.Sample.Models
             Secrets = new ChangeTrackingList<VaultSecretGroup>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateOSProfile"/>. </summary>
+        /// <param name="customData">
+        /// A base-64 encoded string of custom data.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.customData
+        /// </param>
+        /// <param name="windowsConfiguration">
+        /// The Windows Configuration of the OS profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.windowsConfiguration
+        /// </param>
+        /// <param name="linuxConfiguration">
+        /// The Linux Configuration of the OS profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.linuxConfiguration
+        /// </param>
+        /// <param name="secrets">
+        /// The List of certificates for addition to the VM.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.secrets
+        /// </param>
+        internal VirtualMachineScaleSetUpdateOSProfile(string customData, WindowsConfiguration windowsConfiguration, LinuxConfiguration linuxConfiguration, IList<VaultSecretGroup> secrets)
+        {
+            CustomData = customData;
+            WindowsConfiguration = windowsConfiguration;
+            LinuxConfiguration = linuxConfiguration;
+            Secrets = secrets;
+        }
+
         /// <summary>
         /// A base-64 encoded string of custom data.
         /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.customData

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateStorageProfile.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateStorageProfile.cs
@@ -22,6 +22,26 @@ namespace Azure.ResourceManager.Sample.Models
             DataDisks = new ChangeTrackingList<VirtualMachineScaleSetDataDisk>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateStorageProfile"/>. </summary>
+        /// <param name="imageReference">
+        /// The image reference.
+        /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.imageReference
+        /// </param>
+        /// <param name="osDisk">
+        /// The OS disk.
+        /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.osDisk
+        /// </param>
+        /// <param name="dataDisks">
+        /// The data disks.
+        /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.dataDisks
+        /// </param>
+        internal VirtualMachineScaleSetUpdateStorageProfile(ImageReference imageReference, VirtualMachineScaleSetUpdateOSDisk osDisk, IList<VirtualMachineScaleSetDataDisk> dataDisks)
+        {
+            ImageReference = imageReference;
+            OSDisk = osDisk;
+            DataDisks = dataDisks;
+        }
+
         /// <summary>
         /// The image reference.
         /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.imageReference

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateVmProfile.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetUpdateVmProfile.cs
@@ -18,6 +18,56 @@ namespace Azure.ResourceManager.Sample.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateVmProfile"/>. </summary>
+        /// <param name="osProfile">
+        /// The virtual machine scale set OS profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.osProfile
+        /// </param>
+        /// <param name="storageProfile">
+        /// The virtual machine scale set storage profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.storageProfile
+        /// </param>
+        /// <param name="networkProfile">
+        /// The virtual machine scale set network profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.networkProfile
+        /// </param>
+        /// <param name="securityProfile">
+        /// The virtual machine scale set Security profile
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.securityProfile
+        /// </param>
+        /// <param name="diagnosticsProfile">
+        /// The virtual machine scale set diagnostics profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.diagnosticsProfile
+        /// </param>
+        /// <param name="extensionProfile">
+        /// The virtual machine scale set extension profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.extensionProfile
+        /// </param>
+        /// <param name="licenseType">
+        /// The license type, which is for bring your own license scenario.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.licenseType
+        /// </param>
+        /// <param name="billingProfile">
+        /// Specifies the billing related details of a Azure Spot VMSS. &lt;br&gt;&lt;br&gt;Minimum api-version: 2019-03-01.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.billingProfile
+        /// </param>
+        /// <param name="scheduledEventsProfile">
+        /// Specifies Scheduled Event related configurations.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.scheduledEventsProfile
+        /// </param>
+        internal VirtualMachineScaleSetUpdateVmProfile(VirtualMachineScaleSetUpdateOSProfile osProfile, VirtualMachineScaleSetUpdateStorageProfile storageProfile, VirtualMachineScaleSetUpdateNetworkProfile networkProfile, SecurityProfile securityProfile, DiagnosticsProfile diagnosticsProfile, VirtualMachineScaleSetExtensionProfile extensionProfile, string licenseType, BillingProfile billingProfile, ScheduledEventsProfile scheduledEventsProfile)
+        {
+            OSProfile = osProfile;
+            StorageProfile = storageProfile;
+            NetworkProfile = networkProfile;
+            SecurityProfile = securityProfile;
+            DiagnosticsProfile = diagnosticsProfile;
+            ExtensionProfile = extensionProfile;
+            LicenseType = licenseType;
+            BillingProfile = billingProfile;
+            ScheduledEventsProfile = scheduledEventsProfile;
+        }
+
         /// <summary>
         /// The virtual machine scale set OS profile.
         /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.osProfile

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetVmInstanceIds.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetVmInstanceIds.cs
@@ -22,6 +22,16 @@ namespace Azure.ResourceManager.Sample.Models
             InstanceIds = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVmInstanceIds"/>. </summary>
+        /// <param name="instanceIds">
+        /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
+        /// Serialized Name: VirtualMachineScaleSetVMInstanceIDs.instanceIds
+        /// </param>
+        internal VirtualMachineScaleSetVmInstanceIds(IList<string> instanceIds)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary>
         /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
         /// Serialized Name: VirtualMachineScaleSetVMInstanceIDs.instanceIds

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetVmInstanceRequiredIds.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetVmInstanceRequiredIds.cs
@@ -31,6 +31,16 @@ namespace Azure.ResourceManager.Sample.Models
             InstanceIds = instanceIds.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVmInstanceRequiredIds"/>. </summary>
+        /// <param name="instanceIds">
+        /// The virtual machine scale set instance ids.
+        /// Serialized Name: VirtualMachineScaleSetVMInstanceRequiredIDs.instanceIds
+        /// </param>
+        internal VirtualMachineScaleSetVmInstanceRequiredIds(IList<string> instanceIds)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary>
         /// The virtual machine scale set instance ids.
         /// Serialized Name: VirtualMachineScaleSetVMInstanceRequiredIDs.instanceIds

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetVmReimageContent.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VirtualMachineScaleSetVmReimageContent.cs
@@ -17,5 +17,14 @@ namespace Azure.ResourceManager.Sample.Models
         public VirtualMachineScaleSetVmReimageContent()
         {
         }
+
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVmReimageContent"/>. </summary>
+        /// <param name="tempDisk">
+        /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
+        /// Serialized Name: VirtualMachineReimageParameters.tempDisk
+        /// </param>
+        internal VirtualMachineScaleSetVmReimageContent(bool? tempDisk) : base(tempDisk)
+        {
+        }
     }
 }

--- a/samples/Azure.ResourceManager.Sample/Generated/Models/VmScaleSetConvertToSinglePlacementGroupContent.cs
+++ b/samples/Azure.ResourceManager.Sample/Generated/Models/VmScaleSetConvertToSinglePlacementGroupContent.cs
@@ -18,6 +18,16 @@ namespace Azure.ResourceManager.Sample.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VmScaleSetConvertToSinglePlacementGroupContent"/>. </summary>
+        /// <param name="activePlacementGroupId">
+        /// Id of the placement group in which you want future virtual machine instances to be placed. To query placement group Id, please use Virtual Machine Scale Set VMs - Get API. If not provided, the platform will choose one with maximum number of virtual machine instances.
+        /// Serialized Name: VMScaleSetConvertToSinglePlacementGroupInput.activePlacementGroupId
+        /// </param>
+        internal VmScaleSetConvertToSinglePlacementGroupContent(string activePlacementGroupId)
+        {
+            ActivePlacementGroupId = activePlacementGroupId;
+        }
+
         /// <summary>
         /// Id of the placement group in which you want future virtual machine instances to be placed. To query placement group Id, please use Virtual Machine Scale Set VMs - Get API. If not provided, the platform will choose one with maximum number of virtual machine instances.
         /// Serialized Name: VMScaleSetConvertToSinglePlacementGroupInput.activePlacementGroupId

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/AccountSasContent.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/AccountSasContent.cs
@@ -25,6 +25,27 @@ namespace Azure.ResourceManager.Storage.Models
             SharedAccessExpiryOn = sharedAccessExpiryOn;
         }
 
+        /// <summary> Initializes a new instance of <see cref="AccountSasContent"/>. </summary>
+        /// <param name="services"> The signed services accessible with the account SAS. Possible values include: Blob (b), Queue (q), Table (t), File (f). </param>
+        /// <param name="resourceTypes"> The signed resource types that are accessible with the account SAS. Service (s): Access to service-level APIs; Container (c): Access to container-level APIs; Object (o): Access to object-level APIs for blobs, queue messages, table entities, and files. </param>
+        /// <param name="permissions"> The signed permissions for the account SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p). </param>
+        /// <param name="ipAddressOrRange"> An IP address or a range of IP addresses from which to accept requests. </param>
+        /// <param name="protocols"> The protocol permitted for a request made with the account SAS. </param>
+        /// <param name="sharedAccessStartOn"> The time at which the SAS becomes valid. </param>
+        /// <param name="sharedAccessExpiryOn"> The time at which the shared access signature becomes invalid. </param>
+        /// <param name="keyToSign"> The key to sign the account SAS token with. </param>
+        internal AccountSasContent(Service services, SignedResourceType resourceTypes, Permission permissions, string ipAddressOrRange, HttpProtocol? protocols, DateTimeOffset? sharedAccessStartOn, DateTimeOffset sharedAccessExpiryOn, string keyToSign)
+        {
+            Services = services;
+            ResourceTypes = resourceTypes;
+            Permissions = permissions;
+            IPAddressOrRange = ipAddressOrRange;
+            Protocols = protocols;
+            SharedAccessStartOn = sharedAccessStartOn;
+            SharedAccessExpiryOn = sharedAccessExpiryOn;
+            KeyToSign = keyToSign;
+        }
+
         /// <summary> The signed services accessible with the account SAS. Possible values include: Blob (b), Queue (q), Table (t), File (f). </summary>
         public Service Services { get; }
         /// <summary> The signed resource types that are accessible with the account SAS. Service (s): Access to service-level APIs; Container (c): Access to container-level APIs; Object (o): Access to object-level APIs for blobs, queue messages, table entities, and files. </summary>

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/LeaseContainerContent.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/LeaseContainerContent.cs
@@ -17,6 +17,21 @@ namespace Azure.ResourceManager.Storage.Models
             Action = action;
         }
 
+        /// <summary> Initializes a new instance of <see cref="LeaseContainerContent"/>. </summary>
+        /// <param name="action"> Specifies the lease action. Can be one of the available actions. </param>
+        /// <param name="leaseId"> Identifies the lease. Can be specified in any valid GUID string format. </param>
+        /// <param name="breakPeriod"> Optional. For a break action, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. </param>
+        /// <param name="leaseDuration"> Required for acquire. Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. </param>
+        /// <param name="proposedLeaseId"> Optional for acquire, required for change. Proposed lease ID, in a GUID string format. </param>
+        internal LeaseContainerContent(LeaseContainerRequestAction action, string leaseId, int? breakPeriod, int? leaseDuration, string proposedLeaseId)
+        {
+            Action = action;
+            LeaseId = leaseId;
+            BreakPeriod = breakPeriod;
+            LeaseDuration = leaseDuration;
+            ProposedLeaseId = proposedLeaseId;
+        }
+
         /// <summary> Specifies the lease action. Can be one of the available actions. </summary>
         public LeaseContainerRequestAction Action { get; }
         /// <summary> Identifies the lease. Can be specified in any valid GUID string format. </summary>

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/LeaseShareContent.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/LeaseShareContent.cs
@@ -17,6 +17,21 @@ namespace Azure.ResourceManager.Storage.Models
             Action = action;
         }
 
+        /// <summary> Initializes a new instance of <see cref="LeaseShareContent"/>. </summary>
+        /// <param name="action"> Specifies the lease action. Can be one of the available actions. </param>
+        /// <param name="leaseId"> Identifies the lease. Can be specified in any valid GUID string format. </param>
+        /// <param name="breakPeriod"> Optional. For a break action, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. </param>
+        /// <param name="leaseDuration"> Required for acquire. Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. </param>
+        /// <param name="proposedLeaseId"> Optional for acquire, required for change. Proposed lease ID, in a GUID string format. </param>
+        internal LeaseShareContent(LeaseShareAction action, string leaseId, int? breakPeriod, int? leaseDuration, string proposedLeaseId)
+        {
+            Action = action;
+            LeaseId = leaseId;
+            BreakPeriod = breakPeriod;
+            LeaseDuration = leaseDuration;
+            ProposedLeaseId = proposedLeaseId;
+        }
+
         /// <summary> Specifies the lease action. Can be one of the available actions. </summary>
         public LeaseShareAction Action { get; }
         /// <summary> Identifies the lease. Can be specified in any valid GUID string format. </summary>

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/ServiceSasContent.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/ServiceSasContent.cs
@@ -23,6 +23,47 @@ namespace Azure.ResourceManager.Storage.Models
             CanonicalizedResource = canonicalizedResource;
         }
 
+        /// <summary> Initializes a new instance of <see cref="ServiceSasContent"/>. </summary>
+        /// <param name="canonicalizedResource"> The canonical path to the signed resource. </param>
+        /// <param name="resource"> The signed services accessible with the service SAS. Possible values include: Blob (b), Container (c), File (f), Share (s). </param>
+        /// <param name="permissions"> The signed permissions for the service SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p). </param>
+        /// <param name="ipAddressOrRange"> An IP address or a range of IP addresses from which to accept requests. </param>
+        /// <param name="protocols"> The protocol permitted for a request made with the account SAS. </param>
+        /// <param name="sharedAccessStartOn"> The time at which the SAS becomes valid. </param>
+        /// <param name="sharedAccessExpiryOn"> The time at which the shared access signature becomes invalid. </param>
+        /// <param name="identifier"> A unique value up to 64 characters in length that correlates to an access policy specified for the container, queue, or table. </param>
+        /// <param name="partitionKeyStart"> The start of partition key. </param>
+        /// <param name="partitionKeyEnd"> The end of partition key. </param>
+        /// <param name="rowKeyStart"> The start of row key. </param>
+        /// <param name="rowKeyEnd"> The end of row key. </param>
+        /// <param name="keyToSign"> The key to sign the account SAS token with. </param>
+        /// <param name="cacheControl"> The response header override for cache control. </param>
+        /// <param name="contentDisposition"> The response header override for content disposition. </param>
+        /// <param name="contentEncoding"> The response header override for content encoding. </param>
+        /// <param name="contentLanguage"> The response header override for content language. </param>
+        /// <param name="contentType"> The response header override for content type. </param>
+        internal ServiceSasContent(string canonicalizedResource, SignedResource? resource, Permission? permissions, string ipAddressOrRange, HttpProtocol? protocols, DateTimeOffset? sharedAccessStartOn, DateTimeOffset? sharedAccessExpiryOn, string identifier, string partitionKeyStart, string partitionKeyEnd, string rowKeyStart, string rowKeyEnd, string keyToSign, string cacheControl, string contentDisposition, string contentEncoding, string contentLanguage, string contentType)
+        {
+            CanonicalizedResource = canonicalizedResource;
+            Resource = resource;
+            Permissions = permissions;
+            IPAddressOrRange = ipAddressOrRange;
+            Protocols = protocols;
+            SharedAccessStartOn = sharedAccessStartOn;
+            SharedAccessExpiryOn = sharedAccessExpiryOn;
+            Identifier = identifier;
+            PartitionKeyStart = partitionKeyStart;
+            PartitionKeyEnd = partitionKeyEnd;
+            RowKeyStart = rowKeyStart;
+            RowKeyEnd = rowKeyEnd;
+            KeyToSign = keyToSign;
+            CacheControl = cacheControl;
+            ContentDisposition = contentDisposition;
+            ContentEncoding = contentEncoding;
+            ContentLanguage = contentLanguage;
+            ContentType = contentType;
+        }
+
         /// <summary> The canonical path to the signed resource. </summary>
         public string CanonicalizedResource { get; }
         /// <summary> The signed services accessible with the service SAS. Possible values include: Blob (b), Container (c), File (f), Share (s). </summary>

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/StorageAccountCheckNameAvailabilityContent.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/StorageAccountCheckNameAvailabilityContent.cs
@@ -24,6 +24,15 @@ namespace Azure.ResourceManager.Storage.Models
             ResourceType = Type.MicrosoftStorageStorageAccounts;
         }
 
+        /// <summary> Initializes a new instance of <see cref="StorageAccountCheckNameAvailabilityContent"/>. </summary>
+        /// <param name="name"> The storage account name. </param>
+        /// <param name="resourceType"> The type of resource, Microsoft.Storage/storageAccounts. </param>
+        internal StorageAccountCheckNameAvailabilityContent(string name, Type resourceType)
+        {
+            Name = name;
+            ResourceType = resourceType;
+        }
+
         /// <summary> The storage account name. </summary>
         public string Name { get; }
         /// <summary> The type of resource, Microsoft.Storage/storageAccounts. </summary>

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/StorageAccountCreateOrUpdateContent.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/StorageAccountCreateOrUpdateContent.cs
@@ -31,6 +31,61 @@ namespace Azure.ResourceManager.Storage.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="StorageAccountCreateOrUpdateContent"/>. </summary>
+        /// <param name="sku"> Required. Gets or sets the SKU name. </param>
+        /// <param name="kind"> Required. Indicates the type of storage account. </param>
+        /// <param name="location"> Required. Gets or sets the location of the resource. This will be one of the supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.). The geo region of a resource cannot be changed once it is created, but if an identical geo region is specified on update, the request will succeed. </param>
+        /// <param name="extendedLocation"> Optional. Set the extended location of the resource. If not set, the storage account will be created in Azure main region. Otherwise it will be created in the specified extended location. </param>
+        /// <param name="tags"> Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters. </param>
+        /// <param name="identity"> The identity of the resource. </param>
+        /// <param name="publicNetworkAccess"> Allow or disallow public network access to Storage Account. Value is optional but if passed in, must be 'Enabled' or 'Disabled'. </param>
+        /// <param name="sasPolicy"> SasPolicy assigned to the storage account. </param>
+        /// <param name="keyPolicy"> KeyPolicy assigned to the storage account. </param>
+        /// <param name="customDomain"> User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name property. </param>
+        /// <param name="encryption"> Not applicable. Azure Storage encryption is enabled for all storage accounts and cannot be disabled. </param>
+        /// <param name="networkRuleSet"> Network rule set. </param>
+        /// <param name="accessTier"> Required for storage accounts where kind = BlobStorage. The access tier used for billing. </param>
+        /// <param name="azureFilesIdentityBasedAuthentication"> Provides the identity based authentication settings for Azure Files. </param>
+        /// <param name="enableHttpsTrafficOnly"> Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01. </param>
+        /// <param name="isHnsEnabled"> Account HierarchicalNamespace enabled if sets to true. </param>
+        /// <param name="largeFileSharesState"> Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled. </param>
+        /// <param name="routingPreference"> Maintains information about the network routing choice opted by the user for data transfer. </param>
+        /// <param name="allowBlobPublicAccess"> Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property. </param>
+        /// <param name="minimumTlsVersion"> Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property. </param>
+        /// <param name="allowSharedKeyAccess"> Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is null, which is equivalent to true. </param>
+        /// <param name="enableNfsV3"> NFS 3.0 protocol support enabled if set to true. </param>
+        /// <param name="allowCrossTenantReplication"> Allow or disallow cross AAD tenant object replication. The default interpretation is true for this property. </param>
+        /// <param name="defaultToOAuthAuthentication"> A boolean flag which indicates whether the default authentication is OAuth or not. The default interpretation is false for this property. </param>
+        /// <param name="immutableStorageWithVersioning"> The property is immutable and can only be set to true at the account creation time. When set to true, it enables object level immutability for all the new containers in the account by default. </param>
+        internal StorageAccountCreateOrUpdateContent(StorageSku sku, StorageKind kind, AzureLocation location, ExtendedLocation extendedLocation, IDictionary<string, string> tags, ManagedServiceIdentity identity, PublicNetworkAccess? publicNetworkAccess, SasPolicy sasPolicy, KeyPolicy keyPolicy, CustomDomain customDomain, Encryption encryption, NetworkRuleSet networkRuleSet, AccessTier? accessTier, AzureFilesIdentityBasedAuthentication azureFilesIdentityBasedAuthentication, bool? enableHttpsTrafficOnly, bool? isHnsEnabled, LargeFileSharesState? largeFileSharesState, RoutingPreference routingPreference, bool? allowBlobPublicAccess, MinimumTlsVersion? minimumTlsVersion, bool? allowSharedKeyAccess, bool? enableNfsV3, bool? allowCrossTenantReplication, bool? defaultToOAuthAuthentication, ImmutableStorageAccount immutableStorageWithVersioning)
+        {
+            Sku = sku;
+            Kind = kind;
+            Location = location;
+            ExtendedLocation = extendedLocation;
+            Tags = tags;
+            Identity = identity;
+            PublicNetworkAccess = publicNetworkAccess;
+            SasPolicy = sasPolicy;
+            KeyPolicy = keyPolicy;
+            CustomDomain = customDomain;
+            Encryption = encryption;
+            NetworkRuleSet = networkRuleSet;
+            AccessTier = accessTier;
+            AzureFilesIdentityBasedAuthentication = azureFilesIdentityBasedAuthentication;
+            EnableHttpsTrafficOnly = enableHttpsTrafficOnly;
+            IsHnsEnabled = isHnsEnabled;
+            LargeFileSharesState = largeFileSharesState;
+            RoutingPreference = routingPreference;
+            AllowBlobPublicAccess = allowBlobPublicAccess;
+            MinimumTlsVersion = minimumTlsVersion;
+            AllowSharedKeyAccess = allowSharedKeyAccess;
+            EnableNfsV3 = enableNfsV3;
+            AllowCrossTenantReplication = allowCrossTenantReplication;
+            DefaultToOAuthAuthentication = defaultToOAuthAuthentication;
+            ImmutableStorageWithVersioning = immutableStorageWithVersioning;
+        }
+
         /// <summary> Required. Gets or sets the SKU name. </summary>
         public StorageSku Sku { get; }
         /// <summary> Required. Indicates the type of storage account. </summary>

--- a/samples/Azure.ResourceManager.Storage/Generated/Models/StorageAccountPatch.cs
+++ b/samples/Azure.ResourceManager.Storage/Generated/Models/StorageAccountPatch.cs
@@ -20,6 +20,53 @@ namespace Azure.ResourceManager.Storage.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="StorageAccountPatch"/>. </summary>
+        /// <param name="sku"> Gets or sets the SKU name. Note that the SKU name cannot be updated to Standard_ZRS, Premium_LRS or Premium_ZRS, nor can accounts of those SKU names be updated to any other value. </param>
+        /// <param name="tags"> Gets or sets a list of key value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater in length than 128 characters and a value no greater in length than 256 characters. </param>
+        /// <param name="identity"> The identity of the resource. </param>
+        /// <param name="kind"> Optional. Indicates the type of storage account. Currently only StorageV2 value supported by server. </param>
+        /// <param name="customDomain"> Custom domain assigned to the storage account by the user. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name property. </param>
+        /// <param name="encryption"> Provides the encryption settings on the account. The default setting is unencrypted. </param>
+        /// <param name="sasPolicy"> SasPolicy assigned to the storage account. </param>
+        /// <param name="keyPolicy"> KeyPolicy assigned to the storage account. </param>
+        /// <param name="accessTier"> Required for storage accounts where kind = BlobStorage. The access tier used for billing. </param>
+        /// <param name="azureFilesIdentityBasedAuthentication"> Provides the identity based authentication settings for Azure Files. </param>
+        /// <param name="enableHttpsTrafficOnly"> Allows https traffic only to storage service if sets to true. </param>
+        /// <param name="networkRuleSet"> Network rule set. </param>
+        /// <param name="largeFileSharesState"> Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled. </param>
+        /// <param name="routingPreference"> Maintains information about the network routing choice opted by the user for data transfer. </param>
+        /// <param name="allowBlobPublicAccess"> Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property. </param>
+        /// <param name="minimumTlsVersion"> Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property. </param>
+        /// <param name="allowSharedKeyAccess"> Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is null, which is equivalent to true. </param>
+        /// <param name="allowCrossTenantReplication"> Allow or disallow cross AAD tenant object replication. The default interpretation is true for this property. </param>
+        /// <param name="defaultToOAuthAuthentication"> A boolean flag which indicates whether the default authentication is OAuth or not. The default interpretation is false for this property. </param>
+        /// <param name="publicNetworkAccess"> Allow or disallow public network access to Storage Account. Value is optional but if passed in, must be 'Enabled' or 'Disabled'. </param>
+        /// <param name="immutableStorageWithVersioning"> The property is immutable and can only be set to true at the account creation time. When set to true, it enables object level immutability for all the containers in the account by default. </param>
+        internal StorageAccountPatch(StorageSku sku, IDictionary<string, string> tags, ManagedServiceIdentity identity, StorageKind? kind, CustomDomain customDomain, Encryption encryption, SasPolicy sasPolicy, KeyPolicy keyPolicy, AccessTier? accessTier, AzureFilesIdentityBasedAuthentication azureFilesIdentityBasedAuthentication, bool? enableHttpsTrafficOnly, NetworkRuleSet networkRuleSet, LargeFileSharesState? largeFileSharesState, RoutingPreference routingPreference, bool? allowBlobPublicAccess, MinimumTlsVersion? minimumTlsVersion, bool? allowSharedKeyAccess, bool? allowCrossTenantReplication, bool? defaultToOAuthAuthentication, PublicNetworkAccess? publicNetworkAccess, ImmutableStorageAccount immutableStorageWithVersioning)
+        {
+            Sku = sku;
+            Tags = tags;
+            Identity = identity;
+            Kind = kind;
+            CustomDomain = customDomain;
+            Encryption = encryption;
+            SasPolicy = sasPolicy;
+            KeyPolicy = keyPolicy;
+            AccessTier = accessTier;
+            AzureFilesIdentityBasedAuthentication = azureFilesIdentityBasedAuthentication;
+            EnableHttpsTrafficOnly = enableHttpsTrafficOnly;
+            NetworkRuleSet = networkRuleSet;
+            LargeFileSharesState = largeFileSharesState;
+            RoutingPreference = routingPreference;
+            AllowBlobPublicAccess = allowBlobPublicAccess;
+            MinimumTlsVersion = minimumTlsVersion;
+            AllowSharedKeyAccess = allowSharedKeyAccess;
+            AllowCrossTenantReplication = allowCrossTenantReplication;
+            DefaultToOAuthAuthentication = defaultToOAuthAuthentication;
+            PublicNetworkAccess = publicNetworkAccess;
+            ImmutableStorageWithVersioning = immutableStorageWithVersioning;
+        }
+
         /// <summary> Gets or sets the SKU name. Note that the SKU name cannot be updated to Standard_ZRS, Premium_LRS or Premium_ZRS, nor can accounts of those SKU names be updated to any other value. </summary>
         public StorageSku Sku { get; set; }
         /// <summary> Gets or sets a list of key value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater in length than 128 characters and a value no greater in length than 256 characters. </summary>

--- a/samples/Azure.Storage.Tables/src/Generated/Models/QueryOptions.cs
+++ b/samples/Azure.Storage.Tables/src/Generated/Models/QueryOptions.cs
@@ -17,6 +17,19 @@ namespace Azure.Storage.Tables.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="QueryOptions"/>. </summary>
+        /// <param name="format"> Specifies the media type for the response. </param>
+        /// <param name="top"> Maximum number of records to return. </param>
+        /// <param name="select"> Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId, ResourceId". </param>
+        /// <param name="filter"> OData filter expression. </param>
+        internal QueryOptions(ResponseFormat? format, int? top, string select, string filter)
+        {
+            Format = format;
+            Top = top;
+            Select = select;
+            Filter = filter;
+        }
+
         /// <summary> Specifies the media type for the response. </summary>
         public ResponseFormat? Format { get; set; }
         /// <summary> Maximum number of records to return. </summary>

--- a/samples/Azure.Storage.Tables/src/Generated/Models/TableProperties.cs
+++ b/samples/Azure.Storage.Tables/src/Generated/Models/TableProperties.cs
@@ -15,6 +15,13 @@ namespace Azure.Storage.Tables.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="TableProperties"/>. </summary>
+        /// <param name="tableName"> The name of the table to create. </param>
+        internal TableProperties(string tableName)
+        {
+            TableName = tableName;
+        }
+
         /// <summary> The name of the table to create. </summary>
         public string TableName { get; set; }
     }

--- a/samples/CognitiveSearch/Generated/Models/AccessCondition.cs
+++ b/samples/CognitiveSearch/Generated/Models/AccessCondition.cs
@@ -15,6 +15,15 @@ namespace CognitiveSearch.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="AccessCondition"/>. </summary>
+        /// <param name="ifMatch"> Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value. </param>
+        /// <param name="ifNoneMatch"> Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value. </param>
+        internal AccessCondition(string ifMatch, string ifNoneMatch)
+        {
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+        }
+
         /// <summary> Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value. </summary>
         public string IfMatch { get; set; }
         /// <summary> Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value. </summary>

--- a/samples/CognitiveSearch/Generated/Models/AnalyzeRequest.cs
+++ b/samples/CognitiveSearch/Generated/Models/AnalyzeRequest.cs
@@ -26,6 +26,21 @@ namespace CognitiveSearch.Models
             CharFilters = new ChangeTrackingList<CharFilterName>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="AnalyzeRequest"/>. </summary>
+        /// <param name="text"> The text to break into tokens. </param>
+        /// <param name="analyzer"> The name of the analyzer to use to break the given text. If this parameter is not specified, you must specify a tokenizer instead. The tokenizer and analyzer parameters are mutually exclusive. </param>
+        /// <param name="tokenizer"> The name of the tokenizer to use to break the given text. If this parameter is not specified, you must specify an analyzer instead. The tokenizer and analyzer parameters are mutually exclusive. </param>
+        /// <param name="tokenFilters"> An optional list of token filters to use when breaking the given text. This parameter can only be set when using the tokenizer parameter. </param>
+        /// <param name="charFilters"> An optional list of character filters to use when breaking the given text. This parameter can only be set when using the tokenizer parameter. </param>
+        internal AnalyzeRequest(string text, AnalyzerName? analyzer, TokenizerName? tokenizer, IList<TokenFilterName> tokenFilters, IList<CharFilterName> charFilters)
+        {
+            Text = text;
+            Analyzer = analyzer;
+            Tokenizer = tokenizer;
+            TokenFilters = tokenFilters;
+            CharFilters = charFilters;
+        }
+
         /// <summary> The text to break into tokens. </summary>
         public string Text { get; }
         /// <summary> The name of the analyzer to use to break the given text. If this parameter is not specified, you must specify a tokenizer instead. The tokenizer and analyzer parameters are mutually exclusive. </summary>

--- a/samples/CognitiveSearch/Generated/Models/AutocompleteOptions.cs
+++ b/samples/CognitiveSearch/Generated/Models/AutocompleteOptions.cs
@@ -19,6 +19,27 @@ namespace CognitiveSearch.Models
             SearchFields = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="AutocompleteOptions"/>. </summary>
+        /// <param name="autocompleteMode"> Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms. </param>
+        /// <param name="filter"> An OData expression that filters the documents used to produce completed terms for the Autocomplete result. </param>
+        /// <param name="useFuzzyMatching"> A value indicating whether to use fuzzy matching for the autocomplete query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources. </param>
+        /// <param name="highlightPostTag"> A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting is disabled. </param>
+        /// <param name="highlightPreTag"> A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting is disabled. </param>
+        /// <param name="minimumCoverage"> A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. </param>
+        /// <param name="searchFields"> The list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester. </param>
+        /// <param name="top"> The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5. </param>
+        internal AutocompleteOptions(AutocompleteMode? autocompleteMode, string filter, bool? useFuzzyMatching, string highlightPostTag, string highlightPreTag, double? minimumCoverage, IList<string> searchFields, int? top)
+        {
+            AutocompleteMode = autocompleteMode;
+            Filter = filter;
+            UseFuzzyMatching = useFuzzyMatching;
+            HighlightPostTag = highlightPostTag;
+            HighlightPreTag = highlightPreTag;
+            MinimumCoverage = minimumCoverage;
+            SearchFields = searchFields;
+            Top = top;
+        }
+
         /// <summary> Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms. </summary>
         public AutocompleteMode? AutocompleteMode { get; set; }
         /// <summary> An OData expression that filters the documents used to produce completed terms for the Autocomplete result. </summary>

--- a/samples/CognitiveSearch/Generated/Models/AutocompleteRequest.cs
+++ b/samples/CognitiveSearch/Generated/Models/AutocompleteRequest.cs
@@ -26,6 +26,31 @@ namespace CognitiveSearch.Models
             SuggesterName = suggesterName;
         }
 
+        /// <summary> Initializes a new instance of <see cref="AutocompleteRequest"/>. </summary>
+        /// <param name="searchText"> The search text on which to base autocomplete results. </param>
+        /// <param name="autocompleteMode"> Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms. </param>
+        /// <param name="filter"> An OData expression that filters the documents used to produce completed terms for the Autocomplete result. </param>
+        /// <param name="useFuzzyMatching"> A value indicating whether to use fuzzy matching for the autocomplete query. Default is false. When set to true, the query will autocomplete terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources. </param>
+        /// <param name="highlightPostTag"> A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting is disabled. </param>
+        /// <param name="highlightPreTag"> A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting is disabled. </param>
+        /// <param name="minimumCoverage"> A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. </param>
+        /// <param name="searchFields"> The comma-separated list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester. </param>
+        /// <param name="suggesterName"> The name of the suggester as specified in the suggesters collection that's part of the index definition. </param>
+        /// <param name="top"> The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5. </param>
+        internal AutocompleteRequest(string searchText, AutocompleteMode? autocompleteMode, string filter, bool? useFuzzyMatching, string highlightPostTag, string highlightPreTag, double? minimumCoverage, string searchFields, string suggesterName, int? top)
+        {
+            SearchText = searchText;
+            AutocompleteMode = autocompleteMode;
+            Filter = filter;
+            UseFuzzyMatching = useFuzzyMatching;
+            HighlightPostTag = highlightPostTag;
+            HighlightPreTag = highlightPreTag;
+            MinimumCoverage = minimumCoverage;
+            SearchFields = searchFields;
+            SuggesterName = suggesterName;
+            Top = top;
+        }
+
         /// <summary> The search text on which to base autocomplete results. </summary>
         public string SearchText { get; }
         /// <summary> Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms. </summary>

--- a/samples/CognitiveSearch/Generated/Models/IndexAction.cs
+++ b/samples/CognitiveSearch/Generated/Models/IndexAction.cs
@@ -19,6 +19,15 @@ namespace CognitiveSearch.Models
             AdditionalProperties = new ChangeTrackingDictionary<string, object>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="IndexAction"/>. </summary>
+        /// <param name="actionType"> The operation to perform on a document in an indexing batch. </param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
+        internal IndexAction(IndexActionType? actionType, IDictionary<string, object> additionalProperties)
+        {
+            ActionType = actionType;
+            AdditionalProperties = additionalProperties;
+        }
+
         /// <summary> The operation to perform on a document in an indexing batch. </summary>
         public IndexActionType? ActionType { get; set; }
         /// <summary> Additional Properties. </summary>

--- a/samples/CognitiveSearch/Generated/Models/IndexBatch.cs
+++ b/samples/CognitiveSearch/Generated/Models/IndexBatch.cs
@@ -25,6 +25,13 @@ namespace CognitiveSearch.Models
             Actions = actions.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="IndexBatch"/>. </summary>
+        /// <param name="actions"> The actions in the batch. </param>
+        internal IndexBatch(IList<IndexAction> actions)
+        {
+            Actions = actions;
+        }
+
         /// <summary> The actions in the batch. </summary>
         public IList<IndexAction> Actions { get; }
     }

--- a/samples/CognitiveSearch/Generated/Models/RequestOptions.cs
+++ b/samples/CognitiveSearch/Generated/Models/RequestOptions.cs
@@ -17,6 +17,13 @@ namespace CognitiveSearch.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="RequestOptions"/>. </summary>
+        /// <param name="xMsClientRequestId"> The tracking ID sent with the request to help with debugging. </param>
+        internal RequestOptions(Guid? xMsClientRequestId)
+        {
+            XMsClientRequestId = xMsClientRequestId;
+        }
+
         /// <summary> The tracking ID sent with the request to help with debugging. </summary>
         public Guid? XMsClientRequestId { get; set; }
     }

--- a/samples/CognitiveSearch/Generated/Models/SearchOptions.cs
+++ b/samples/CognitiveSearch/Generated/Models/SearchOptions.cs
@@ -24,6 +24,43 @@ namespace CognitiveSearch.Models
             Select = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="SearchOptions"/>. </summary>
+        /// <param name="includeTotalResultCount"> A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation. </param>
+        /// <param name="facets"> The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs. </param>
+        /// <param name="filter"> The OData $filter expression to apply to the search query. </param>
+        /// <param name="highlightFields"> The list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting. </param>
+        /// <param name="highlightPostTag"> A string tag that is appended to hit highlights. Must be set with highlightPreTag. Default is &lt;/em&gt;. </param>
+        /// <param name="highlightPreTag"> A string tag that is prepended to hit highlights. Must be set with highlightPostTag. Default is &lt;em&gt;. </param>
+        /// <param name="minimumCoverage"> A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100. </param>
+        /// <param name="orderBy"> The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. </param>
+        /// <param name="queryType"> A value that specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax. </param>
+        /// <param name="scoringParameters"> The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name-values. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be "mylocation--122.2,44.8" (without the quotes). </param>
+        /// <param name="scoringProfile"> The name of a scoring profile to evaluate match scores for matching documents in order to sort the results. </param>
+        /// <param name="searchFields"> The list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter. </param>
+        /// <param name="searchMode"> A value that specifies whether any or all of the search terms must be matched in order to count the document as a match. </param>
+        /// <param name="select"> The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included. </param>
+        /// <param name="skip"> The number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use $skip due to this limitation, consider using $orderby on a totally-ordered key and $filter with a range query instead. </param>
+        /// <param name="top"> The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results. </param>
+        internal SearchOptions(bool? includeTotalResultCount, IList<string> facets, string filter, IList<string> highlightFields, string highlightPostTag, string highlightPreTag, double? minimumCoverage, IList<string> orderBy, QueryType? queryType, IList<string> scoringParameters, string scoringProfile, IList<string> searchFields, SearchMode? searchMode, IList<string> select, int? skip, int? top)
+        {
+            IncludeTotalResultCount = includeTotalResultCount;
+            Facets = facets;
+            Filter = filter;
+            HighlightFields = highlightFields;
+            HighlightPostTag = highlightPostTag;
+            HighlightPreTag = highlightPreTag;
+            MinimumCoverage = minimumCoverage;
+            OrderBy = orderBy;
+            QueryType = queryType;
+            ScoringParameters = scoringParameters;
+            ScoringProfile = scoringProfile;
+            SearchFields = searchFields;
+            SearchMode = searchMode;
+            Select = select;
+            Skip = skip;
+            Top = top;
+        }
+
         /// <summary> A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation. </summary>
         public bool? IncludeTotalResultCount { get; set; }
         /// <summary> The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs. </summary>

--- a/samples/CognitiveSearch/Generated/Models/SuggestOptions.cs
+++ b/samples/CognitiveSearch/Generated/Models/SuggestOptions.cs
@@ -21,6 +21,29 @@ namespace CognitiveSearch.Models
             Select = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="SuggestOptions"/>. </summary>
+        /// <param name="filter"> An OData expression that filters the documents considered for suggestions. </param>
+        /// <param name="useFuzzyMatching"> A value indicating whether to use fuzzy matching for the suggestions query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestions queries are slower and consume more resources. </param>
+        /// <param name="highlightPostTag"> A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting of suggestions is disabled. </param>
+        /// <param name="highlightPreTag"> A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting of suggestions is disabled. </param>
+        /// <param name="minimumCoverage"> A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestions query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. </param>
+        /// <param name="orderBy"> The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. </param>
+        /// <param name="searchFields"> The list of field names to search for the specified search text. Target fields must be included in the specified suggester. </param>
+        /// <param name="select"> The list of fields to retrieve. If unspecified, only the key field will be included in the results. </param>
+        /// <param name="top"> The number of suggestions to retrieve. The value must be a number between 1 and 100. The default is 5. </param>
+        internal SuggestOptions(string filter, bool? useFuzzyMatching, string highlightPostTag, string highlightPreTag, double? minimumCoverage, IList<string> orderBy, IList<string> searchFields, IList<string> select, int? top)
+        {
+            Filter = filter;
+            UseFuzzyMatching = useFuzzyMatching;
+            HighlightPostTag = highlightPostTag;
+            HighlightPreTag = highlightPreTag;
+            MinimumCoverage = minimumCoverage;
+            OrderBy = orderBy;
+            SearchFields = searchFields;
+            Select = select;
+            Top = top;
+        }
+
         /// <summary> An OData expression that filters the documents considered for suggestions. </summary>
         public string Filter { get; set; }
         /// <summary> A value indicating whether to use fuzzy matching for the suggestions query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestions queries are slower and consume more resources. </summary>

--- a/samples/CognitiveSearch/Generated/Models/SuggestRequest.cs
+++ b/samples/CognitiveSearch/Generated/Models/SuggestRequest.cs
@@ -26,6 +26,33 @@ namespace CognitiveSearch.Models
             SuggesterName = suggesterName;
         }
 
+        /// <summary> Initializes a new instance of <see cref="SuggestRequest"/>. </summary>
+        /// <param name="filter"> An OData expression that filters the documents considered for suggestions. </param>
+        /// <param name="useFuzzyMatching"> A value indicating whether to use fuzzy matching for the suggestion query. Default is false. When set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources. </param>
+        /// <param name="highlightPostTag"> A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting of suggestions is disabled. </param>
+        /// <param name="highlightPreTag"> A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting of suggestions is disabled. </param>
+        /// <param name="minimumCoverage"> A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestion query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. </param>
+        /// <param name="orderBy"> The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. </param>
+        /// <param name="searchText"> The search text to use to suggest documents. Must be at least 1 character, and no more than 100 characters. </param>
+        /// <param name="searchFields"> The comma-separated list of field names to search for the specified search text. Target fields must be included in the specified suggester. </param>
+        /// <param name="select"> The comma-separated list of fields to retrieve. If unspecified, only the key field will be included in the results. </param>
+        /// <param name="suggesterName"> The name of the suggester as specified in the suggesters collection that's part of the index definition. </param>
+        /// <param name="top"> The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5. </param>
+        internal SuggestRequest(string filter, bool? useFuzzyMatching, string highlightPostTag, string highlightPreTag, double? minimumCoverage, string orderBy, string searchText, string searchFields, string select, string suggesterName, int? top)
+        {
+            Filter = filter;
+            UseFuzzyMatching = useFuzzyMatching;
+            HighlightPostTag = highlightPostTag;
+            HighlightPreTag = highlightPreTag;
+            MinimumCoverage = minimumCoverage;
+            OrderBy = orderBy;
+            SearchText = searchText;
+            SearchFields = searchFields;
+            Select = select;
+            SuggesterName = suggesterName;
+            Top = top;
+        }
+
         /// <summary> An OData expression that filters the documents considered for suggestions. </summary>
         public string Filter { get; set; }
         /// <summary> A value indicating whether to use fuzzy matching for the suggestion query. Default is false. When set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources. </summary>

--- a/samples/CognitiveServices.TextAnalytics/Generated/Models/LanguageBatchInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/Generated/Models/LanguageBatchInput.cs
@@ -25,6 +25,13 @@ namespace CognitiveServices.TextAnalytics.Models
             Documents = documents.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="LanguageBatchInput"/>. </summary>
+        /// <param name="documents"></param>
+        internal LanguageBatchInput(IList<LanguageInput> documents)
+        {
+            Documents = documents;
+        }
+
         /// <summary> Gets the documents. </summary>
         public IList<LanguageInput> Documents { get; }
     }

--- a/samples/CognitiveServices.TextAnalytics/Generated/Models/LanguageInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/Generated/Models/LanguageInput.cs
@@ -26,6 +26,17 @@ namespace CognitiveServices.TextAnalytics.Models
             Text = text;
         }
 
+        /// <summary> Initializes a new instance of <see cref="LanguageInput"/>. </summary>
+        /// <param name="id"> Unique, non-empty document identifier. </param>
+        /// <param name="text"></param>
+        /// <param name="countryHint"></param>
+        internal LanguageInput(string id, string text, string countryHint)
+        {
+            Id = id;
+            Text = text;
+            CountryHint = countryHint;
+        }
+
         /// <summary> Unique, non-empty document identifier. </summary>
         public string Id { get; }
         /// <summary> Gets the text. </summary>

--- a/samples/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageBatchInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageBatchInput.cs
@@ -25,6 +25,13 @@ namespace CognitiveServices.TextAnalytics.Models
             Documents = documents.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="MultiLanguageBatchInput"/>. </summary>
+        /// <param name="documents"> The set of documents to process as part of this batch. </param>
+        internal MultiLanguageBatchInput(IList<MultiLanguageInput> documents)
+        {
+            Documents = documents;
+        }
+
         /// <summary> The set of documents to process as part of this batch. </summary>
         public IList<MultiLanguageInput> Documents { get; }
     }

--- a/samples/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageInput.cs
+++ b/samples/CognitiveServices.TextAnalytics/Generated/Models/MultiLanguageInput.cs
@@ -26,6 +26,17 @@ namespace CognitiveServices.TextAnalytics.Models
             Text = text;
         }
 
+        /// <summary> Initializes a new instance of <see cref="MultiLanguageInput"/>. </summary>
+        /// <param name="id"> A unique, non-empty document identifier. </param>
+        /// <param name="text"> The input text to process. </param>
+        /// <param name="language"> (Optional) This is the 2 letter ISO 639-1 representation of a language. For example, use "en" for English; "es" for Spanish etc. If not set, use "en" for English as default. </param>
+        internal MultiLanguageInput(string id, string text, string language)
+        {
+            Id = id;
+            Text = text;
+            Language = language;
+        }
+
         /// <summary> A unique, non-empty document identifier. </summary>
         public string Id { get; }
         /// <summary> The input text to process. </summary>

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/SchemaObjectType.cs
@@ -302,7 +302,6 @@ namespace AutoRest.CSharp.Output.Models.Types
         protected bool SkipInitializerConstructor => ObjectSchema != null &&
             ObjectSchema.Extensions != null &&
             ObjectSchema.Extensions.SkipInitCtor;
-        protected bool SkipSerializerConstructor => !IncludeDeserializer;
         public CSharpType? ImplementsDictionaryType => _implementsDictionaryType ??= CreateInheritedDictionaryType();
         protected override IEnumerable<ObjectTypeConstructor> BuildConstructors()
         {
@@ -313,7 +312,7 @@ namespace AutoRest.CSharp.Output.Models.Types
             }
 
             // Skip serialization ctor if they are the same
-            if (!SkipSerializerConstructor && InitializationConstructor != SerializationConstructor)
+            if (InitializationConstructor != SerializationConstructor)
             {
                 yield return SerializationConstructor;
             }

--- a/test/AutoRest.TestServer.Tests/constantsModel.cs
+++ b/test/AutoRest.TestServer.Tests/constantsModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using constants.Models;
 using NUnit.Framework;
@@ -14,11 +15,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void NoModelAsStringNoRequiredTwoValueDefault_HasOneDefaultCtor()
+        public void NoModelAsStringNoRequiredTwoValueDefault_HasDefaultCtor()
         {
-            var constructors = typeof(NoModelAsStringNoRequiredTwoValueDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(NoModelAsStringNoRequiredTwoValueDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -51,11 +53,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void NoModelAsStringNoRequiredTwoValueNoDefault_HasOneDefaultCtor()
+        public void NoModelAsStringNoRequiredTwoValueNoDefault_HasDefaultCtor()
         {
-            var constructors = typeof(NoModelAsStringNoRequiredTwoValueNoDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(NoModelAsStringNoRequiredTwoValueNoDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -88,11 +91,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void NoModelAsStringNoRequiredOneValueNoDefault_HasOneDefaultCtor()
+        public void NoModelAsStringNoRequiredOneValueNoDefault_HasDefaultCtor()
         {
-            var constructors = typeof(NoModelAsStringNoRequiredOneValueNoDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(NoModelAsStringNoRequiredOneValueNoDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -114,11 +118,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void NoModelAsStringNoRequiredOneValueDefault_HasOneDefaultCtor()
+        public void NoModelAsStringNoRequiredOneValueDefault_HasDefaultCtor()
         {
-            var constructors = typeof(NoModelAsStringNoRequiredOneValueDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(NoModelAsStringNoRequiredOneValueDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -223,11 +228,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void NoModelAsStringRequiredOneValueNoDefault_HasOneDefaultCtor()
+        public void NoModelAsStringRequiredOneValueNoDefault_HasDefaultCtor()
         {
-            var constructors = typeof(NoModelAsStringRequiredOneValueNoDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(NoModelAsStringRequiredOneValueNoDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -256,11 +262,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void NoModelAsStringRequiredOneValueDefault_HasOneDefaultCtor()
+        public void NoModelAsStringRequiredOneValueDefault_HasDefaultCtor()
         {
-            var constructors = typeof(NoModelAsStringRequiredOneValueDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(NoModelAsStringRequiredOneValueDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -289,11 +296,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void ModelAsStringNoRequiredTwoValueNoDefault_HasOneDefaultCtor()
+        public void ModelAsStringNoRequiredTwoValueNoDefault_HasDefaultCtor()
         {
-            var constructors = typeof(ModelAsStringNoRequiredTwoValueNoDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(ModelAsStringNoRequiredTwoValueNoDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -326,11 +334,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void ModelAsStringNoRequiredTwoValueDefault_HasOneDefaultCtor()
+        public void ModelAsStringNoRequiredTwoValueDefault_HasDefaultCtor()
         {
-            var constructors = typeof(ModelAsStringNoRequiredTwoValueDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(ModelAsStringNoRequiredTwoValueDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]
@@ -363,11 +372,12 @@ namespace AutoRest.TestServer.Tests
         }
 
         [Test]
-        public void ModelAsStringNoRequiredOneValueDefault_HasOneDefaultCtor()
+        public void ModelAsStringNoRequiredOneValueDefault_HasDefaultCtor()
         {
-            var constructors = typeof(ModelAsStringNoRequiredOneValueDefault).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.AreEqual(1, constructors.Length);
-            Assert.AreEqual(0, constructors[0].GetParameters().Length);
+            var constructor = typeof(ModelAsStringNoRequiredOneValueDefault)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(ctor => ctor.GetParameters().Length == 0);
+            Assert.IsNotNull(constructor);
         }
 
         [Test]

--- a/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
+++ b/test/TestProjects/AdditionalPropertiesEx/Generated/Models/InputAdditionalPropertiesModel.cs
@@ -21,6 +21,15 @@ namespace AdditionalPropertiesEx.Models
             AdditionalProperties = new ChangeTrackingDictionary<string, object>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="InputAdditionalPropertiesModel"/>. </summary>
+        /// <param name="id"></param>
+        /// <param name="additionalProperties"> Additional Properties. </param>
+        internal InputAdditionalPropertiesModel(int id, IDictionary<string, object> additionalProperties)
+        {
+            Id = id;
+            AdditionalProperties = additionalProperties;
+        }
+
         /// <summary> Gets the id. </summary>
         public int Id { get; }
         /// <summary> Additional Properties. </summary>

--- a/test/TestProjects/FlattenedParameters/Generated/Models/Paths18Pe4VhOperationrequiredPatchRequestbodyContentApplicationJsonSchema.cs
+++ b/test/TestProjects/FlattenedParameters/Generated/Models/Paths18Pe4VhOperationrequiredPatchRequestbodyContentApplicationJsonSchema.cs
@@ -23,6 +23,15 @@ namespace FlattenedParameters.Models
             Required = required;
         }
 
+        /// <summary> Initializes a new instance of <see cref="Paths18Pe4VhOperationrequiredPatchRequestbodyContentApplicationJsonSchema"/>. </summary>
+        /// <param name="required"></param>
+        /// <param name="nonRequired"></param>
+        internal Paths18Pe4VhOperationrequiredPatchRequestbodyContentApplicationJsonSchema(string required, string nonRequired)
+        {
+            Required = required;
+            NonRequired = nonRequired;
+        }
+
         /// <summary> Gets the required. </summary>
         public string Required { get; }
         /// <summary> Gets or sets the non required. </summary>

--- a/test/TestProjects/FlattenedParameters/Generated/Models/Paths1Ti27MtOperationnotrequiredPatchRequestbodyContentApplicationJsonSchema.cs
+++ b/test/TestProjects/FlattenedParameters/Generated/Models/Paths1Ti27MtOperationnotrequiredPatchRequestbodyContentApplicationJsonSchema.cs
@@ -15,6 +15,15 @@ namespace FlattenedParameters.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="Paths1Ti27MtOperationnotrequiredPatchRequestbodyContentApplicationJsonSchema"/>. </summary>
+        /// <param name="required"></param>
+        /// <param name="nonRequired"></param>
+        internal Paths1Ti27MtOperationnotrequiredPatchRequestbodyContentApplicationJsonSchema(string required, string nonRequired)
+        {
+            Required = required;
+            NonRequired = nonRequired;
+        }
+
         /// <summary> Gets or sets the required. </summary>
         public string Required { get; set; }
         /// <summary> Gets or sets the non required. </summary>

--- a/test/TestProjects/FlattenedParameters/Generated/Models/PathsPv53C7OperationnotnullPatchRequestbodyContentApplicationJsonSchema.cs
+++ b/test/TestProjects/FlattenedParameters/Generated/Models/PathsPv53C7OperationnotnullPatchRequestbodyContentApplicationJsonSchema.cs
@@ -19,6 +19,13 @@ namespace FlattenedParameters.Models
             Items = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="PathsPv53C7OperationnotnullPatchRequestbodyContentApplicationJsonSchema"/>. </summary>
+        /// <param name="items"></param>
+        internal PathsPv53C7OperationnotnullPatchRequestbodyContentApplicationJsonSchema(IList<string> items)
+        {
+            Items = items;
+        }
+
         /// <summary> Gets the items. </summary>
         public IList<string> Items { get; }
     }

--- a/test/TestProjects/FlattenedParameters/Generated/Models/PathsYkez7BOperationPatchRequestbodyContentApplicationJsonSchema.cs
+++ b/test/TestProjects/FlattenedParameters/Generated/Models/PathsYkez7BOperationPatchRequestbodyContentApplicationJsonSchema.cs
@@ -19,6 +19,13 @@ namespace FlattenedParameters.Models
             Items = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="PathsYkez7BOperationPatchRequestbodyContentApplicationJsonSchema"/>. </summary>
+        /// <param name="items"></param>
+        internal PathsYkez7BOperationPatchRequestbodyContentApplicationJsonSchema(IList<string> items)
+        {
+            Items = items;
+        }
+
         /// <summary> Gets or sets the items. </summary>
         public IList<string> Items { get; set; }
     }

--- a/test/TestProjects/Inheritance/Generated/Models/BaseClassWithEnumDiscriminator.cs
+++ b/test/TestProjects/Inheritance/Generated/Models/BaseClassWithEnumDiscriminator.cs
@@ -19,6 +19,13 @@ namespace Inheritance.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="BaseClassWithEnumDiscriminator"/>. </summary>
+        /// <param name="discriminatorProperty"></param>
+        internal BaseClassWithEnumDiscriminator(BaseClassWithEnumDiscriminatorEnum discriminatorProperty)
+        {
+            DiscriminatorProperty = discriminatorProperty;
+        }
+
         /// <summary> Gets or sets the discriminator property. </summary>
         internal BaseClassWithEnumDiscriminatorEnum DiscriminatorProperty { get; set; }
     }

--- a/test/TestProjects/Inheritance/Generated/Models/ClassThatAlsoDefinesBaseClassProperty.cs
+++ b/test/TestProjects/Inheritance/Generated/Models/ClassThatAlsoDefinesBaseClassProperty.cs
@@ -15,6 +15,13 @@ namespace Inheritance.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ClassThatAlsoDefinesBaseClassProperty"/>. </summary>
+        /// <param name="baseClassProperty"></param>
+        internal ClassThatAlsoDefinesBaseClassProperty(string baseClassProperty)
+        {
+            BaseClassProperty = baseClassProperty;
+        }
+
         /// <summary> Gets the base class property. </summary>
         public string BaseClassProperty { get; }
     }

--- a/test/TestProjects/Inheritance/Generated/Models/DerivedClassWithEnumDiscriminator.cs
+++ b/test/TestProjects/Inheritance/Generated/Models/DerivedClassWithEnumDiscriminator.cs
@@ -15,5 +15,12 @@ namespace Inheritance.Models
         {
             DiscriminatorProperty = BaseClassWithEnumDiscriminatorEnum.Derived;
         }
+
+        /// <summary> Initializes a new instance of <see cref="DerivedClassWithEnumDiscriminator"/>. </summary>
+        /// <param name="discriminatorProperty"></param>
+        internal DerivedClassWithEnumDiscriminator(BaseClassWithEnumDiscriminatorEnum discriminatorProperty) : base(discriminatorProperty)
+        {
+            DiscriminatorProperty = discriminatorProperty;
+        }
     }
 }

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/ImagePatch.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/ImagePatch.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using Azure.Core;
 using Azure.ResourceManager.Resources.Models;
 
@@ -19,6 +20,35 @@ namespace MgmtAcronymMapping.Models
         /// <summary> Initializes a new instance of <see cref="ImagePatch"/>. </summary>
         public ImagePatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="ImagePatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="sourceVirtualMachine">
+        /// The source virtual machine from which Image is created.
+        /// Serialized Name: ImageUpdate.properties.sourceVirtualMachine
+        /// </param>
+        /// <param name="storageProfile">
+        /// Specifies the storage settings for the virtual machine disks.
+        /// Serialized Name: ImageUpdate.properties.storageProfile
+        /// </param>
+        /// <param name="provisioningState">
+        /// The provisioning state.
+        /// Serialized Name: ImageUpdate.properties.provisioningState
+        /// </param>
+        /// <param name="hyperVGeneration">
+        /// Gets the HyperVGenerationType of the VirtualMachine created from the image
+        /// Serialized Name: ImageUpdate.properties.hyperVGeneration
+        /// </param>
+        internal ImagePatch(IDictionary<string, string> tags, WritableSubResource sourceVirtualMachine, ImageStorageProfile storageProfile, string provisioningState, HyperVGenerationType? hyperVGeneration) : base(tags)
+        {
+            SourceVirtualMachine = sourceVirtualMachine;
+            StorageProfile = storageProfile;
+            ProvisioningState = provisioningState;
+            HyperVGeneration = hyperVGeneration;
         }
 
         /// <summary>

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/LogAnalyticsInputBase.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/LogAnalyticsInputBase.cs
@@ -39,6 +39,41 @@ namespace MgmtAcronymMapping.Models
             ToTime = toTime;
         }
 
+        /// <summary> Initializes a new instance of <see cref="LogAnalyticsInputBase"/>. </summary>
+        /// <param name="blobContainerSasUri">
+        /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
+        /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri
+        /// </param>
+        /// <param name="fromTime">
+        /// From time of the query
+        /// Serialized Name: LogAnalyticsInputBase.fromTime
+        /// </param>
+        /// <param name="toTime">
+        /// To time of the query
+        /// Serialized Name: LogAnalyticsInputBase.toTime
+        /// </param>
+        /// <param name="groupByThrottlePolicy">
+        /// Group query result by Throttle Policy applied.
+        /// Serialized Name: LogAnalyticsInputBase.groupByThrottlePolicy
+        /// </param>
+        /// <param name="groupByOperationName">
+        /// Group query result by Operation Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByOperationName
+        /// </param>
+        /// <param name="groupByResourceName">
+        /// Group query result by Resource Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByResourceName
+        /// </param>
+        internal LogAnalyticsInputBase(Uri blobContainerSasUri, DateTimeOffset fromTime, DateTimeOffset toTime, bool? groupByThrottlePolicy, bool? groupByOperationName, bool? groupByResourceName)
+        {
+            BlobContainerSasUri = blobContainerSasUri;
+            FromTime = fromTime;
+            ToTime = toTime;
+            GroupByThrottlePolicy = groupByThrottlePolicy;
+            GroupByOperationName = groupByOperationName;
+            GroupByResourceName = groupByResourceName;
+        }
+
         /// <summary>
         /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
         /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/RequestRateByIntervalContent.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/RequestRateByIntervalContent.cs
@@ -41,6 +41,40 @@ namespace MgmtAcronymMapping.Models
             IntervalLength = intervalLength;
         }
 
+        /// <summary> Initializes a new instance of <see cref="RequestRateByIntervalContent"/>. </summary>
+        /// <param name="blobContainerSasUri">
+        /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
+        /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri
+        /// </param>
+        /// <param name="fromTime">
+        /// From time of the query
+        /// Serialized Name: LogAnalyticsInputBase.fromTime
+        /// </param>
+        /// <param name="toTime">
+        /// To time of the query
+        /// Serialized Name: LogAnalyticsInputBase.toTime
+        /// </param>
+        /// <param name="groupByThrottlePolicy">
+        /// Group query result by Throttle Policy applied.
+        /// Serialized Name: LogAnalyticsInputBase.groupByThrottlePolicy
+        /// </param>
+        /// <param name="groupByOperationName">
+        /// Group query result by Operation Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByOperationName
+        /// </param>
+        /// <param name="groupByResourceName">
+        /// Group query result by Resource Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByResourceName
+        /// </param>
+        /// <param name="intervalLength">
+        /// Interval value in minutes used to create LogAnalytics call rate logs.
+        /// Serialized Name: RequestRateByIntervalInput.intervalLength
+        /// </param>
+        internal RequestRateByIntervalContent(Uri blobContainerSasUri, DateTimeOffset fromTime, DateTimeOffset toTime, bool? groupByThrottlePolicy, bool? groupByOperationName, bool? groupByResourceName, IntervalInMin intervalLength) : base(blobContainerSasUri, fromTime, toTime, groupByThrottlePolicy, groupByOperationName, groupByResourceName)
+        {
+            IntervalLength = intervalLength;
+        }
+
         /// <summary>
         /// Interval value in minutes used to create LogAnalytics call rate logs.
         /// Serialized Name: RequestRateByIntervalInput.intervalLength

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/ThrottledRequestsContent.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/ThrottledRequestsContent.cs
@@ -34,5 +34,34 @@ namespace MgmtAcronymMapping.Models
         {
             Argument.AssertNotNull(blobContainerSasUri, nameof(blobContainerSasUri));
         }
+
+        /// <summary> Initializes a new instance of <see cref="ThrottledRequestsContent"/>. </summary>
+        /// <param name="blobContainerSasUri">
+        /// SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
+        /// Serialized Name: LogAnalyticsInputBase.blobContainerSasUri
+        /// </param>
+        /// <param name="fromTime">
+        /// From time of the query
+        /// Serialized Name: LogAnalyticsInputBase.fromTime
+        /// </param>
+        /// <param name="toTime">
+        /// To time of the query
+        /// Serialized Name: LogAnalyticsInputBase.toTime
+        /// </param>
+        /// <param name="groupByThrottlePolicy">
+        /// Group query result by Throttle Policy applied.
+        /// Serialized Name: LogAnalyticsInputBase.groupByThrottlePolicy
+        /// </param>
+        /// <param name="groupByOperationName">
+        /// Group query result by Operation Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByOperationName
+        /// </param>
+        /// <param name="groupByResourceName">
+        /// Group query result by Resource Name.
+        /// Serialized Name: LogAnalyticsInputBase.groupByResourceName
+        /// </param>
+        internal ThrottledRequestsContent(Uri blobContainerSasUri, DateTimeOffset fromTime, DateTimeOffset toTime, bool? groupByThrottlePolicy, bool? groupByOperationName, bool? groupByResourceName) : base(blobContainerSasUri, fromTime, toTime, groupByThrottlePolicy, groupByOperationName, groupByResourceName)
+        {
+        }
     }
 }

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/UpdateResource.cs
@@ -22,6 +22,16 @@ namespace MgmtAcronymMapping.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary>
         /// Resource tags
         /// Serialized Name: UpdateResource.tags

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachinePatch.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachinePatch.cs
@@ -24,6 +24,130 @@ namespace MgmtAcronymMapping.Models
             Zones = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachinePatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="plan">
+        /// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -&gt;**. Enter any required information and then click **Save**.
+        /// Serialized Name: VirtualMachineUpdate.plan
+        /// </param>
+        /// <param name="identity">
+        /// The identity of the virtual machine, if configured.
+        /// Serialized Name: VirtualMachineUpdate.identity
+        /// </param>
+        /// <param name="zones">
+        /// The virtual machine zones.
+        /// Serialized Name: VirtualMachineUpdate.zones
+        /// </param>
+        /// <param name="hardwareProfile">
+        /// Specifies the hardware settings for the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.hardwareProfile
+        /// </param>
+        /// <param name="storageProfile">
+        /// Specifies the storage settings for the virtual machine disks.
+        /// Serialized Name: VirtualMachineUpdate.properties.storageProfile
+        /// </param>
+        /// <param name="additionalCapabilities">
+        /// Specifies additional capabilities enabled or disabled on the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.additionalCapabilities
+        /// </param>
+        /// <param name="osProfile">
+        /// Specifies the operating system settings used while creating the virtual machine. Some of the settings cannot be changed once VM is provisioned.
+        /// Serialized Name: VirtualMachineUpdate.properties.osProfile
+        /// </param>
+        /// <param name="networkProfile">
+        /// Specifies the network interfaces of the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.networkProfile
+        /// </param>
+        /// <param name="securityProfile">
+        /// Specifies the Security related profile settings for the virtual machine.
+        /// Serialized Name: VirtualMachineUpdate.properties.securityProfile
+        /// </param>
+        /// <param name="diagnosticsProfile">
+        /// Specifies the boot diagnostic settings state. &lt;br&gt;&lt;br&gt;Minimum api-version: 2015-06-15.
+        /// Serialized Name: VirtualMachineUpdate.properties.diagnosticsProfile
+        /// </param>
+        /// <param name="availabilitySet">
+        /// Specifies information about the availability set that the virtual machine should be assigned to. Virtual machines specified in the same availability set are allocated to different nodes to maximize availability. For more information about availability sets, see [Manage the availability of virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-manage-availability?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json). &lt;br&gt;&lt;br&gt; For more information on Azure planned maintenance, see [Planned maintenance for virtual machines in Azure](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-planned-maintenance?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json) &lt;br&gt;&lt;br&gt; Currently, a VM can only be added to availability set at creation time. The availability set to which the VM is being added should be under the same resource group as the availability set resource. An existing VM cannot be added to an availability set. &lt;br&gt;&lt;br&gt;This property cannot exist along with a non-null properties.virtualMachineScaleSet reference.
+        /// Serialized Name: VirtualMachineUpdate.properties.availabilitySet
+        /// </param>
+        /// <param name="virtualMachineScaleSet">
+        /// Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines specified in the same virtual machine scale set are allocated to different nodes to maximize availability. Currently, a VM can only be added to virtual machine scale set at creation time. An existing VM cannot be added to a virtual machine scale set. &lt;br&gt;&lt;br&gt;This property cannot exist along with a non-null properties.availabilitySet reference. &lt;br&gt;&lt;br&gt;Minimum api‐version: 2019‐03‐01
+        /// Serialized Name: VirtualMachineUpdate.properties.virtualMachineScaleSet
+        /// </param>
+        /// <param name="proximityPlacementGroup">
+        /// Specifies information about the proximity placement group that the virtual machine should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01.
+        /// Serialized Name: VirtualMachineUpdate.properties.proximityPlacementGroup
+        /// </param>
+        /// <param name="priority">
+        /// Specifies the priority for the virtual machine. &lt;br&gt;&lt;br&gt;Minimum api-version: 2019-03-01
+        /// Serialized Name: VirtualMachineUpdate.properties.priority
+        /// </param>
+        /// <param name="evictionPolicy">
+        /// Specifies the eviction policy for the Azure Spot virtual machine and Azure Spot scale set. &lt;br&gt;&lt;br&gt;For Azure Spot virtual machines, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2019-03-01. &lt;br&gt;&lt;br&gt;For Azure Spot scale sets, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2017-10-30-preview.
+        /// Serialized Name: VirtualMachineUpdate.properties.evictionPolicy
+        /// </param>
+        /// <param name="billingProfile">
+        /// Specifies the billing related details of a Azure Spot virtual machine. &lt;br&gt;&lt;br&gt;Minimum api-version: 2019-03-01.
+        /// Serialized Name: VirtualMachineUpdate.properties.billingProfile
+        /// </param>
+        /// <param name="host">
+        /// Specifies information about the dedicated host that the virtual machine resides in. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-10-01.
+        /// Serialized Name: VirtualMachineUpdate.properties.host
+        /// </param>
+        /// <param name="hostGroup">
+        /// Specifies information about the dedicated host group that the virtual machine resides in. &lt;br&gt;&lt;br&gt;Minimum api-version: 2020-06-01. &lt;br&gt;&lt;br&gt;NOTE: User cannot specify both host and hostGroup properties.
+        /// Serialized Name: VirtualMachineUpdate.properties.hostGroup
+        /// </param>
+        /// <param name="provisioningState">
+        /// The provisioning state, which only appears in the response.
+        /// Serialized Name: VirtualMachineUpdate.properties.provisioningState
+        /// </param>
+        /// <param name="instanceView">
+        /// The virtual machine instance view.
+        /// Serialized Name: VirtualMachineUpdate.properties.instanceView
+        /// </param>
+        /// <param name="licenseType">
+        /// Specifies that the image or disk that is being used was licensed on-premises. This element is only used for images that contain the Windows Server operating system. &lt;br&gt;&lt;br&gt; Possible values are: &lt;br&gt;&lt;br&gt; Windows_Client &lt;br&gt;&lt;br&gt; Windows_Server &lt;br&gt;&lt;br&gt; If this element is included in a request for an update, the value must match the initial value. This value cannot be updated. &lt;br&gt;&lt;br&gt; For more information, see [Azure Hybrid Use Benefit for Windows Server](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json) &lt;br&gt;&lt;br&gt; Minimum api-version: 2015-06-15
+        /// Serialized Name: VirtualMachineUpdate.properties.licenseType
+        /// </param>
+        /// <param name="vmId">
+        /// Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.
+        /// Serialized Name: VirtualMachineUpdate.properties.vmId
+        /// </param>
+        /// <param name="extensionsTimeBudget">
+        /// Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). &lt;br&gt;&lt;br&gt; Minimum api-version: 2020-06-01
+        /// Serialized Name: VirtualMachineUpdate.properties.extensionsTimeBudget
+        /// </param>
+        internal VirtualMachinePatch(IDictionary<string, string> tags, MgmtAcronymMappingPlan plan, ManagedServiceIdentity identity, IList<string> zones, HardwareProfile hardwareProfile, StorageProfile storageProfile, AdditionalCapabilities additionalCapabilities, OSProfile osProfile, NetworkProfile networkProfile, SecurityProfile securityProfile, DiagnosticsProfile diagnosticsProfile, WritableSubResource availabilitySet, WritableSubResource virtualMachineScaleSet, WritableSubResource proximityPlacementGroup, VirtualMachinePriorityType? priority, VirtualMachineEvictionPolicyType? evictionPolicy, BillingProfile billingProfile, WritableSubResource host, WritableSubResource hostGroup, string provisioningState, VirtualMachineInstanceView instanceView, string licenseType, string vmId, string extensionsTimeBudget) : base(tags)
+        {
+            Plan = plan;
+            Identity = identity;
+            Zones = zones;
+            HardwareProfile = hardwareProfile;
+            StorageProfile = storageProfile;
+            AdditionalCapabilities = additionalCapabilities;
+            OSProfile = osProfile;
+            NetworkProfile = networkProfile;
+            SecurityProfile = securityProfile;
+            DiagnosticsProfile = diagnosticsProfile;
+            AvailabilitySet = availabilitySet;
+            VirtualMachineScaleSet = virtualMachineScaleSet;
+            ProximityPlacementGroup = proximityPlacementGroup;
+            Priority = priority;
+            EvictionPolicy = evictionPolicy;
+            BillingProfile = billingProfile;
+            Host = host;
+            HostGroup = hostGroup;
+            ProvisioningState = provisioningState;
+            InstanceView = instanceView;
+            LicenseType = licenseType;
+            VmId = vmId;
+            ExtensionsTimeBudget = extensionsTimeBudget;
+        }
+
         /// <summary>
         /// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -&gt;**. Enter any required information and then click **Save**.
         /// Serialized Name: VirtualMachineUpdate.plan

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineReimageContent.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineReimageContent.cs
@@ -18,6 +18,16 @@ namespace MgmtAcronymMapping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineReimageContent"/>. </summary>
+        /// <param name="tempDisk">
+        /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
+        /// Serialized Name: VirtualMachineReimageParameters.tempDisk
+        /// </param>
+        internal VirtualMachineReimageContent(bool? tempDisk)
+        {
+            TempDisk = tempDisk;
+        }
+
         /// <summary>
         /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
         /// Serialized Name: VirtualMachineReimageParameters.tempDisk

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetPatch.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetPatch.cs
@@ -23,6 +23,75 @@ namespace MgmtAcronymMapping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetPatch"/>. </summary>
+        /// <param name="tags">
+        /// Resource tags
+        /// Serialized Name: UpdateResource.tags
+        /// </param>
+        /// <param name="sku">
+        /// The virtual machine scale set sku.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.sku
+        /// </param>
+        /// <param name="plan">
+        /// The purchase plan when deploying a virtual machine scale set from VM Marketplace images.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.plan
+        /// </param>
+        /// <param name="identity">
+        /// The identity of the virtual machine scale set, if configured.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.identity
+        /// </param>
+        /// <param name="upgradePolicy">
+        /// The upgrade policy.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.upgradePolicy
+        /// </param>
+        /// <param name="automaticRepairsPolicy">
+        /// Policy for automatic repairs.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.automaticRepairsPolicy
+        /// </param>
+        /// <param name="virtualMachineProfile">
+        /// The virtual machine profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.virtualMachineProfile
+        /// </param>
+        /// <param name="overprovision">
+        /// Specifies whether the Virtual Machine Scale Set should be overprovisioned.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.overprovision
+        /// </param>
+        /// <param name="doNotRunExtensionsOnOverprovisionedVms">
+        /// When Overprovision is enabled, extensions are launched only on the requested number of VMs which are finally kept. This property will hence ensure that the extensions do not run on the extra overprovisioned VMs.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.doNotRunExtensionsOnOverprovisionedVMs
+        /// </param>
+        /// <param name="singlePlacementGroup">
+        /// When true this limits the scale set to a single placement group, of max size 100 virtual machines. NOTE: If singlePlacementGroup is true, it may be modified to false. However, if singlePlacementGroup is false, it may not be modified to true.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.singlePlacementGroup
+        /// </param>
+        /// <param name="additionalCapabilities">
+        /// Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the Virtual Machines have the capability to support attaching managed data disks with UltraSSD_LRS storage account type.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.additionalCapabilities
+        /// </param>
+        /// <param name="scaleInPolicy">
+        /// Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.scaleInPolicy
+        /// </param>
+        /// <param name="proximityPlacementGroup">
+        /// Specifies information about the proximity placement group that the virtual machine scale set should be assigned to. &lt;br&gt;&lt;br&gt;Minimum api-version: 2018-04-01.
+        /// Serialized Name: VirtualMachineScaleSetUpdate.properties.proximityPlacementGroup
+        /// </param>
+        internal VirtualMachineScaleSetPatch(IDictionary<string, string> tags, MgmtAcronymMappingSku sku, MgmtAcronymMappingPlan plan, ManagedServiceIdentity identity, UpgradePolicy upgradePolicy, AutomaticRepairsPolicy automaticRepairsPolicy, VirtualMachineScaleSetUpdateVmProfile virtualMachineProfile, bool? overprovision, bool? doNotRunExtensionsOnOverprovisionedVms, bool? singlePlacementGroup, AdditionalCapabilities additionalCapabilities, ScaleInPolicy scaleInPolicy, WritableSubResource proximityPlacementGroup) : base(tags)
+        {
+            Sku = sku;
+            Plan = plan;
+            Identity = identity;
+            UpgradePolicy = upgradePolicy;
+            AutomaticRepairsPolicy = automaticRepairsPolicy;
+            VirtualMachineProfile = virtualMachineProfile;
+            Overprovision = overprovision;
+            DoNotRunExtensionsOnOverprovisionedVms = doNotRunExtensionsOnOverprovisionedVms;
+            SinglePlacementGroup = singlePlacementGroup;
+            AdditionalCapabilities = additionalCapabilities;
+            ScaleInPolicy = scaleInPolicy;
+            ProximityPlacementGroup = proximityPlacementGroup;
+        }
+
         /// <summary>
         /// The virtual machine scale set sku.
         /// Serialized Name: VirtualMachineScaleSetUpdate.sku

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetReimageContent.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetReimageContent.cs
@@ -22,6 +22,20 @@ namespace MgmtAcronymMapping.Models
             InstanceIds = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetReimageContent"/>. </summary>
+        /// <param name="tempDisk">
+        /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
+        /// Serialized Name: VirtualMachineReimageParameters.tempDisk
+        /// </param>
+        /// <param name="instanceIds">
+        /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
+        /// Serialized Name: VirtualMachineScaleSetReimageParameters.instanceIds
+        /// </param>
+        internal VirtualMachineScaleSetReimageContent(bool? tempDisk, IList<string> instanceIds) : base(tempDisk)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary>
         /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
         /// Serialized Name: VirtualMachineScaleSetReimageParameters.instanceIds

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateNetworkProfile.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateNetworkProfile.cs
@@ -23,6 +23,21 @@ namespace MgmtAcronymMapping.Models
             NetworkInterfaceConfigurations = new ChangeTrackingList<VirtualMachineScaleSetUpdateNetworkConfiguration>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateNetworkProfile"/>. </summary>
+        /// <param name="healthProbe">
+        /// A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The reference will be in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'.
+        /// Serialized Name: VirtualMachineScaleSetUpdateNetworkProfile.healthProbe
+        /// </param>
+        /// <param name="networkInterfaceConfigurations">
+        /// The list of network configurations.
+        /// Serialized Name: VirtualMachineScaleSetUpdateNetworkProfile.networkInterfaceConfigurations
+        /// </param>
+        internal VirtualMachineScaleSetUpdateNetworkProfile(WritableSubResource healthProbe, IList<VirtualMachineScaleSetUpdateNetworkConfiguration> networkInterfaceConfigurations)
+        {
+            HealthProbe = healthProbe;
+            NetworkInterfaceConfigurations = networkInterfaceConfigurations;
+        }
+
         /// <summary>
         /// A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The reference will be in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'.
         /// Serialized Name: VirtualMachineScaleSetUpdateNetworkProfile.healthProbe

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateOSDisk.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateOSDisk.cs
@@ -23,6 +23,41 @@ namespace MgmtAcronymMapping.Models
             VhdContainers = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateOSDisk"/>. </summary>
+        /// <param name="caching">
+        /// The caching type.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.caching
+        /// </param>
+        /// <param name="writeAcceleratorEnabled">
+        /// Specifies whether writeAccelerator should be enabled or disabled on the disk.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.writeAcceleratorEnabled
+        /// </param>
+        /// <param name="diskSizeGB">
+        /// Specifies the size of the operating system disk in gigabytes. This element can be used to overwrite the size of the disk in a virtual machine image. &lt;br&gt;&lt;br&gt; This value cannot be larger than 1023 GB
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.diskSizeGB
+        /// </param>
+        /// <param name="image">
+        /// The Source User Image VirtualHardDisk. This VirtualHardDisk will be copied before using it to attach to the Virtual Machine. If SourceImage is provided, the destination VirtualHardDisk should not exist.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.image
+        /// </param>
+        /// <param name="vhdContainers">
+        /// The list of virtual hard disk container uris.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.vhdContainers
+        /// </param>
+        /// <param name="managedDisk">
+        /// The managed disk parameters.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.managedDisk
+        /// </param>
+        internal VirtualMachineScaleSetUpdateOSDisk(CachingType? caching, bool? writeAcceleratorEnabled, int? diskSizeGB, VirtualHardDisk image, IList<string> vhdContainers, VirtualMachineScaleSetManagedDiskParameters managedDisk)
+        {
+            Caching = caching;
+            WriteAcceleratorEnabled = writeAcceleratorEnabled;
+            DiskSizeGB = diskSizeGB;
+            Image = image;
+            VhdContainers = vhdContainers;
+            ManagedDisk = managedDisk;
+        }
+
         /// <summary>
         /// The caching type.
         /// Serialized Name: VirtualMachineScaleSetUpdateOSDisk.caching

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateOSProfile.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateOSProfile.cs
@@ -22,6 +22,31 @@ namespace MgmtAcronymMapping.Models
             Secrets = new ChangeTrackingList<VaultSecretGroup>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateOSProfile"/>. </summary>
+        /// <param name="customData">
+        /// A base-64 encoded string of custom data.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.customData
+        /// </param>
+        /// <param name="windowsConfiguration">
+        /// The Windows Configuration of the OS profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.windowsConfiguration
+        /// </param>
+        /// <param name="linuxConfiguration">
+        /// The Linux Configuration of the OS profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.linuxConfiguration
+        /// </param>
+        /// <param name="secrets">
+        /// The List of certificates for addition to the VM.
+        /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.secrets
+        /// </param>
+        internal VirtualMachineScaleSetUpdateOSProfile(string customData, WindowsConfiguration windowsConfiguration, LinuxConfiguration linuxConfiguration, IList<VaultSecretGroup> secrets)
+        {
+            CustomData = customData;
+            WindowsConfiguration = windowsConfiguration;
+            LinuxConfiguration = linuxConfiguration;
+            Secrets = secrets;
+        }
+
         /// <summary>
         /// A base-64 encoded string of custom data.
         /// Serialized Name: VirtualMachineScaleSetUpdateOSProfile.customData

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateStorageProfile.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateStorageProfile.cs
@@ -22,6 +22,26 @@ namespace MgmtAcronymMapping.Models
             DataDisks = new ChangeTrackingList<VirtualMachineScaleSetDataDisk>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateStorageProfile"/>. </summary>
+        /// <param name="imageReference">
+        /// The image reference.
+        /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.imageReference
+        /// </param>
+        /// <param name="osDisk">
+        /// The OS disk.
+        /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.osDisk
+        /// </param>
+        /// <param name="dataDisks">
+        /// The data disks.
+        /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.dataDisks
+        /// </param>
+        internal VirtualMachineScaleSetUpdateStorageProfile(ImageReference imageReference, VirtualMachineScaleSetUpdateOSDisk osDisk, IList<VirtualMachineScaleSetDataDisk> dataDisks)
+        {
+            ImageReference = imageReference;
+            OSDisk = osDisk;
+            DataDisks = dataDisks;
+        }
+
         /// <summary>
         /// The image reference.
         /// Serialized Name: VirtualMachineScaleSetUpdateStorageProfile.imageReference

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateVmProfile.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetUpdateVmProfile.cs
@@ -18,6 +18,56 @@ namespace MgmtAcronymMapping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetUpdateVmProfile"/>. </summary>
+        /// <param name="osProfile">
+        /// The virtual machine scale set OS profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.osProfile
+        /// </param>
+        /// <param name="storageProfile">
+        /// The virtual machine scale set storage profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.storageProfile
+        /// </param>
+        /// <param name="networkProfile">
+        /// The virtual machine scale set network profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.networkProfile
+        /// </param>
+        /// <param name="securityProfile">
+        /// The virtual machine scale set Security profile
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.securityProfile
+        /// </param>
+        /// <param name="diagnosticsProfile">
+        /// The virtual machine scale set diagnostics profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.diagnosticsProfile
+        /// </param>
+        /// <param name="extensionProfile">
+        /// The virtual machine scale set extension profile.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.extensionProfile
+        /// </param>
+        /// <param name="licenseType">
+        /// The license type, which is for bring your own license scenario.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.licenseType
+        /// </param>
+        /// <param name="billingProfile">
+        /// Specifies the billing related details of a Azure Spot VMSS. &lt;br&gt;&lt;br&gt;Minimum api-version: 2019-03-01.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.billingProfile
+        /// </param>
+        /// <param name="scheduledEventsProfile">
+        /// Specifies Scheduled Event related configurations.
+        /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.scheduledEventsProfile
+        /// </param>
+        internal VirtualMachineScaleSetUpdateVmProfile(VirtualMachineScaleSetUpdateOSProfile osProfile, VirtualMachineScaleSetUpdateStorageProfile storageProfile, VirtualMachineScaleSetUpdateNetworkProfile networkProfile, SecurityProfile securityProfile, DiagnosticsProfile diagnosticsProfile, VirtualMachineScaleSetExtensionProfile extensionProfile, string licenseType, BillingProfile billingProfile, ScheduledEventsProfile scheduledEventsProfile)
+        {
+            OSProfile = osProfile;
+            StorageProfile = storageProfile;
+            NetworkProfile = networkProfile;
+            SecurityProfile = securityProfile;
+            DiagnosticsProfile = diagnosticsProfile;
+            ExtensionProfile = extensionProfile;
+            LicenseType = licenseType;
+            BillingProfile = billingProfile;
+            ScheduledEventsProfile = scheduledEventsProfile;
+        }
+
         /// <summary>
         /// The virtual machine scale set OS profile.
         /// Serialized Name: VirtualMachineScaleSetUpdateVMProfile.osProfile

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetVmInstanceIds.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetVmInstanceIds.cs
@@ -22,6 +22,16 @@ namespace MgmtAcronymMapping.Models
             InstanceIds = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVmInstanceIds"/>. </summary>
+        /// <param name="instanceIds">
+        /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
+        /// Serialized Name: VirtualMachineScaleSetVMInstanceIDs.instanceIds
+        /// </param>
+        internal VirtualMachineScaleSetVmInstanceIds(IList<string> instanceIds)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary>
         /// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set.
         /// Serialized Name: VirtualMachineScaleSetVMInstanceIDs.instanceIds

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetVmInstanceRequiredIds.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetVmInstanceRequiredIds.cs
@@ -31,6 +31,16 @@ namespace MgmtAcronymMapping.Models
             InstanceIds = instanceIds.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVmInstanceRequiredIds"/>. </summary>
+        /// <param name="instanceIds">
+        /// The virtual machine scale set instance ids.
+        /// Serialized Name: VirtualMachineScaleSetVMInstanceRequiredIDs.instanceIds
+        /// </param>
+        internal VirtualMachineScaleSetVmInstanceRequiredIds(IList<string> instanceIds)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary>
         /// The virtual machine scale set instance ids.
         /// Serialized Name: VirtualMachineScaleSetVMInstanceRequiredIDs.instanceIds

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetVmReimageContent.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VirtualMachineScaleSetVmReimageContent.cs
@@ -17,5 +17,14 @@ namespace MgmtAcronymMapping.Models
         public VirtualMachineScaleSetVmReimageContent()
         {
         }
+
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVmReimageContent"/>. </summary>
+        /// <param name="tempDisk">
+        /// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported for VM/VMSS with Ephemeral OS disk.
+        /// Serialized Name: VirtualMachineReimageParameters.tempDisk
+        /// </param>
+        internal VirtualMachineScaleSetVmReimageContent(bool? tempDisk) : base(tempDisk)
+        {
+        }
     }
 }

--- a/test/TestProjects/MgmtAcronymMapping/Generated/Models/VmScaleSetConvertToSinglePlacementGroupContent.cs
+++ b/test/TestProjects/MgmtAcronymMapping/Generated/Models/VmScaleSetConvertToSinglePlacementGroupContent.cs
@@ -18,6 +18,16 @@ namespace MgmtAcronymMapping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="VmScaleSetConvertToSinglePlacementGroupContent"/>. </summary>
+        /// <param name="activePlacementGroupId">
+        /// Id of the placement group in which you want future virtual machine instances to be placed. To query placement group Id, please use Virtual Machine Scale Set VMs - Get API. If not provided, the platform will choose one with maximum number of virtual machine instances.
+        /// Serialized Name: VMScaleSetConvertToSinglePlacementGroupInput.activePlacementGroupId
+        /// </param>
+        internal VmScaleSetConvertToSinglePlacementGroupContent(string activePlacementGroupId)
+        {
+            ActivePlacementGroupId = activePlacementGroupId;
+        }
+
         /// <summary>
         /// Id of the placement group in which you want future virtual machine instances to be placed. To query placement group Id, please use Virtual Machine Scale Set VMs - Get API. If not provided, the platform will choose one with maximum number of virtual machine instances.
         /// Serialized Name: VMScaleSetConvertToSinglePlacementGroupInput.activePlacementGroupId

--- a/test/TestProjects/MgmtConstants/Generated/Models/OptionalMachinePatch.cs
+++ b/test/TestProjects/MgmtConstants/Generated/Models/OptionalMachinePatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtConstants.Models
 {
     /// <summary> Describes a Virtual Machine Update. </summary>
@@ -13,6 +15,16 @@ namespace MgmtConstants.Models
         /// <summary> Initializes a new instance of <see cref="OptionalMachinePatch"/>. </summary>
         public OptionalMachinePatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="OptionalMachinePatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="listener"> Describes Protocol and thumbprint of Windows Remote Management listener. </param>
+        /// <param name="content"> Specifies additional XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup. Contents are defined by setting name, component name, and the pass in which the content is applied. </param>
+        internal OptionalMachinePatch(IDictionary<string, string> tags, ModelWithRequiredConstant listener, ModelWithOptionalConstant content) : base(tags)
+        {
+            Listener = listener;
+            Content = content;
         }
 
         /// <summary> Describes Protocol and thumbprint of Windows Remote Management listener. </summary>

--- a/test/TestProjects/MgmtConstants/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtConstants/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtConstants.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/DnsResourceReferenceContent.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/DnsResourceReferenceContent.cs
@@ -20,6 +20,13 @@ namespace MgmtExpandResourceTypes.Models
             TargetResources = new ChangeTrackingList<WritableSubResource>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="DnsResourceReferenceContent"/>. </summary>
+        /// <param name="targetResources"> A list of references to azure resources for which referencing dns records need to be queried. </param>
+        internal DnsResourceReferenceContent(IList<WritableSubResource> targetResources)
+        {
+            TargetResources = targetResources;
+        }
+
         /// <summary> A list of references to azure resources for which referencing dns records need to be queried. </summary>
         public IList<WritableSubResource> TargetResources { get; }
     }

--- a/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/ZonePatch.cs
+++ b/test/TestProjects/MgmtExpandResourceTypes/Generated/Models/ZonePatch.cs
@@ -19,6 +19,13 @@ namespace MgmtExpandResourceTypes.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="ZonePatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal ZonePatch(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtExtensionResource/Generated/Models/ValidateSomethingContent.cs
+++ b/test/TestProjects/MgmtExtensionResource/Generated/Models/ValidateSomethingContent.cs
@@ -15,6 +15,13 @@ namespace MgmtExtensionResource.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ValidateSomethingContent"/>. </summary>
+        /// <param name="something"> The something to validate. </param>
+        internal ValidateSomethingContent(string something)
+        {
+            Something = something;
+        }
+
         /// <summary> The something to validate. </summary>
         public string Something { get; set; }
     }

--- a/test/TestProjects/MgmtLRO/Generated/Models/BarPatch.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/BarPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtLRO.Models
 {
@@ -15,6 +16,14 @@ namespace MgmtLRO.Models
         /// <summary> Initializes a new instance of <see cref="BarPatch"/>. </summary>
         public BarPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="BarPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="buzz"> Update Domain count. </param>
+        internal BarPatch(IDictionary<string, string> tags, Guid? buzz) : base(tags)
+        {
+            Buzz = buzz;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtLRO/Generated/Models/FakePatch.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/FakePatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtLRO.Models
 {
     /// <summary> Specifies information about the fake that the virtual machine should be assigned to. Only tags may be updated. </summary>
@@ -13,6 +15,16 @@ namespace MgmtLRO.Models
         /// <summary> Initializes a new instance of <see cref="FakePatch"/>. </summary>
         public FakePatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="FakePatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformUpdateDomainCount"> Update Domain count. </param>
+        /// <param name="platformFaultDomainCount"> Fault Domain count. </param>
+        internal FakePatch(IDictionary<string, string> tags, int? platformUpdateDomainCount, int? platformFaultDomainCount) : base(tags)
+        {
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtLRO/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtLRO/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtLRO.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtListMethods/Generated/Models/QuotaBaseProperties.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/QuotaBaseProperties.cs
@@ -15,6 +15,19 @@ namespace MgmtListMethods.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="QuotaBaseProperties"/>. </summary>
+        /// <param name="id"> Specifies the resource ID. </param>
+        /// <param name="quotaBasePropertiesType"> Specifies the resource type. </param>
+        /// <param name="limit"> The maximum permitted quota of the resource. </param>
+        /// <param name="unit"> An enum describing the unit of quota measurement. </param>
+        internal QuotaBaseProperties(string id, string quotaBasePropertiesType, long? limit, QuotaUnit? unit)
+        {
+            Id = id;
+            QuotaBasePropertiesType = quotaBasePropertiesType;
+            Limit = limit;
+            Unit = unit;
+        }
+
         /// <summary> Specifies the resource ID. </summary>
         public string Id { get; set; }
         /// <summary> Specifies the resource type. </summary>

--- a/test/TestProjects/MgmtListMethods/Generated/Models/QuotaUpdateContent.cs
+++ b/test/TestProjects/MgmtListMethods/Generated/Models/QuotaUpdateContent.cs
@@ -19,6 +19,15 @@ namespace MgmtListMethods.Models
             Value = new ChangeTrackingList<QuotaBaseProperties>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="QuotaUpdateContent"/>. </summary>
+        /// <param name="value"> The list for update quota. </param>
+        /// <param name="location"> Region of workspace quota to be updated. </param>
+        internal QuotaUpdateContent(IList<QuotaBaseProperties> value, string location)
+        {
+            Value = value;
+            Location = location;
+        }
+
         /// <summary> The list for update quota. </summary>
         public IList<QuotaBaseProperties> Value { get; }
         /// <summary> Region of workspace quota to be updated. </summary>

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/Models/DiskEncryptionSetPatch.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/Models/DiskEncryptionSetPatch.cs
@@ -20,6 +20,23 @@ namespace MgmtMockAndSample.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="DiskEncryptionSetPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="identity"> Identity for the virtual machine. </param>
+        /// <param name="encryptionType"> The type of key used to encrypt the data of the disk. </param>
+        /// <param name="activeKey"> Key Vault Key Url to be used for server side encryption of Managed Disks and Snapshots. </param>
+        /// <param name="rotationToLatestKeyVersionEnabled"> Set this flag to true to enable auto-updating of this disk encryption set to the latest key version. </param>
+        /// <param name="federatedClientId"> Multi-tenant application client id to access key vault in a different tenant. Setting the value to 'None' will clear the property. </param>
+        internal DiskEncryptionSetPatch(IDictionary<string, string> tags, ManagedServiceIdentity identity, DiskEncryptionSetType? encryptionType, KeyForDiskEncryptionSet activeKey, bool? rotationToLatestKeyVersionEnabled, string federatedClientId)
+        {
+            Tags = tags;
+            Identity = identity;
+            EncryptionType = encryptionType;
+            ActiveKey = activeKey;
+            RotationToLatestKeyVersionEnabled = rotationToLatestKeyVersionEnabled;
+            FederatedClientId = federatedClientId;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
         /// <summary> Identity for the virtual machine. </summary>

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/Models/RoleAssignmentCreateOrUpdateContent.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/Models/RoleAssignmentCreateOrUpdateContent.cs
@@ -15,6 +15,17 @@ namespace MgmtMockAndSample.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="RoleAssignmentCreateOrUpdateContent"/>. </summary>
+        /// <param name="roleDefinitionId"> The role definition ID used in the role assignment. </param>
+        /// <param name="principalId"> The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group. </param>
+        /// <param name="canDelegate"> The delegation flag used for creating a role assignment. </param>
+        internal RoleAssignmentCreateOrUpdateContent(string roleDefinitionId, string principalId, bool? canDelegate)
+        {
+            RoleDefinitionId = roleDefinitionId;
+            PrincipalId = principalId;
+            CanDelegate = canDelegate;
+        }
+
         /// <summary> The role definition ID used in the role assignment. </summary>
         public string RoleDefinitionId { get; set; }
         /// <summary> The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group. </summary>

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultCheckNameAvailabilityContent.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultCheckNameAvailabilityContent.cs
@@ -24,6 +24,15 @@ namespace MgmtMockAndSample.Models
             ResourceType = EncryptionType.MicrosoftKeyVaultVaults;
         }
 
+        /// <summary> Initializes a new instance of <see cref="VaultCheckNameAvailabilityContent"/>. </summary>
+        /// <param name="name"> The vault name. </param>
+        /// <param name="resourceType"> The type of resource, Microsoft.KeyVault/vaults. </param>
+        internal VaultCheckNameAvailabilityContent(string name, EncryptionType resourceType)
+        {
+            Name = name;
+            ResourceType = resourceType;
+        }
+
         /// <summary> The vault name. </summary>
         public string Name { get; }
         /// <summary> The type of resource, Microsoft.KeyVault/vaults. </summary>

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultCreateOrUpdateContent.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultCreateOrUpdateContent.cs
@@ -28,6 +28,19 @@ namespace MgmtMockAndSample.Models
             Properties = properties;
         }
 
+        /// <summary> Initializes a new instance of <see cref="VaultCreateOrUpdateContent"/>. </summary>
+        /// <param name="location"> The supported Azure location where the key vault should be created. </param>
+        /// <param name="tags"> The tags that will be assigned to the key vault. </param>
+        /// <param name="properties"> Properties of the vault. </param>
+        /// <param name="identity"> Identity for the virtual machine. </param>
+        internal VaultCreateOrUpdateContent(AzureLocation location, IDictionary<string, string> tags, VaultProperties properties, ManagedServiceIdentity identity)
+        {
+            Location = location;
+            Tags = tags;
+            Properties = properties;
+            Identity = identity;
+        }
+
         /// <summary> The supported Azure location where the key vault should be created. </summary>
         public AzureLocation Location { get; }
         /// <summary> The tags that will be assigned to the key vault. </summary>

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultPatch.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultPatch.cs
@@ -19,6 +19,15 @@ namespace MgmtMockAndSample.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VaultPatch"/>. </summary>
+        /// <param name="tags"> The tags that will be assigned to the key vault. </param>
+        /// <param name="properties"> Properties of the vault. </param>
+        internal VaultPatch(IDictionary<string, string> tags, VaultPatchProperties properties)
+        {
+            Tags = tags;
+            Properties = properties;
+        }
+
         /// <summary> The tags that will be assigned to the key vault. </summary>
         public IDictionary<string, string> Tags { get; }
         /// <summary> Properties of the vault. </summary>

--- a/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultPatchProperties.cs
+++ b/test/TestProjects/MgmtMockAndSample/src/Generated/Models/VaultPatchProperties.cs
@@ -20,6 +20,37 @@ namespace MgmtMockAndSample.Models
             AccessPolicies = new ChangeTrackingList<AccessPolicyEntry>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VaultPatchProperties"/>. </summary>
+        /// <param name="tenantId"> The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. </param>
+        /// <param name="sku"> SKU details. </param>
+        /// <param name="accessPolicies"> An array of 0 to 16 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID. </param>
+        /// <param name="enabledForDeployment"> Property to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault. </param>
+        /// <param name="enabledForDiskEncryption"> Property to specify whether Azure Disk Encryption is permitted to retrieve secrets from the vault and unwrap keys. </param>
+        /// <param name="enabledForTemplateDeployment"> Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault. </param>
+        /// <param name="enableSoftDelete"> Property to specify whether the 'soft delete' functionality is enabled for this key vault. Once set to true, it cannot be reverted to false. </param>
+        /// <param name="enableRbacAuthorization"> Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored. When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the value of this property will not change. </param>
+        /// <param name="softDeleteRetentionInDays"> softDelete data retention days. It accepts &gt;=7 and &lt;=90. </param>
+        /// <param name="createMode"> The vault's create mode to indicate whether the vault need to be recovered or not. </param>
+        /// <param name="enablePurgeProtection"> Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value. </param>
+        /// <param name="networkAcls"> A collection of rules governing the accessibility of the vault from specific network locations. </param>
+        /// <param name="publicNetworkAccess"> Property to specify whether the vault will accept traffic from public internet. If set to 'disabled' all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, meaning that even if the firewall rules are present we will not honor the rules. </param>
+        internal VaultPatchProperties(Guid? tenantId, MgmtMockAndSampleSku sku, IList<AccessPolicyEntry> accessPolicies, bool? enabledForDeployment, bool? enabledForDiskEncryption, bool? enabledForTemplateDeployment, bool? enableSoftDelete, bool? enableRbacAuthorization, int? softDeleteRetentionInDays, CreateMode? createMode, bool? enablePurgeProtection, NetworkRuleSet networkAcls, string publicNetworkAccess)
+        {
+            TenantId = tenantId;
+            Sku = sku;
+            AccessPolicies = accessPolicies;
+            EnabledForDeployment = enabledForDeployment;
+            EnabledForDiskEncryption = enabledForDiskEncryption;
+            EnabledForTemplateDeployment = enabledForTemplateDeployment;
+            EnableSoftDelete = enableSoftDelete;
+            EnableRbacAuthorization = enableRbacAuthorization;
+            SoftDeleteRetentionInDays = softDeleteRetentionInDays;
+            CreateMode = createMode;
+            EnablePurgeProtection = enablePurgeProtection;
+            NetworkAcls = networkAcls;
+            PublicNetworkAccess = publicNetworkAccess;
+        }
+
         /// <summary> The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. </summary>
         public Guid? TenantId { get; set; }
         /// <summary> SKU details. </summary>

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/Models/AnotherParentPatch.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/Models/AnotherParentPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtMultipleParentResource.Models
 {
@@ -15,6 +16,26 @@ namespace MgmtMultipleParentResource.Models
         /// <summary> Initializes a new instance of <see cref="AnotherParentPatch"/>. </summary>
         public AnotherParentPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="AnotherParentPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="asyncExecution"> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </param>
+        /// <param name="runAsUser"> Specifies the user account on the VM when executing the run command. </param>
+        /// <param name="runAsPassword"> Specifies the user account password on the VM when executing the run command. </param>
+        /// <param name="timeoutInSeconds"> The timeout in seconds to execute the run command. </param>
+        /// <param name="outputBlobUri"> Specifies the Azure storage blob where script output stream will be uploaded. </param>
+        /// <param name="errorBlobUri"> Specifies the Azure storage blob where script error stream will be uploaded. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        internal AnotherParentPatch(IDictionary<string, string> tags, bool? asyncExecution, string runAsUser, string runAsPassword, int? timeoutInSeconds, Uri outputBlobUri, Uri errorBlobUri, string provisioningState) : base(tags)
+        {
+            AsyncExecution = asyncExecution;
+            RunAsUser = runAsUser;
+            RunAsPassword = runAsPassword;
+            TimeoutInSeconds = timeoutInSeconds;
+            OutputBlobUri = outputBlobUri;
+            ErrorBlobUri = errorBlobUri;
+            ProvisioningState = provisioningState;
         }
 
         /// <summary> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </summary>

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/Models/ChildBodyUpdate.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/Models/ChildBodyUpdate.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtMultipleParentResource.Models
 {
@@ -15,6 +16,26 @@ namespace MgmtMultipleParentResource.Models
         /// <summary> Initializes a new instance of <see cref="ChildBodyUpdate"/>. </summary>
         public ChildBodyUpdate()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="ChildBodyUpdate"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="asyncExecution"> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </param>
+        /// <param name="runAsUser"> Specifies the user account on the VM when executing the run command. </param>
+        /// <param name="runAsPassword"> Specifies the user account password on the VM when executing the run command. </param>
+        /// <param name="timeoutInSeconds"> The timeout in seconds to execute the run command. </param>
+        /// <param name="outputBlobUri"> Specifies the Azure storage blob where script output stream will be uploaded. </param>
+        /// <param name="errorBlobUri"> Specifies the Azure storage blob where script error stream will be uploaded. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        internal ChildBodyUpdate(IDictionary<string, string> tags, bool? asyncExecution, string runAsUser, string runAsPassword, int? timeoutInSeconds, Uri outputBlobUri, Uri errorBlobUri, string provisioningState) : base(tags)
+        {
+            AsyncExecution = asyncExecution;
+            RunAsUser = runAsUser;
+            RunAsPassword = runAsPassword;
+            TimeoutInSeconds = timeoutInSeconds;
+            OutputBlobUri = outputBlobUri;
+            ErrorBlobUri = errorBlobUri;
+            ProvisioningState = provisioningState;
         }
 
         /// <summary> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </summary>

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/Models/SubParentPatch.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/Models/SubParentPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtMultipleParentResource.Models
 {
@@ -15,6 +16,26 @@ namespace MgmtMultipleParentResource.Models
         /// <summary> Initializes a new instance of <see cref="SubParentPatch"/>. </summary>
         public SubParentPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="SubParentPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="asyncExecution"> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </param>
+        /// <param name="runAsUser"> Specifies the user account on the VM when executing the run command. </param>
+        /// <param name="runAsPassword"> Specifies the user account password on the VM when executing the run command. </param>
+        /// <param name="timeoutInSeconds"> The timeout in seconds to execute the run command. </param>
+        /// <param name="outputBlobUri"> Specifies the Azure storage blob where script output stream will be uploaded. </param>
+        /// <param name="errorBlobUri"> Specifies the Azure storage blob where script error stream will be uploaded. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        internal SubParentPatch(IDictionary<string, string> tags, bool? asyncExecution, string runAsUser, string runAsPassword, int? timeoutInSeconds, Uri outputBlobUri, Uri errorBlobUri, string provisioningState) : base(tags)
+        {
+            AsyncExecution = asyncExecution;
+            RunAsUser = runAsUser;
+            RunAsPassword = runAsPassword;
+            TimeoutInSeconds = timeoutInSeconds;
+            OutputBlobUri = outputBlobUri;
+            ErrorBlobUri = errorBlobUri;
+            ProvisioningState = provisioningState;
         }
 
         /// <summary> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </summary>

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/Models/TheParentPatch.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/Models/TheParentPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtMultipleParentResource.Models
 {
@@ -15,6 +16,26 @@ namespace MgmtMultipleParentResource.Models
         /// <summary> Initializes a new instance of <see cref="TheParentPatch"/>. </summary>
         public TheParentPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="TheParentPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="asyncExecution"> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </param>
+        /// <param name="runAsUser"> Specifies the user account on the VM when executing the run command. </param>
+        /// <param name="runAsPassword"> Specifies the user account password on the VM when executing the run command. </param>
+        /// <param name="timeoutInSeconds"> The timeout in seconds to execute the run command. </param>
+        /// <param name="outputBlobUri"> Specifies the Azure storage blob where script output stream will be uploaded. </param>
+        /// <param name="errorBlobUri"> Specifies the Azure storage blob where script error stream will be uploaded. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        internal TheParentPatch(IDictionary<string, string> tags, bool? asyncExecution, string runAsUser, string runAsPassword, int? timeoutInSeconds, Uri outputBlobUri, Uri errorBlobUri, string provisioningState) : base(tags)
+        {
+            AsyncExecution = asyncExecution;
+            RunAsUser = runAsUser;
+            RunAsPassword = runAsPassword;
+            TimeoutInSeconds = timeoutInSeconds;
+            OutputBlobUri = outputBlobUri;
+            ErrorBlobUri = errorBlobUri;
+            ProvisioningState = provisioningState;
         }
 
         /// <summary> Optional. If set to true, provisioning will complete as soon as the script starts and will not wait for script to complete. </summary>

--- a/test/TestProjects/MgmtMultipleParentResource/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtMultipleParentResource/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtMultipleParentResource.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/BarPatch.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/BarPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtNonStringPathVariable.Models
 {
@@ -15,6 +16,14 @@ namespace MgmtNonStringPathVariable.Models
         /// <summary> Initializes a new instance of <see cref="BarPatch"/>. </summary>
         public BarPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="BarPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="buzz"> Update Domain count. </param>
+        internal BarPatch(IDictionary<string, string> tags, Guid? buzz) : base(tags)
+        {
+            Buzz = buzz;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/FakePatch.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/FakePatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtNonStringPathVariable.Models
 {
     /// <summary> Specifies information about the fake that the virtual machine should be assigned to. Only tags may be updated. </summary>
@@ -13,6 +15,16 @@ namespace MgmtNonStringPathVariable.Models
         /// <summary> Initializes a new instance of <see cref="FakePatch"/>. </summary>
         public FakePatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="FakePatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformUpdateDomainCount"> Update Domain count. </param>
+        /// <param name="platformFaultDomainCount"> Fault Domain count. </param>
+        internal FakePatch(IDictionary<string, string> tags, int? platformUpdateDomainCount, int? platformFaultDomainCount) : base(tags)
+        {
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtNonStringPathVariable/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtNonStringPathVariable.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetUpdate.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/AvailabilitySetUpdate.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtOperations.Models
 {
     /// <summary> Specifies information about the availability set that the virtual machine should be assigned to. Only tags may be updated. </summary>
@@ -13,6 +15,16 @@ namespace MgmtOperations.Models
         /// <summary> Initializes a new instance of <see cref="AvailabilitySetUpdate"/>. </summary>
         public AvailabilitySetUpdate()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="AvailabilitySetUpdate"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformUpdateDomainCount"> Update Domain count. </param>
+        /// <param name="platformFaultDomainCount"> Fault Domain count. </param>
+        internal AvailabilitySetUpdate(IDictionary<string, string> tags, int? platformUpdateDomainCount, int? platformFaultDomainCount) : base(tags)
+        {
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourcePatch.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/UnpatchableResourcePatch.cs
@@ -19,6 +19,13 @@ namespace MgmtOperations.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UnpatchableResourcePatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UnpatchableResourcePatch(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtOperations/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtOperations/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtOperations.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/AvailabilitySetPatch.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/AvailabilitySetPatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtParamOrdering.Models
 {
     /// <summary> Specifies information about the availability set that the virtual machine should be assigned to. Only tags may be updated. </summary>
@@ -13,6 +15,16 @@ namespace MgmtParamOrdering.Models
         /// <summary> Initializes a new instance of <see cref="AvailabilitySetPatch"/>. </summary>
         public AvailabilitySetPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="AvailabilitySetPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformUpdateDomainCount"> Update Domain count. </param>
+        /// <param name="platformFaultDomainCount"> Fault Domain count. </param>
+        internal AvailabilitySetPatch(IDictionary<string, string> tags, int? platformUpdateDomainCount, int? platformFaultDomainCount) : base(tags)
+        {
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostGroupPatch.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostGroupPatch.cs
@@ -19,6 +19,18 @@ namespace MgmtParamOrdering.Models
             Zones = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="DedicatedHostGroupPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="zones"> Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone. </param>
+        /// <param name="platformFaultDomainCount"> Number of fault domains that the host group can span. </param>
+        /// <param name="supportAutomaticPlacement"> Specifies whether virtual machines or virtual machine scale sets can be placed automatically on the dedicated host group. Automatic placement means resources are allocated on dedicated hosts, that are chosen by Azure, under the dedicated host group. The value is defaulted to 'true' when not provided. &lt;br&gt;&lt;br&gt;Minimum api-version: 2020-06-01. </param>
+        internal DedicatedHostGroupPatch(IDictionary<string, string> tags, IList<string> zones, int? platformFaultDomainCount, bool? supportAutomaticPlacement) : base(tags)
+        {
+            Zones = zones;
+            PlatformFaultDomainCount = platformFaultDomainCount;
+            SupportAutomaticPlacement = supportAutomaticPlacement;
+        }
+
         /// <summary> Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone. </summary>
         public IList<string> Zones { get; }
         /// <summary> Number of fault domains that the host group can span. </summary>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostPatch.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/DedicatedHostPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtParamOrdering.Models
 {
@@ -15,6 +16,22 @@ namespace MgmtParamOrdering.Models
         /// <summary> Initializes a new instance of <see cref="DedicatedHostPatch"/>. </summary>
         public DedicatedHostPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="DedicatedHostPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformFaultDomain"> Fault domain of the dedicated host within a dedicated host group. </param>
+        /// <param name="autoReplaceOnFailure"> Specifies whether the dedicated host should be replaced automatically in case of a failure. The value is defaulted to 'true' when not provided. </param>
+        /// <param name="hostId"> A unique id generated and assigned to the dedicated host by the platform. &lt;br&gt;&lt;br&gt; Does not change throughout the lifetime of the host. </param>
+        /// <param name="provisioningOn"> The date when the host was first provisioned. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        internal DedicatedHostPatch(IDictionary<string, string> tags, int? platformFaultDomain, bool? autoReplaceOnFailure, string hostId, DateTimeOffset? provisioningOn, string provisioningState) : base(tags)
+        {
+            PlatformFaultDomain = platformFaultDomain;
+            AutoReplaceOnFailure = autoReplaceOnFailure;
+            HostId = hostId;
+            ProvisioningOn = provisioningOn;
+            ProvisioningState = provisioningState;
         }
 
         /// <summary> Fault domain of the dedicated host within a dedicated host group. </summary>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/LocationFormatObject.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/LocationFormatObject.cs
@@ -17,6 +17,15 @@ namespace MgmtParamOrdering.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="LocationFormatObject"/>. </summary>
+        /// <param name="stringLocation"> This location should be a string. </param>
+        /// <param name="objectLocation"> This location should be an AzureLocation. </param>
+        internal LocationFormatObject(string stringLocation, AzureLocation? objectLocation)
+        {
+            StringLocation = stringLocation;
+            ObjectLocation = objectLocation;
+        }
+
         /// <summary> This location should be a string. </summary>
         public string StringLocation { get; }
         /// <summary> This location should be an AzureLocation. </summary>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/MgmtParamOrderingSku.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/MgmtParamOrderingSku.cs
@@ -15,6 +15,17 @@ namespace MgmtParamOrdering.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="MgmtParamOrderingSku"/>. </summary>
+        /// <param name="name"> The sku name. </param>
+        /// <param name="tier"> Specifies the tier of virtual machines in a scale set.&lt;br /&gt;&lt;br /&gt; Possible Values:&lt;br /&gt;&lt;br /&gt; **Standard**&lt;br /&gt;&lt;br /&gt; **Basic**. </param>
+        /// <param name="capacity"> Specifies the number of virtual machines in the scale set. </param>
+        internal MgmtParamOrderingSku(string name, string tier, long? capacity)
+        {
+            Name = name;
+            Tier = tier;
+            Capacity = capacity;
+        }
+
         /// <summary> The sku name. </summary>
         public string Name { get; set; }
         /// <summary> Specifies the tier of virtual machines in a scale set.&lt;br /&gt;&lt;br /&gt; Possible Values:&lt;br /&gt;&lt;br /&gt; **Standard**&lt;br /&gt;&lt;br /&gt; **Basic**. </summary>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtParamOrdering.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetPatch.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetPatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtParamOrdering.Models
 {
     /// <summary> Describes a Virtual Machine Scale Set. </summary>
@@ -13,6 +15,14 @@ namespace MgmtParamOrdering.Models
         /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetPatch"/>. </summary>
         public VirtualMachineScaleSetPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="sku"> The virtual machine scale set sku. </param>
+        internal VirtualMachineScaleSetPatch(IDictionary<string, string> tags, MgmtParamOrderingSku sku) : base(tags)
+        {
+            Sku = sku;
         }
 
         /// <summary> The virtual machine scale set sku. </summary>

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVMInstanceIDs.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVMInstanceIDs.cs
@@ -19,6 +19,13 @@ namespace MgmtParamOrdering.Models
             InstanceIds = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVMInstanceIDs"/>. </summary>
+        /// <param name="instanceIds"> The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set. </param>
+        internal VirtualMachineScaleSetVMInstanceIDs(IList<string> instanceIds)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary> The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual machines in the virtual machine scale set. </summary>
         public IList<string> InstanceIds { get; }
     }

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVMInstanceRequiredIDs.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/VirtualMachineScaleSetVMInstanceRequiredIDs.cs
@@ -25,6 +25,13 @@ namespace MgmtParamOrdering.Models
             InstanceIds = instanceIds.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachineScaleSetVMInstanceRequiredIDs"/>. </summary>
+        /// <param name="instanceIds"> The virtual machine scale set instance ids. </param>
+        internal VirtualMachineScaleSetVMInstanceRequiredIDs(IList<string> instanceIds)
+        {
+            InstanceIds = instanceIds;
+        }
+
         /// <summary> The virtual machine scale set instance ids. </summary>
         public IList<string> InstanceIds { get; }
     }

--- a/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspacePatch.cs
+++ b/test/TestProjects/MgmtParamOrdering/Generated/Models/WorkspacePatch.cs
@@ -19,6 +19,13 @@ namespace MgmtParamOrdering.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="WorkspacePatch"/>. </summary>
+        /// <param name="tags"> The resource tags for the machine learning workspace. </param>
+        internal WorkspacePatch(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> The resource tags for the machine learning workspace. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtParent/Generated/Models/AvailabilitySetPatch.cs
+++ b/test/TestProjects/MgmtParent/Generated/Models/AvailabilitySetPatch.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace MgmtParent.Models
 {
     /// <summary> Specifies information about the availability set that the virtual machine should be assigned to. Only tags may be updated. </summary>
@@ -13,6 +15,16 @@ namespace MgmtParent.Models
         /// <summary> Initializes a new instance of <see cref="AvailabilitySetPatch"/>. </summary>
         public AvailabilitySetPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="AvailabilitySetPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformUpdateDomainCount"> Update Domain count. </param>
+        /// <param name="platformFaultDomainCount"> Fault Domain count. </param>
+        internal AvailabilitySetPatch(IDictionary<string, string> tags, int? platformUpdateDomainCount, int? platformFaultDomainCount) : base(tags)
+        {
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
         }
 
         /// <summary> Update Domain count. </summary>

--- a/test/TestProjects/MgmtParent/Generated/Models/DedicatedHostGroupPatch.cs
+++ b/test/TestProjects/MgmtParent/Generated/Models/DedicatedHostGroupPatch.cs
@@ -19,6 +19,18 @@ namespace MgmtParent.Models
             Zones = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="DedicatedHostGroupPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="zones"> Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone. </param>
+        /// <param name="platformFaultDomainCount"> Number of fault domains that the host group can span. </param>
+        /// <param name="supportAutomaticPlacement"> Specifies whether virtual machines or virtual machine scale sets can be placed automatically on the dedicated host group. Automatic placement means resources are allocated on dedicated hosts, that are chosen by Azure, under the dedicated host group. The value is defaulted to 'true' when not provided. &lt;br&gt;&lt;br&gt;Minimum api-version: 2020-06-01. </param>
+        internal DedicatedHostGroupPatch(IDictionary<string, string> tags, IList<string> zones, int? platformFaultDomainCount, bool? supportAutomaticPlacement) : base(tags)
+        {
+            Zones = zones;
+            PlatformFaultDomainCount = platformFaultDomainCount;
+            SupportAutomaticPlacement = supportAutomaticPlacement;
+        }
+
         /// <summary> Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone. </summary>
         public IList<string> Zones { get; }
         /// <summary> Number of fault domains that the host group can span. </summary>

--- a/test/TestProjects/MgmtParent/Generated/Models/DedicatedHostPatch.cs
+++ b/test/TestProjects/MgmtParent/Generated/Models/DedicatedHostPatch.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace MgmtParent.Models
 {
@@ -15,6 +16,22 @@ namespace MgmtParent.Models
         /// <summary> Initializes a new instance of <see cref="DedicatedHostPatch"/>. </summary>
         public DedicatedHostPatch()
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="DedicatedHostPatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="platformFaultDomain"> Fault domain of the dedicated host within a dedicated host group. </param>
+        /// <param name="autoReplaceOnFailure"> Specifies whether the dedicated host should be replaced automatically in case of a failure. The value is defaulted to 'true' when not provided. </param>
+        /// <param name="hostId"> A unique id generated and assigned to the dedicated host by the platform. &lt;br&gt;&lt;br&gt; Does not change throughout the lifetime of the host. </param>
+        /// <param name="provisioningOn"> The date when the host was first provisioned. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        internal DedicatedHostPatch(IDictionary<string, string> tags, int? platformFaultDomain, bool? autoReplaceOnFailure, string hostId, DateTimeOffset? provisioningOn, string provisioningState) : base(tags)
+        {
+            PlatformFaultDomain = platformFaultDomain;
+            AutoReplaceOnFailure = autoReplaceOnFailure;
+            HostId = hostId;
+            ProvisioningOn = provisioningOn;
+            ProvisioningState = provisioningState;
         }
 
         /// <summary> Fault domain of the dedicated host within a dedicated host group. </summary>

--- a/test/TestProjects/MgmtParent/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtParent/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtParent.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtPropertyBag/Generated/Models/FooPatch.cs
+++ b/test/TestProjects/MgmtPropertyBag/Generated/Models/FooPatch.cs
@@ -15,6 +15,13 @@ namespace MgmtPropertyBag.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="FooPatch"/>. </summary>
+        /// <param name="details"> The details of the resource. </param>
+        internal FooPatch(string details)
+        {
+            Details = details;
+        }
+
         /// <summary> The details of the resource. </summary>
         public string Details { get; set; }
     }

--- a/test/TestProjects/MgmtPropertyChooser/Generated/Models/UpdateResource.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/Models/UpdateResource.cs
@@ -19,6 +19,13 @@ namespace MgmtPropertyChooser.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="UpdateResource"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        internal UpdateResource(IDictionary<string, string> tags)
+        {
+            Tags = tags;
+        }
+
         /// <summary> Resource tags. </summary>
         public IDictionary<string, string> Tags { get; }
     }

--- a/test/TestProjects/MgmtPropertyChooser/Generated/Models/VirtualMachinePatch.cs
+++ b/test/TestProjects/MgmtPropertyChooser/Generated/Models/VirtualMachinePatch.cs
@@ -20,6 +20,26 @@ namespace MgmtPropertyChooser.Models
             Zones = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="VirtualMachinePatch"/>. </summary>
+        /// <param name="tags"> Resource tags. </param>
+        /// <param name="plan"> Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -&gt;**. Enter any required information and then click **Save**. </param>
+        /// <param name="identity"> The identity of the virtual machine, if configured. </param>
+        /// <param name="zones"> The virtual machine zones. </param>
+        /// <param name="provisioningState"> The provisioning state, which only appears in the response. </param>
+        /// <param name="licenseType"> Specifies that the image or disk that is being used was licensed on-premises. This element is only used for images that contain the Windows Server operating system. &lt;br&gt;&lt;br&gt; Possible values are: &lt;br&gt;&lt;br&gt; Windows_Client &lt;br&gt;&lt;br&gt; Windows_Server &lt;br&gt;&lt;br&gt; If this element is included in a request for an update, the value must match the initial value. This value cannot be updated. &lt;br&gt;&lt;br&gt; For more information, see [Azure Hybrid Use Benefit for Windows Server](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json) &lt;br&gt;&lt;br&gt; Minimum api-version: 2015-06-15. </param>
+        /// <param name="vmId"> Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands. </param>
+        /// <param name="extensionsTimeBudget"> Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M). &lt;br&gt;&lt;br&gt; Minimum api-version: 2020-06-01. </param>
+        internal VirtualMachinePatch(IDictionary<string, string> tags, ArmPlan plan, ManagedServiceIdentity identity, IList<string> zones, string provisioningState, string licenseType, string vmId, string extensionsTimeBudget) : base(tags)
+        {
+            Plan = plan;
+            Identity = identity;
+            Zones = zones;
+            ProvisioningState = provisioningState;
+            LicenseType = licenseType;
+            VmId = vmId;
+            ExtensionsTimeBudget = extensionsTimeBudget;
+        }
+
         /// <summary> Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started -&gt;**. Enter any required information and then click **Save**. </summary>
         public ArmPlan Plan { get; set; }
         /// <summary> The identity of the virtual machine, if configured. </summary>

--- a/test/TestProjects/MgmtReferenceTypes/Generated/Models/ResourceNon.cs
+++ b/test/TestProjects/MgmtReferenceTypes/Generated/Models/ResourceNon.cs
@@ -15,6 +15,17 @@ namespace MgmtReferenceTypes.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ResourceNon"/>. </summary>
+        /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
+        /// <param name="name"> The name of the resource. </param>
+        /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
+        internal ResourceNon(string id, string name, string resourceType)
+        {
+            Id = id;
+            Name = name;
+            ResourceType = resourceType;
+        }
+
         /// <summary> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </summary>
         public string Id { get; }
         /// <summary> The name of the resource. </summary>

--- a/test/TestProjects/MgmtSafeFlatten/Generated/Models/LayerOneProperties.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/Models/LayerOneProperties.cs
@@ -15,6 +15,13 @@ namespace MgmtSafeFlatten.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="LayerOneProperties"/>. </summary>
+        /// <param name="uniqueId"> The id of layer one. </param>
+        internal LayerOneProperties(string uniqueId)
+        {
+            UniqueId = uniqueId;
+        }
+
         /// <summary> The id of layer one. </summary>
         public string UniqueId { get; }
     }

--- a/test/TestProjects/MgmtSafeFlatten/Generated/Models/TypeFour.cs
+++ b/test/TestProjects/MgmtSafeFlatten/Generated/Models/TypeFour.cs
@@ -15,6 +15,15 @@ namespace MgmtSafeFlatten.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="TypeFour"/>. </summary>
+        /// <param name="myType"> The details of the type. </param>
+        /// <param name="properties"> The single value prop. </param>
+        internal TypeFour(string myType, LayerOneProperties properties)
+        {
+            MyType = myType;
+            Properties = properties;
+        }
+
         /// <summary> The details of the type. </summary>
         public string MyType { get; }
         /// <summary> The single value prop. </summary>

--- a/test/TestProjects/MgmtScopeResource/Generated/Models/Deployment.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Models/Deployment.cs
@@ -25,6 +25,17 @@ namespace MgmtScopeResource.Models
             Tags = new ChangeTrackingDictionary<string, string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="Deployment"/>. </summary>
+        /// <param name="location"> The location to store the deployment data. </param>
+        /// <param name="properties"> The deployment properties. </param>
+        /// <param name="tags"> Deployment tags. </param>
+        internal Deployment(string location, DeploymentProperties properties, IDictionary<string, string> tags)
+        {
+            Location = location;
+            Properties = properties;
+            Tags = tags;
+        }
+
         /// <summary> The location to store the deployment data. </summary>
         public string Location { get; set; }
         /// <summary> The deployment properties. </summary>

--- a/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentProperties.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentProperties.cs
@@ -19,6 +19,17 @@ namespace MgmtScopeResource.Models
             Mode = mode;
         }
 
+        /// <summary> Initializes a new instance of <see cref="DeploymentProperties"/>. </summary>
+        /// <param name="template"> The template content. You use this element when you want to pass the template syntax directly in the request rather than link to an existing template. It can be a JObject or well-formed JSON string. Use either the templateLink property or the template property, but not both. </param>
+        /// <param name="parameters"> Name and value pairs that define the deployment parameters for the template. You use this element when you want to provide the parameter values directly in the request rather than link to an existing parameter file. Use either the parametersLink property or the parameters property, but not both. It can be a JObject or a well formed JSON string. </param>
+        /// <param name="mode"> The mode that is used to deploy resources. This value can be either Incremental or Complete. In Incremental mode, resources are deployed without deleting existing resources that are not included in the template. In Complete mode, resources are deployed and existing resources in the resource group that are not included in the template are deleted. Be careful when using Complete mode as you may unintentionally delete resources. </param>
+        internal DeploymentProperties(BinaryData template, BinaryData parameters, DeploymentMode mode)
+        {
+            Template = template;
+            Parameters = parameters;
+            Mode = mode;
+        }
+
         /// <summary>
         /// The template content. You use this element when you want to pass the template syntax directly in the request rather than link to an existing template. It can be a JObject or well-formed JSON string. Use either the templateLink property or the template property, but not both.
         /// <para>

--- a/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentWhatIf.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentWhatIf.cs
@@ -23,6 +23,15 @@ namespace MgmtScopeResource.Models
             Properties = properties;
         }
 
+        /// <summary> Initializes a new instance of <see cref="DeploymentWhatIf"/>. </summary>
+        /// <param name="location"> The location to store the deployment data. </param>
+        /// <param name="properties"> The deployment properties. </param>
+        internal DeploymentWhatIf(string location, DeploymentWhatIfProperties properties)
+        {
+            Location = location;
+            Properties = properties;
+        }
+
         /// <summary> The location to store the deployment data. </summary>
         public string Location { get; set; }
         /// <summary> The deployment properties. </summary>

--- a/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentWhatIfProperties.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentWhatIfProperties.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System;
+
 namespace MgmtScopeResource.Models
 {
     /// <summary> Deployment What-if properties. </summary>
@@ -14,6 +16,16 @@ namespace MgmtScopeResource.Models
         /// <param name="mode"> The mode that is used to deploy resources. This value can be either Incremental or Complete. In Incremental mode, resources are deployed without deleting existing resources that are not included in the template. In Complete mode, resources are deployed and existing resources in the resource group that are not included in the template are deleted. Be careful when using Complete mode as you may unintentionally delete resources. </param>
         public DeploymentWhatIfProperties(DeploymentMode mode) : base(mode)
         {
+        }
+
+        /// <summary> Initializes a new instance of <see cref="DeploymentWhatIfProperties"/>. </summary>
+        /// <param name="template"> The template content. You use this element when you want to pass the template syntax directly in the request rather than link to an existing template. It can be a JObject or well-formed JSON string. Use either the templateLink property or the template property, but not both. </param>
+        /// <param name="parameters"> Name and value pairs that define the deployment parameters for the template. You use this element when you want to provide the parameter values directly in the request rather than link to an existing parameter file. Use either the parametersLink property or the parameters property, but not both. It can be a JObject or a well formed JSON string. </param>
+        /// <param name="mode"> The mode that is used to deploy resources. This value can be either Incremental or Complete. In Incremental mode, resources are deployed without deleting existing resources that are not included in the template. In Complete mode, resources are deployed and existing resources in the resource group that are not included in the template are deleted. Be careful when using Complete mode as you may unintentionally delete resources. </param>
+        /// <param name="whatIfSettings"> Optional What-If operation settings. </param>
+        internal DeploymentWhatIfProperties(BinaryData template, BinaryData parameters, DeploymentMode mode, DeploymentWhatIfSettings whatIfSettings) : base(template, parameters, mode)
+        {
+            WhatIfSettings = whatIfSettings;
         }
 
         /// <summary> Optional What-If operation settings. </summary>

--- a/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentWhatIfSettings.cs
+++ b/test/TestProjects/MgmtScopeResource/Generated/Models/DeploymentWhatIfSettings.cs
@@ -15,6 +15,13 @@ namespace MgmtScopeResource.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="DeploymentWhatIfSettings"/>. </summary>
+        /// <param name="resultFormat"> The format of the What-If results. </param>
+        internal DeploymentWhatIfSettings(WhatIfResultFormat? resultFormat)
+        {
+            ResultFormat = resultFormat;
+        }
+
         /// <summary> The format of the What-If results. </summary>
         public WhatIfResultFormat? ResultFormat { get; set; }
     }

--- a/test/TestProjects/ModelNamespace/Generated/Models/TestModel.cs
+++ b/test/TestProjects/ModelNamespace/Generated/Models/TestModel.cs
@@ -15,6 +15,15 @@ namespace ModelNamespace
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="TestModel"/>. </summary>
+        /// <param name="code"></param>
+        /// <param name="status"></param>
+        internal TestModel(string code, string status)
+        {
+            Code = code;
+            Status = status;
+        }
+
         /// <summary> Gets the code. </summary>
         public string Code { get; }
         /// <summary> Gets the status. </summary>

--- a/test/TestProjects/ModelShapes/Generated/Models/InputModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/InputModel.cs
@@ -55,6 +55,59 @@ namespace ModelShapes.Models
             VectorRequiredNullable = vectorRequiredNullable;
         }
 
+        /// <summary> Initializes a new instance of <see cref="InputModel"/>. </summary>
+        /// <param name="requiredString"></param>
+        /// <param name="requiredInt"></param>
+        /// <param name="requiredStringList"></param>
+        /// <param name="requiredIntList"></param>
+        /// <param name="nonRequiredString"></param>
+        /// <param name="nonRequiredInt"></param>
+        /// <param name="nonRequiredStringList"></param>
+        /// <param name="nonRequiredIntList"></param>
+        /// <param name="requiredNullableString"></param>
+        /// <param name="requiredNullableInt"></param>
+        /// <param name="requiredNullableStringList"></param>
+        /// <param name="requiredNullableIntList"></param>
+        /// <param name="nonRequiredNullableString"></param>
+        /// <param name="nonRequiredNullableInt"></param>
+        /// <param name="nonRequiredNullableStringList"></param>
+        /// <param name="nonRequiredNullableIntList"></param>
+        /// <param name="vector"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnly"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorRequired"> The vector representation of a search query. </param>
+        /// <param name="vectorNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorReadOnlyRequiredNullable"> The vector representation of a search query. </param>
+        /// <param name="vectorRequiredNullable"> The vector representation of a search query. </param>
+        internal InputModel(string requiredString, int requiredInt, IList<string> requiredStringList, IList<int> requiredIntList, string nonRequiredString, int? nonRequiredInt, IList<string> nonRequiredStringList, IList<int> nonRequiredIntList, string requiredNullableString, int? requiredNullableInt, IList<string> requiredNullableStringList, IList<int> requiredNullableIntList, string nonRequiredNullableString, int? nonRequiredNullableInt, IList<string> nonRequiredNullableStringList, IList<int> nonRequiredNullableIntList, ReadOnlyMemory<float> vector, ReadOnlyMemory<float> vectorReadOnly, ReadOnlyMemory<float> vectorReadOnlyRequired, ReadOnlyMemory<float> vectorRequired, ReadOnlyMemory<float>? vectorNullable, ReadOnlyMemory<float>? vectorReadOnlyNullable, ReadOnlyMemory<float>? vectorReadOnlyRequiredNullable, ReadOnlyMemory<float>? vectorRequiredNullable)
+        {
+            RequiredString = requiredString;
+            RequiredInt = requiredInt;
+            RequiredStringList = requiredStringList;
+            RequiredIntList = requiredIntList;
+            NonRequiredString = nonRequiredString;
+            NonRequiredInt = nonRequiredInt;
+            NonRequiredStringList = nonRequiredStringList;
+            NonRequiredIntList = nonRequiredIntList;
+            RequiredNullableString = requiredNullableString;
+            RequiredNullableInt = requiredNullableInt;
+            RequiredNullableStringList = requiredNullableStringList;
+            RequiredNullableIntList = requiredNullableIntList;
+            NonRequiredNullableString = nonRequiredNullableString;
+            NonRequiredNullableInt = nonRequiredNullableInt;
+            NonRequiredNullableStringList = nonRequiredNullableStringList;
+            NonRequiredNullableIntList = nonRequiredNullableIntList;
+            Vector = vector;
+            VectorReadOnly = vectorReadOnly;
+            VectorReadOnlyRequired = vectorReadOnlyRequired;
+            VectorRequired = vectorRequired;
+            VectorNullable = vectorNullable;
+            VectorReadOnlyNullable = vectorReadOnlyNullable;
+            VectorReadOnlyRequiredNullable = vectorReadOnlyRequiredNullable;
+            VectorRequiredNullable = vectorRequiredNullable;
+        }
+
         /// <summary> Gets the required string. </summary>
         public string RequiredString { get; }
         /// <summary> Gets the required int. </summary>

--- a/test/TestProjects/ModelShapes/Generated/Models/ParametersModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/ParametersModel.cs
@@ -15,6 +15,15 @@ namespace ModelShapes.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ParametersModel"/>. </summary>
+        /// <param name="code"></param>
+        /// <param name="status"></param>
+        internal ParametersModel(string code, string status)
+        {
+            Code = code;
+            Status = status;
+        }
+
         /// <summary> Gets or sets the code. </summary>
         public string Code { get; set; }
         /// <summary> Gets or sets the status. </summary>

--- a/test/TestProjects/ModelShapes/Generated/Models/UnusedModel.cs
+++ b/test/TestProjects/ModelShapes/Generated/Models/UnusedModel.cs
@@ -15,6 +15,13 @@ namespace ModelShapes.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="UnusedModel"/>. </summary>
+        /// <param name="unusedString"></param>
+        internal UnusedModel(string unusedString)
+        {
+            UnusedString = unusedString;
+        }
+
         /// <summary> Gets the unused string. </summary>
         public string UnusedString { get; }
     }

--- a/test/TestProjects/ModelWithConverterUsage/Generated/Models/InputModel.cs
+++ b/test/TestProjects/ModelWithConverterUsage/Generated/Models/InputModel.cs
@@ -15,6 +15,13 @@ namespace ModelWithConverterUsage.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="InputModel"/>. </summary>
+        /// <param name="inputModelProperty"> Constant string. </param>
+        internal InputModel(string inputModelProperty)
+        {
+            InputModelProperty = inputModelProperty;
+        }
+
         /// <summary> Constant string. </summary>
         public string InputModelProperty { get; set; }
     }

--- a/test/TestProjects/MultipleInputFiles/Generated/Models/TestModel.cs
+++ b/test/TestProjects/MultipleInputFiles/Generated/Models/TestModel.cs
@@ -15,6 +15,15 @@ namespace MultipleInputFiles.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="TestModel"/>. </summary>
+        /// <param name="code"></param>
+        /// <param name="status"></param>
+        internal TestModel(string code, string status)
+        {
+            Code = code;
+            Status = status;
+        }
+
         /// <summary> Gets or sets the code. </summary>
         public string Code { get; set; }
         /// <summary> Gets or sets the status. </summary>

--- a/test/TestProjects/ProtocolMethodsInRestClient/Generated/Models/Grouped.cs
+++ b/test/TestProjects/ProtocolMethodsInRestClient/Generated/Models/Grouped.cs
@@ -17,6 +17,15 @@ namespace ProtocolMethodsInRestClient.Models
             Second = second;
         }
 
+        /// <summary> Initializes a new instance of <see cref="Grouped"/>. </summary>
+        /// <param name="first"> First in group. </param>
+        /// <param name="second"> Second in group. </param>
+        internal Grouped(string first, int second)
+        {
+            First = first;
+            Second = second;
+        }
+
         /// <summary> First in group. </summary>
         public string First { get; set; }
         /// <summary> Second in group. </summary>

--- a/test/TestProjects/PublicClientCtor/Generated/Models/TestModel.cs
+++ b/test/TestProjects/PublicClientCtor/Generated/Models/TestModel.cs
@@ -15,6 +15,15 @@ namespace PublicClientCtor.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="TestModel"/>. </summary>
+        /// <param name="code"></param>
+        /// <param name="status"></param>
+        internal TestModel(string code, string status)
+        {
+            Code = code;
+            Status = status;
+        }
+
         /// <summary> Gets or sets the code. </summary>
         public string Code { get; set; }
         /// <summary> Gets or sets the status. </summary>

--- a/test/TestProjects/TypeSchemaMapping/SomeFolder/Generated/Models/ModelWithCustomNamespace.cs
+++ b/test/TestProjects/TypeSchemaMapping/SomeFolder/Generated/Models/ModelWithCustomNamespace.cs
@@ -15,6 +15,13 @@ namespace Very.Custom.Namespace.From.Swagger
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ModelWithCustomNamespace"/>. </summary>
+        /// <param name="modelProperty"> . </param>
+        internal ModelWithCustomNamespace(string modelProperty)
+        {
+            ModelProperty = modelProperty;
+        }
+
         /// <summary> . </summary>
         public string ModelProperty { get; }
     }

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/FirstParameterGroup.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/FirstParameterGroup.cs
@@ -15,6 +15,15 @@ namespace azure_parameter_grouping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="FirstParameterGroup"/>. </summary>
+        /// <param name="headerOne"></param>
+        /// <param name="queryOne"> Query parameter with default. </param>
+        internal FirstParameterGroup(string headerOne, int? queryOne)
+        {
+            HeaderOne = headerOne;
+            QueryOne = queryOne;
+        }
+
         /// <summary> Gets or sets the header one. </summary>
         public string HeaderOne { get; set; }
         /// <summary> Query parameter with default. </summary>

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/Grouper.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/Grouper.cs
@@ -15,6 +15,15 @@ namespace azure_parameter_grouping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="Grouper"/>. </summary>
+        /// <param name="groupedConstant"> A grouped parameter that is a constant. </param>
+        /// <param name="groupedParameter"> Optional parameter part of a parameter grouping. </param>
+        internal Grouper(EncryptionAlgorithmType? groupedConstant, string groupedParameter)
+        {
+            GroupedConstant = groupedConstant;
+            GroupedParameter = groupedParameter;
+        }
+
         /// <summary> A grouped parameter that is a constant. </summary>
         public EncryptionAlgorithmType? GroupedConstant { get; set; }
         /// <summary> Optional parameter part of a parameter grouping. </summary>

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostMultiParamGroupsSecondParamGroup.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostMultiParamGroupsSecondParamGroup.cs
@@ -15,6 +15,15 @@ namespace azure_parameter_grouping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ParameterGroupingPostMultiParamGroupsSecondParamGroup"/>. </summary>
+        /// <param name="headerTwo"></param>
+        /// <param name="queryTwo"> Query parameter with default. </param>
+        internal ParameterGroupingPostMultiParamGroupsSecondParamGroup(string headerTwo, int? queryTwo)
+        {
+            HeaderTwo = headerTwo;
+            QueryTwo = queryTwo;
+        }
+
         /// <summary> Gets or sets the header two. </summary>
         public string HeaderTwo { get; set; }
         /// <summary> Query parameter with default. </summary>

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostOptionalParameters.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostOptionalParameters.cs
@@ -15,6 +15,15 @@ namespace azure_parameter_grouping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ParameterGroupingPostOptionalParameters"/>. </summary>
+        /// <param name="customHeader"></param>
+        /// <param name="query"> Query parameter with default. </param>
+        internal ParameterGroupingPostOptionalParameters(string customHeader, int? query)
+        {
+            CustomHeader = customHeader;
+            Query = query;
+        }
+
         /// <summary> Gets or sets the custom header. </summary>
         public string CustomHeader { get; set; }
         /// <summary> Query parameter with default. </summary>

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostRequiredParameters.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostRequiredParameters.cs
@@ -25,6 +25,19 @@ namespace azure_parameter_grouping.Models
             Body = body;
         }
 
+        /// <summary> Initializes a new instance of <see cref="ParameterGroupingPostRequiredParameters"/>. </summary>
+        /// <param name="customHeader"></param>
+        /// <param name="query"> Query parameter with default. </param>
+        /// <param name="path"> Path parameter. </param>
+        /// <param name="body"></param>
+        internal ParameterGroupingPostRequiredParameters(string customHeader, int? query, string path, int body)
+        {
+            CustomHeader = customHeader;
+            Query = query;
+            Path = path;
+            Body = body;
+        }
+
         /// <summary> Gets or sets the custom header. </summary>
         public string CustomHeader { get; set; }
         /// <summary> Query parameter with default. </summary>

--- a/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostReservedWordsParameters.cs
+++ b/test/TestServerProjects/azure-parameter-grouping/Generated/Models/ParameterGroupingPostReservedWordsParameters.cs
@@ -15,6 +15,15 @@ namespace azure_parameter_grouping.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ParameterGroupingPostReservedWordsParameters"/>. </summary>
+        /// <param name="from"> 'from' is a reserved word. Pass in 'bob' to pass. </param>
+        /// <param name="accept"> 'accept' is a reserved word. Pass in 'yes' to pass. </param>
+        internal ParameterGroupingPostReservedWordsParameters(string @from, string accept)
+        {
+            From = @from;
+            Accept = accept;
+        }
+
         /// <summary> 'from' is a reserved word. Pass in 'bob' to pass. </summary>
         public string From { get; set; }
         /// <summary> 'accept' is a reserved word. Pass in 'yes' to pass. </summary>

--- a/test/TestServerProjects/azure-special-properties/Generated/Models/OdataFilter.cs
+++ b/test/TestServerProjects/azure-special-properties/Generated/Models/OdataFilter.cs
@@ -15,6 +15,15 @@ namespace azure_special_properties.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="OdataFilter"/>. </summary>
+        /// <param name="id"></param>
+        /// <param name="name"></param>
+        internal OdataFilter(int? id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
         /// <summary> Gets the id. </summary>
         public int? Id { get; }
         /// <summary> Gets the name. </summary>

--- a/test/TestServerProjects/body-formdata-urlencoded/Generated/Models/Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.cs
+++ b/test/TestServerProjects/body-formdata-urlencoded/Generated/Models/Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.cs
@@ -21,6 +21,21 @@ namespace body_formdata_urlencoded.Models
             PetAge = petAge;
         }
 
+        /// <summary> Initializes a new instance of <see cref="Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema"/>. </summary>
+        /// <param name="petType"> Can take a value of dog, or cat, or fish. </param>
+        /// <param name="petFood"> Can take a value of meat, or fish, or plant. </param>
+        /// <param name="petAge"> How many years is it old?. </param>
+        /// <param name="name"> Updated name of the pet. </param>
+        /// <param name="status"> Updated status of the pet. </param>
+        internal Paths14Hl8BdFormsdataurlencodedPetAddPetidPostRequestbodyContentApplicationXWwwFormUrlencodedSchema(PetType petType, PetFood petFood, int petAge, string name, string status)
+        {
+            PetType = petType;
+            PetFood = petFood;
+            PetAge = petAge;
+            Name = name;
+            Status = status;
+        }
+
         /// <summary> Can take a value of dog, or cat, or fish. </summary>
         public PetType PetType { get; }
         /// <summary> Can take a value of meat, or fish, or plant. </summary>

--- a/test/TestServerProjects/body-formdata-urlencoded/Generated/Models/PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.cs
+++ b/test/TestServerProjects/body-formdata-urlencoded/Generated/Models/PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema.cs
@@ -27,6 +27,17 @@ namespace body_formdata_urlencoded.Models
             AadAccessToken = aadAccessToken;
         }
 
+        /// <summary> Initializes a new instance of <see cref="PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema"/>. </summary>
+        /// <param name="grantType"> Constant part of a formdata body. </param>
+        /// <param name="service"> Indicates the name of your Azure container registry. </param>
+        /// <param name="aadAccessToken"> AAD access token, mandatory when grant_type is access_token_refresh_token or access_token. </param>
+        internal PathsPvivzlFormsdataurlencodedPartialconstantbodyPostRequestbodyContentApplicationXWwwFormUrlencodedSchema(PostContentSchemaGrantType grantType, string service, string aadAccessToken)
+        {
+            GrantType = grantType;
+            Service = service;
+            AadAccessToken = aadAccessToken;
+        }
+
         /// <summary> Constant part of a formdata body. </summary>
         public PostContentSchemaGrantType GrantType { get; }
         /// <summary> Indicates the name of your Azure container registry. </summary>

--- a/test/TestServerProjects/body-formdata/Generated/Models/Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema.cs
+++ b/test/TestServerProjects/body-formdata/Generated/Models/Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema.cs
@@ -26,6 +26,13 @@ namespace body_formdata.Models
             FileContent = fileContent.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema"/>. </summary>
+        /// <param name="fileContent"> Files to upload. </param>
+        internal Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema(IReadOnlyList<Stream> fileContent)
+        {
+            FileContent = fileContent;
+        }
+
         /// <summary> Files to upload. </summary>
         public IReadOnlyList<Stream> FileContent { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredOneValueDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredOneValueDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ModelAsStringNoRequiredOneValueDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal ModelAsStringNoRequiredOneValueDefault(ModelAsStringNoRequiredOneValueDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public ModelAsStringNoRequiredOneValueDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredOneValueNoDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredOneValueNoDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ModelAsStringNoRequiredOneValueNoDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal ModelAsStringNoRequiredOneValueNoDefault(ModelAsStringNoRequiredOneValueNoDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public ModelAsStringNoRequiredOneValueNoDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredTwoValueDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredTwoValueDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ModelAsStringNoRequiredTwoValueDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal ModelAsStringNoRequiredTwoValueDefault(ModelAsStringNoRequiredTwoValueDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public ModelAsStringNoRequiredTwoValueDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredTwoValueNoDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/ModelAsStringNoRequiredTwoValueNoDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ModelAsStringNoRequiredTwoValueNoDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal ModelAsStringNoRequiredTwoValueNoDefault(ModelAsStringNoRequiredTwoValueNoDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public ModelAsStringNoRequiredTwoValueNoDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredOneValueDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredOneValueDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="NoModelAsStringNoRequiredOneValueDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal NoModelAsStringNoRequiredOneValueDefault(NoModelAsStringNoRequiredOneValueDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public NoModelAsStringNoRequiredOneValueDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredOneValueNoDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredOneValueNoDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="NoModelAsStringNoRequiredOneValueNoDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal NoModelAsStringNoRequiredOneValueNoDefault(NoModelAsStringNoRequiredOneValueNoDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public NoModelAsStringNoRequiredOneValueNoDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredTwoValueDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredTwoValueDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="NoModelAsStringNoRequiredTwoValueDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal NoModelAsStringNoRequiredTwoValueDefault(NoModelAsStringNoRequiredTwoValueDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public NoModelAsStringNoRequiredTwoValueDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredTwoValueNoDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/NoModelAsStringNoRequiredTwoValueNoDefault.cs
@@ -15,6 +15,13 @@ namespace constants.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="NoModelAsStringNoRequiredTwoValueNoDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal NoModelAsStringNoRequiredTwoValueNoDefault(NoModelAsStringNoRequiredTwoValueNoDefaultEnum? parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public NoModelAsStringNoRequiredTwoValueNoDefaultEnum? Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/NoModelAsStringRequiredOneValueDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/NoModelAsStringRequiredOneValueDefault.cs
@@ -16,6 +16,13 @@ namespace constants.Models
             Parameter = NoModelAsStringRequiredOneValueDefaultEnum.Value1;
         }
 
+        /// <summary> Initializes a new instance of <see cref="NoModelAsStringRequiredOneValueDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal NoModelAsStringRequiredOneValueDefault(NoModelAsStringRequiredOneValueDefaultEnum parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public NoModelAsStringRequiredOneValueDefaultEnum Parameter { get; }
     }

--- a/test/TestServerProjects/constants/Generated/Models/NoModelAsStringRequiredOneValueNoDefault.cs
+++ b/test/TestServerProjects/constants/Generated/Models/NoModelAsStringRequiredOneValueNoDefault.cs
@@ -16,6 +16,13 @@ namespace constants.Models
             Parameter = NoModelAsStringRequiredOneValueNoDefaultEnum.Value1;
         }
 
+        /// <summary> Initializes a new instance of <see cref="NoModelAsStringRequiredOneValueNoDefault"/>. </summary>
+        /// <param name="parameter"></param>
+        internal NoModelAsStringRequiredOneValueNoDefault(NoModelAsStringRequiredOneValueNoDefaultEnum parameter)
+        {
+            Parameter = parameter;
+        }
+
         /// <summary> Gets the parameter. </summary>
         public NoModelAsStringRequiredOneValueNoDefaultEnum Parameter { get; }
     }

--- a/test/TestServerProjects/custom-baseUrl-paging/Generated/Models/Error.cs
+++ b/test/TestServerProjects/custom-baseUrl-paging/Generated/Models/Error.cs
@@ -15,6 +15,15 @@ namespace custom_baseUrl_paging.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="Error"/>. </summary>
+        /// <param name="status"></param>
+        /// <param name="message"></param>
+        internal Error(int? status, string message)
+        {
+            Status = status;
+            Message = message;
+        }
+
         /// <summary> Gets the status. </summary>
         public int? Status { get; }
         /// <summary> Gets the message. </summary>

--- a/test/TestServerProjects/lro/Generated/Models/OperationResult.cs
+++ b/test/TestServerProjects/lro/Generated/Models/OperationResult.cs
@@ -15,6 +15,15 @@ namespace lro.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="OperationResult"/>. </summary>
+        /// <param name="status"> The status of the request. </param>
+        /// <param name="error"></param>
+        internal OperationResult(OperationResultStatus? status, OperationResultError error)
+        {
+            Status = status;
+            Error = error;
+        }
+
         /// <summary> The status of the request. </summary>
         public OperationResultStatus? Status { get; }
         /// <summary> Gets the error. </summary>

--- a/test/TestServerProjects/lro/Generated/Models/OperationResultError.cs
+++ b/test/TestServerProjects/lro/Generated/Models/OperationResultError.cs
@@ -15,6 +15,15 @@ namespace lro.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="OperationResultError"/>. </summary>
+        /// <param name="code"> The error code for an operation failure. </param>
+        /// <param name="message"> The detailed arror message. </param>
+        internal OperationResultError(int? code, string message)
+        {
+            Code = code;
+            Message = message;
+        }
+
         /// <summary> The error code for an operation failure. </summary>
         public int? Code { get; }
         /// <summary> The detailed arror message. </summary>

--- a/test/TestServerProjects/media_types/Generated/Models/SourcePath.cs
+++ b/test/TestServerProjects/media_types/Generated/Models/SourcePath.cs
@@ -15,6 +15,13 @@ namespace media_types.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="SourcePath"/>. </summary>
+        /// <param name="source"> File source path. </param>
+        internal SourcePath(string source)
+        {
+            Source = source;
+        }
+
         /// <summary> File source path. </summary>
         public string Source { get; set; }
     }

--- a/test/TestServerProjects/model-flattening/Generated/Models/FlattenParameterGroup.cs
+++ b/test/TestServerProjects/model-flattening/Generated/Models/FlattenParameterGroup.cs
@@ -26,6 +26,27 @@ namespace model_flattening.Models
             ProductId = productId;
         }
 
+        /// <summary> Initializes a new instance of <see cref="FlattenParameterGroup"/>. </summary>
+        /// <param name="name"> Product name with value 'groupproduct'. </param>
+        /// <param name="simpleBodyProduct"> Simple body product to put. </param>
+        /// <param name="productId"> Unique identifier representing a specific product for a given latitude &amp; longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles. </param>
+        /// <param name="description"> Description of product. </param>
+        /// <param name="maxProductDisplayName"> Display name of product. </param>
+        /// <param name="capacity"> Capacity of product. For example, 4 people. </param>
+        /// <param name="genericValue"> Generic URL value. </param>
+        /// <param name="odataValue"> URL value. </param>
+        internal FlattenParameterGroup(string name, SimpleProduct simpleBodyProduct, string productId, string description, string maxProductDisplayName, SimpleProductPropertiesMaxProductCapacity? capacity, string genericValue, string odataValue)
+        {
+            Name = name;
+            SimpleBodyProduct = simpleBodyProduct;
+            ProductId = productId;
+            Description = description;
+            MaxProductDisplayName = maxProductDisplayName;
+            Capacity = capacity;
+            GenericValue = genericValue;
+            OdataValue = odataValue;
+        }
+
         /// <summary> Product name with value 'groupproduct'. </summary>
         public string Name { get; }
         /// <summary> Simple body product to put. </summary>

--- a/test/TestServerProjects/model-flattening/Generated/Models/GenericUrl.cs
+++ b/test/TestServerProjects/model-flattening/Generated/Models/GenericUrl.cs
@@ -15,6 +15,13 @@ namespace model_flattening.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="GenericUrl"/>. </summary>
+        /// <param name="genericValue"> Generic URL value. </param>
+        internal GenericUrl(string genericValue)
+        {
+            GenericValue = genericValue;
+        }
+
         /// <summary> Generic URL value. </summary>
         public string GenericValue { get; }
     }

--- a/test/TestServerProjects/model-flattening/Generated/Models/ProductUrl.cs
+++ b/test/TestServerProjects/model-flattening/Generated/Models/ProductUrl.cs
@@ -15,6 +15,14 @@ namespace model_flattening.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ProductUrl"/>. </summary>
+        /// <param name="genericValue"> Generic URL value. </param>
+        /// <param name="odataValue"> URL value. </param>
+        internal ProductUrl(string genericValue, string odataValue) : base(genericValue)
+        {
+            OdataValue = odataValue;
+        }
+
         /// <summary> URL value. </summary>
         public string OdataValue { get; }
     }

--- a/test/TestServerProjects/model-flattening/Generated/Models/WrappedProduct.cs
+++ b/test/TestServerProjects/model-flattening/Generated/Models/WrappedProduct.cs
@@ -15,6 +15,13 @@ namespace model_flattening.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="WrappedProduct"/>. </summary>
+        /// <param name="value"> the product value. </param>
+        internal WrappedProduct(string value)
+        {
+            Value = value;
+        }
+
         /// <summary> the product value. </summary>
         public string Value { get; set; }
     }

--- a/test/TestServerProjects/paging/Generated/Models/BodyParam.cs
+++ b/test/TestServerProjects/paging/Generated/Models/BodyParam.cs
@@ -15,6 +15,13 @@ namespace paging.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="BodyParam"/>. </summary>
+        /// <param name="name"></param>
+        internal BodyParam(string name)
+        {
+            Name = name;
+        }
+
         /// <summary> Gets or sets the name. </summary>
         public string Name { get; set; }
     }

--- a/test/TestServerProjects/paging/Generated/Models/OperationResult.cs
+++ b/test/TestServerProjects/paging/Generated/Models/OperationResult.cs
@@ -15,6 +15,13 @@ namespace paging.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="OperationResult"/>. </summary>
+        /// <param name="status"> The status of the request. </param>
+        internal OperationResult(OperationResultStatus? status)
+        {
+            Status = status;
+        }
+
         /// <summary> The status of the request. </summary>
         public OperationResultStatus? Status { get; }
     }

--- a/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesLroOptions.cs
+++ b/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesLroOptions.cs
@@ -15,6 +15,15 @@ namespace paging.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="PagingGetMultiplePagesLroOptions"/>. </summary>
+        /// <param name="maxresults"> Sets the maximum number of items to return in the response. </param>
+        /// <param name="timeout"> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </param>
+        internal PagingGetMultiplePagesLroOptions(int? maxresults, int? timeout)
+        {
+            Maxresults = maxresults;
+            Timeout = timeout;
+        }
+
         /// <summary> Sets the maximum number of items to return in the response. </summary>
         public int? Maxresults { get; set; }
         /// <summary> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </summary>

--- a/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesOptions.cs
+++ b/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesOptions.cs
@@ -15,6 +15,15 @@ namespace paging.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="PagingGetMultiplePagesOptions"/>. </summary>
+        /// <param name="maxresults"> Sets the maximum number of items to return in the response. </param>
+        /// <param name="timeout"> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </param>
+        internal PagingGetMultiplePagesOptions(int? maxresults, int? timeout)
+        {
+            Maxresults = maxresults;
+            Timeout = timeout;
+        }
+
         /// <summary> Sets the maximum number of items to return in the response. </summary>
         public int? Maxresults { get; set; }
         /// <summary> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </summary>

--- a/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesWithOffsetOptions.cs
+++ b/test/TestServerProjects/paging/Generated/Models/PagingGetMultiplePagesWithOffsetOptions.cs
@@ -17,6 +17,17 @@ namespace paging.Models
             Offset = offset;
         }
 
+        /// <summary> Initializes a new instance of <see cref="PagingGetMultiplePagesWithOffsetOptions"/>. </summary>
+        /// <param name="maxresults"> Sets the maximum number of items to return in the response. </param>
+        /// <param name="offset"> Offset of return value. </param>
+        /// <param name="timeout"> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </param>
+        internal PagingGetMultiplePagesWithOffsetOptions(int? maxresults, int offset, int? timeout)
+        {
+            Maxresults = maxresults;
+            Offset = offset;
+            Timeout = timeout;
+        }
+
         /// <summary> Sets the maximum number of items to return in the response. </summary>
         public int? Maxresults { get; set; }
         /// <summary> Offset of return value. </summary>

--- a/test/TestServerProjects/paging/Generated/Models/PagingGetOdataMultiplePagesOptions.cs
+++ b/test/TestServerProjects/paging/Generated/Models/PagingGetOdataMultiplePagesOptions.cs
@@ -15,6 +15,15 @@ namespace paging.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="PagingGetOdataMultiplePagesOptions"/>. </summary>
+        /// <param name="maxresults"> Sets the maximum number of items to return in the response. </param>
+        /// <param name="timeout"> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </param>
+        internal PagingGetOdataMultiplePagesOptions(int? maxresults, int? timeout)
+        {
+            Maxresults = maxresults;
+            Timeout = timeout;
+        }
+
         /// <summary> Sets the maximum number of items to return in the response. </summary>
         public int? Maxresults { get; set; }
         /// <summary> Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds. </summary>

--- a/test/TestServerProjects/required-optional/Generated/Models/ArrayOptionalWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/ArrayOptionalWrapper.cs
@@ -19,6 +19,13 @@ namespace required_optional.Models
             Value = new ChangeTrackingList<string>();
         }
 
+        /// <summary> Initializes a new instance of <see cref="ArrayOptionalWrapper"/>. </summary>
+        /// <param name="value"></param>
+        internal ArrayOptionalWrapper(IList<string> value)
+        {
+            Value = value;
+        }
+
         /// <summary> Gets the value. </summary>
         public IList<string> Value { get; }
     }

--- a/test/TestServerProjects/required-optional/Generated/Models/ArrayWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/ArrayWrapper.cs
@@ -25,6 +25,13 @@ namespace required_optional.Models
             Value = value.ToList();
         }
 
+        /// <summary> Initializes a new instance of <see cref="ArrayWrapper"/>. </summary>
+        /// <param name="value"></param>
+        internal ArrayWrapper(IList<string> value)
+        {
+            Value = value;
+        }
+
         /// <summary> Gets the value. </summary>
         public IList<string> Value { get; }
     }

--- a/test/TestServerProjects/required-optional/Generated/Models/ClassOptionalWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/ClassOptionalWrapper.cs
@@ -15,6 +15,13 @@ namespace required_optional.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="ClassOptionalWrapper"/>. </summary>
+        /// <param name="value"></param>
+        internal ClassOptionalWrapper(Product value)
+        {
+            Value = value;
+        }
+
         /// <summary> Gets or sets the value. </summary>
         public Product Value { get; set; }
     }

--- a/test/TestServerProjects/required-optional/Generated/Models/IntOptionalWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/IntOptionalWrapper.cs
@@ -15,6 +15,13 @@ namespace required_optional.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="IntOptionalWrapper"/>. </summary>
+        /// <param name="value"></param>
+        internal IntOptionalWrapper(int? value)
+        {
+            Value = value;
+        }
+
         /// <summary> Gets or sets the value. </summary>
         public int? Value { get; set; }
     }

--- a/test/TestServerProjects/required-optional/Generated/Models/Product.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/Product.cs
@@ -17,6 +17,15 @@ namespace required_optional.Models
             Id = id;
         }
 
+        /// <summary> Initializes a new instance of <see cref="Product"/>. </summary>
+        /// <param name="id"></param>
+        /// <param name="name"></param>
+        internal Product(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
         /// <summary> Gets the id. </summary>
         public int Id { get; }
         /// <summary> Gets or sets the name. </summary>

--- a/test/TestServerProjects/required-optional/Generated/Models/StringOptionalWrapper.cs
+++ b/test/TestServerProjects/required-optional/Generated/Models/StringOptionalWrapper.cs
@@ -15,6 +15,13 @@ namespace required_optional.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="StringOptionalWrapper"/>. </summary>
+        /// <param name="value"></param>
+        internal StringOptionalWrapper(string value)
+        {
+            Value = value;
+        }
+
         /// <summary> Gets or sets the value. </summary>
         public string Value { get; set; }
     }

--- a/test/TestServerProjects/xml-service/Generated/Models/JsonInput.cs
+++ b/test/TestServerProjects/xml-service/Generated/Models/JsonInput.cs
@@ -15,6 +15,13 @@ namespace xml_service.Models
         {
         }
 
+        /// <summary> Initializes a new instance of <see cref="JsonInput"/>. </summary>
+        /// <param name="id"></param>
+        internal JsonInput(int? id)
+        {
+            Id = id;
+        }
+
         /// <summary> Gets or sets the id. </summary>
         public int? Id { get; set; }
     }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/3406

# Description

This is one of the changes included in model reader writer generator changes. We separate this into a standalone PR to reduce the amount of changes there

In DPG models, every model has two ctors: one public (for initialization) and one internal (for deserialization) even the model does not have deserialization.
This PR changes HLC and MPG to make their models to align the same behavior by adding the missing internal ctor

Because the added ctor is internal, no public API changes.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first