### PR TITLE
DebuggerDisplay on `TypeProvider` causes premature calculation of `Declaration` property

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/TypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/TypeProvider.cs
@@ -89,7 +89,7 @@ namespace AutoRest.CSharp.Output.Models.Types
         private string GetDebuggerDisplay()
         {
             if (_type is null)
-                return "<pending calculation";
+                return "<pending calculation>";
 
             return $"TypeProvider ({Declaration.Accessibility} {Declaration.Namespace}.{Declaration.Name}";
         }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/TypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/TypeProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 
 namespace AutoRest.CSharp.Output.Models.Types
 {
-    [DebuggerDisplay("Name: {Declaration.Name}, Namespace: {Declaration.Namespace}")]
+    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     internal abstract class TypeProvider
     {
         private readonly Lazy<INamedTypeSymbol?> _existingType;
@@ -84,6 +84,14 @@ namespace AutoRest.CSharp.Output.Models.Types
         public override int GetHashCode()
         {
             return HashCode.Combine(DefaultName, DefaultNamespace, DefaultAccessibility, TypeKind);
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            if (_type is null)
+                return "<pending calculation";
+
+            return $"TypeProvider ({Declaration.Accessibility} {Declaration.Namespace}.{Declaration.Name}";
         }
     }
 }


### PR DESCRIPTION
# Description

As titled.
This PR also changes the format of the debugger display to: `TypeProvider (<accessibility> <fully qualified name of the type>)`

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first