### PR TITLE
add a skipBuildProject flag to the script and make the regenerate all code script no longer build every test project

### DIFF
--- a/.github/workflows/regenerate-code.yml
+++ b/.github/workflows/regenerate-code.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate code
         shell: pwsh
         run: |
-          ./eng/Generate.ps1
+          ./eng/Generate.ps1 -skipBuildProject
 
       - name: Commit generated code
         run: |

--- a/eng/Generate.ps1
+++ b/eng/Generate.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.0
-param($filter, [switch]$continue, [switch]$reset, [switch]$noBuild, [switch]$fast, [switch]$debug, [String[]]$Exclude = "SmokeTests", $parallel = 5)
+param($filter, [switch]$continue, [switch]$reset, [switch]$noBuild, [switch]$fast, [switch]$skipBuildProject, [switch]$debug, [String[]]$Exclude = "SmokeTests", $parallel = 5)
 
 Import-Module "$PSScriptRoot\Generation.psm1" -DisableNameChecking -Force;
 Import-Module "$PSScriptRoot\..\test\scripts\LocalTestNugetSource.psm1" -DisableNameChecking -Force;
@@ -399,14 +399,14 @@ if($testPackagesToInstall.Count -gt 0){
 $keys | % { $swaggerDefinitions[$_] } | ForEach-Object -Parallel {
     if ($_.output -ne $null) {
         Import-Module "$using:PSScriptRoot\Generation.psm1" -DisableNameChecking;
-        Invoke-AutoRest $_.output $_.projectName $_.arguments $using:sharedSource $using:fast $using:debug;
+        Invoke-AutoRest $_.output $_.projectName $_.arguments $using:sharedSource $using:fast $using:debug $using:skipBuildProject;
     }
 } -ThrottleLimit $parallel
 
 $keys | % { $tspDefinitions[$_] } | ForEach-Object -Parallel {
     if ($_.output -ne $null) {
         Import-Module "$using:PSScriptRoot\Generation.psm1" -DisableNameChecking;
-        Invoke-TypeSpec $_.output $_.projectName $_.mainFile $_.arguments $using:sharedSource $using:fast $using:debug;
+        Invoke-TypeSpec $_.output $_.projectName $_.mainFile $_.arguments $using:sharedSource $using:fast $using:debug $using:skipBuildProject;
     }
 } -ThrottleLimit $parallel
 

--- a/eng/Generation.psm1
+++ b/eng/Generation.psm1
@@ -22,7 +22,7 @@ function Invoke($command, $executePath=$repoRoot)
     }
 }
 
-function Invoke-AutoRest($baseOutput, $projectName, $autoRestArguments, $sharedSource, $fast, $debug)
+function Invoke-AutoRest($baseOutput, $projectName, $autoRestArguments, $sharedSource, $fast, $debug, $skipBuildProject)
 {
     $outputPath = $baseOutput
     if(Test-Path "$outputPath/*.sln") {
@@ -51,7 +51,9 @@ function Invoke-AutoRest($baseOutput, $projectName, $autoRestArguments, $sharedS
     if($buildDir.EndsWith("src")) {
         $buildDir = $buildDir -replace ".{4}$"
     }
-    Invoke "dotnet build $buildDir --verbosity quiet /nologo"
+    if (!$skipBuildProject) {
+        Invoke "dotnet build $buildDir --verbosity quiet /nologo"
+    }
 }
 
 function AutoRest-Reset()
@@ -59,7 +61,7 @@ function AutoRest-Reset()
     Invoke "$script:autoRestBinary --reset"
 }
 
-function Invoke-TypeSpec($baseOutput, $projectName, $mainFile, $arguments="", $sharedSource="", $fast="", $debug="")
+function Invoke-TypeSpec($baseOutput, $projectName, $mainFile, $arguments, $sharedSource, $fast, $debug, $skipBuildProject)
 {
     if (!(Test-Path $baseOutput)) {
         New-Item $baseOutput -ItemType Directory
@@ -102,7 +104,9 @@ function Invoke-TypeSpec($baseOutput, $projectName, $mainFile, $arguments="", $s
     if($buildDir.EndsWith("src")) {
         $buildDir = $buildDir -replace ".{4}$"
     }
-    Invoke "dotnet build $buildDir --verbosity quiet /nologo"
+    if (!$skipBuildProject) {
+        Invoke "dotnet build $buildDir --verbosity quiet /nologo"
+    }
 }
 
 function Invoke-TypeSpecSetup()


### PR DESCRIPTION
# Description

The `Generate.ps1` script has a swicth `noBuild` but it only let us "do not build the generator and the emitter".
In the regenerate all code script, we actually only want the result, if any of the project generates but does not build, we actually should also let the script could successfully finish - nevertheless whether the test project could buid without errors will be checked by our pipelines on the PR.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first