### PR TITLE
fix(test): replace `@format("date")` with plainDate

### DIFF
--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/Azure.NewProject.TypeSpec.tsp
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/Azure.NewProject.TypeSpec.tsp
@@ -262,7 +262,7 @@ namespace Hello.Demo2 {
 @doc("top level method")
 @get
 @convenientAPI(true)
-op topAction(@path @format("date") action: string): Thing;
+op topAction(@path action: plainDate): Thing;
 
 @route("/top2")
 @doc("top level method2")

--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/Docs/NewProjectTypeSpecClient.xml
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/Docs/NewProjectTypeSpecClient.xml
@@ -9,7 +9,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"));
 ]]></code>
 This sample shows how to call TopActionAsync with all parameters.
 <code><![CDATA[
@@ -17,7 +17,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"));
 ]]></code></example>
     </member>
     <member name="TopAction(DateTimeOffset,CancellationToken)">
@@ -28,7 +28,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10"));
 ]]></code>
 This sample shows how to call TopAction with all parameters.
 <code><![CDATA[
@@ -36,7 +36,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10"));
 ]]></code></example>
     </member>
     <member name="TopActionAsync(DateTimeOffset,RequestContext)">
@@ -47,7 +47,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"), null);
 
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
@@ -64,7 +64,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"), null);
 
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
@@ -88,7 +88,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10"), null);
 
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());
@@ -105,7 +105,7 @@ Uri endpoint = new Uri("<https://my-service.azure.com>");
 AzureKeyCredential credential = new AzureKeyCredential("<key>");
 NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10"), null);
 
 JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
 Console.WriteLine(result.GetProperty("name").ToString());

--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/NewProjectTypeSpecClient.cs
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/NewProjectTypeSpecClient.cs
@@ -727,7 +727,7 @@ namespace Azure.NewProject.TypeSpec
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
             uri.AppendPath("/top/", false);
-            uri.AppendPath(action, "O", true);
+            uri.AppendPath(action, "D", true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
             return message;

--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/tspCodeModel.json
@@ -1116,8 +1116,8 @@
        "NameInRequest": "action",
        "Type": {
         "$id": "149",
-        "Name": "string",
-        "Kind": "DateTime",
+        "Name": "plainDate",
+        "Kind": "Date",
         "IsNullable": false
        },
        "Location": "Path",

--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/tests/Generated/Samples/Samples_NewProjectTypeSpecClient.cs
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/tests/Generated/Samples/Samples_NewProjectTypeSpecClient.cs
@@ -27,7 +27,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+            Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10"), null);
 
             JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
             Console.WriteLine(result.GetProperty("name").ToString());
@@ -47,7 +47,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+            Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"), null);
 
             JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
             Console.WriteLine(result.GetProperty("name").ToString());
@@ -67,7 +67,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+            Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10"));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+            Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"));
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+            Response response = client.TopAction(DateTimeOffset.Parse("2022-05-10"), null);
 
             JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
             Console.WriteLine(result.GetProperty("name").ToString());
@@ -113,7 +113,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"), null);
+            Response response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"), null);
 
             JsonElement result = JsonDocument.Parse(response.ContentStream).RootElement;
             Console.WriteLine(result.GetProperty("name").ToString());
@@ -137,7 +137,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+            Response<Thing> response = client.TopAction(DateTimeOffset.Parse("2022-05-10"));
         }
 
         [Test]
@@ -148,7 +148,7 @@ namespace Azure.NewProject.TypeSpec.Samples
             AzureKeyCredential credential = new AzureKeyCredential("<key>");
             NewProjectTypeSpecClient client = new NewProjectTypeSpecClient(endpoint, credential);
 
-            Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10T14:57:31.2311892-04:00"));
+            Response<Thing> response = await client.TopActionAsync(DateTimeOffset.Parse("2022-05-10"));
         }
 
         [Test]


### PR DESCRIPTION
# Description
See discussion in https://github.com/Azure/typespec-azure/pull/68

- replace `@format("date")` with plainDate
- this also fixes incorrect generated codes, accoriding to openapi spec: https://swagger.io/docs/specification/data-models/data-types/, `date` should be plain date, but in our existing generated codes, it's generated as date time

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first