### PR TITLE
Performance improvement to GeneratedCodeWorkspace (30% improvement in time to generate)

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/GeneratedCodeWorkspace.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
 
 namespace AutoRest.CSharp.AutoRest.Plugins
 {
@@ -122,18 +123,16 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                     continue;
                 }
 
-                documents.Add(Task.Run(() => ProcessDocument(compilation, document, suppressedTypeNames)));
+                documents.Add(ProcessDocument(compilation, document, suppressedTypeNames));
             }
-
+            var docs = await Task.WhenAll(documents);
             var needProcessGeneratedDocs = _xmlDocFiles.Any();
             var generatedDocs = new Dictionary<string, SyntaxTree>();
 
-            foreach (var task in documents)
+            foreach (var doc in docs)
             {
-                var processed = await task;
+                var processed = doc;
 
-                processed = await Simplifier.ReduceAsync(processed);
-                processed = await Formatter.FormatAsync(processed);
                 var text = await processed.GetSyntaxTreeAsync();
                 yield return (processed.Name, text!.ToString());
                 if (needProcessGeneratedDocs) // TODO -- this is a workaround. In HLC, in some cases, there are multiple documents with the same name added in this list, and we get "dictionary same key has been added" exception
@@ -166,6 +165,8 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 document = document.WithSyntaxRoot(SA1505Rewriter.Visit(modelRemoveRewriter.Visit(await syntaxTree.GetRootAsync())));
             }
 
+            document = await Simplifier.ReduceAsync(document);
+            document = await Formatter.FormatAsync(document);
             return document;
         }
 


### PR DESCRIPTION
# Description
Performance improvement for generation. Test project was to generate Azure.ResourceManager.Sample.

Before:
![image](https://github.com/Azure/autorest.csharp/assets/1279263/48918dd3-c0b2-4c50-aa14-6c8238c366c7)

After:
![image](https://github.com/Azure/autorest.csharp/assets/1279263/9cf3d70c-1d8d-4796-88db-6abd49c5c7fb)
