### PR TITLE
Upload cadl ranch non-azure report

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -124,17 +124,28 @@ stages:
               failOnStderr: false
               displayName: 'Publish to GitHub, npm and coverage report'
               workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-          - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage/cadl-ranch-coverage-csharp.json
+          - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage/cadl-ranch-coverage-csharp-azure.json
+            artifact: CoverageReport
+          - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage/cadl-ranch-coverage-csharp-standard.json
             artifact: CoverageReport
           - ${{if eq(variables['System.TeamProject'], 'internal')}}:
             - task: AzureCLI@2
-              displayName: 'Upload to Cadl Ranch Coverage Report'
+              displayName: 'Upload Cadl Ranch Azure Coverage Report'
               condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
               inputs:
                 azureSubscription: "Cadl Ranch Storage"
                 scriptType: "bash"
                 scriptLocation: "inlineScript"
-                inlineScript: npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version")
+                inlineScript: npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp-azure.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version") --generatorMode azure
+                workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
+            - task: AzureCLI@2
+              displayName: 'Upload Cadl Ranch Standard Coverage Report'
+              condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
+              inputs:
+                azureSubscription: "Cadl Ranch Storage"
+                scriptType: "bash"
+                scriptLocation: "inlineScript"
+                inlineScript: npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp-standard.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version") --generatorMode standard
                 workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
           - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
             - template: new-emitter-package-files.yml

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -124,9 +124,7 @@ stages:
               failOnStderr: false
               displayName: 'Publish to GitHub, npm and coverage report'
               workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
-          - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage/cadl-ranch-coverage-csharp-azure.json
-            artifact: CoverageReport
-          - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage/cadl-ranch-coverage-csharp-standard.json
+          - publish: $(Build.SourcesDirectory)/autorest.csharp/artifacts/coverage
             artifact: CoverageReport
           - ${{if eq(variables['System.TeamProject'], 'internal')}}:
             - task: AzureCLI@2

--- a/test/AutoRest.TestServer.Tests/Infrastructure/CadlRanchNonAzureServer.cs
+++ b/test/AutoRest.TestServer.Tests/Infrastructure/CadlRanchNonAzureServer.cs
@@ -30,7 +30,7 @@ namespace AutoRest.TestServer.Tests.Infrastructure
         }
         internal static string GetCoverageFilePath()
         {
-            return Path.Combine(GetCoverageDirectory(), "cadl-ranch-coverage-csharp-nonAzure.json");
+            return Path.Combine(GetCoverageDirectory(), "cadl-ranch-coverage-csharp-standard.json");
         }
 
         protected override void Stop(Process process)

--- a/test/AutoRest.TestServer.Tests/Infrastructure/CadlRanchServer.cs
+++ b/test/AutoRest.TestServer.Tests/Infrastructure/CadlRanchServer.cs
@@ -30,7 +30,7 @@ namespace AutoRest.TestServer.Tests.Infrastructure
         }
         internal static string GetCoverageFilePath()
         {
-            return Path.Combine(GetCoverageDirectory(), "cadl-ranch-coverage-csharp.json");
+            return Path.Combine(GetCoverageDirectory(), "cadl-ranch-coverage-csharp-azure.json");
         }
 
         protected override void Stop(Process process)

--- a/test/CadlRanchProjectsNonAzure.Tests/AssemblyCleanFixture.cs
+++ b/test/CadlRanchProjectsNonAzure.Tests/AssemblyCleanFixture.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using AutoRest.TestServer.Tests.Infrastructure;
+using NUnit.Framework;
+
+[SetUpFixture]
+public static class AssemblyCleanFixture
+{
+    [OneTimeTearDown]
+    public static void RunOnAssemblyCleanUp()
+    {
+        CadlRanchNonAzureServerSession.Start().Server?.Dispose();
+    }
+}


### PR DESCRIPTION
Now we will have two reports
1. `cadl-ranch-coverage-csharp-azure.json` for azure version report
2. `cadl-ranch-coverage-csharp-standard.json` for non-azure version report

After each build, these two reports will be uploaded to the artifacts.

After merge each PR, two commands will be called to upload these two reports in artifacts to storage account
1. `npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp-azure.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version") --generatorMode azure`
2. `npx cadl-ranch upload-coverage --coverageFile ./artifacts/coverage/cadl-ranch-coverage-csharp-standard.json --generatorName csharp --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version") --generatorMode standard`

The diff from previous command is that there will be a new argument called `generatorMode`.


Guidance for other languages
---
1. Start a cadl-ranch server for all the azure tests, you will get a coverage report for azure. 
2. Start a cadl-ranch server **again** for all the non-azure tests, you will get another coverage report for non-azure. 
3. (Optional) Upload these two reports to build artifacts as what you are currently doing.
4. Call `npx cadl-ranch upload-coverage --coverageFile {your azure report} --generatorMode azure {other arguments}`
5. Call `npx cadl-ranch upload-coverage --coverageFile {your non-azure report} --generatorMode standard {other arguments}`