### PR TITLE
chore(autorest): bump to 3.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@azure-tools/typespec-csharp": "file:src/TypeSpec.Extension/Emitter.Csharp",
         "@azure-tools/unbranded-tests": "file:test/UnbrandedProjects",
         "@microsoft.azure/autorest.testserver": "3.3.48",
-        "autorest": "3.6.3"
+        "autorest": "3.7.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2064,9 +2064,9 @@
       "dev": true
     },
     "node_modules/autorest": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.6.3.tgz",
-      "integrity": "sha512-j/Axwk9bniifTNtBLYVxfQZGQIGPKljFaCQCBWOiybVar2j3tkHP1btiC4a/t9pAJXY6IaFgWctoPM3G/Puhyg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.7.1.tgz",
+      "integrity": "sha512-6q17NtosQZPqBkIOUnaOPedf3PDIBF7Ha1iEGRhTqZF6TG2Q/1E3ID/D+ePIIzZDKvW01p/2pENq/oiBWH9IGQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "@azure-tools/typespec-csharp": "file:src/TypeSpec.Extension/Emitter.Csharp",
     "@azure-tools/unbranded-tests": "file:test/UnbrandedProjects",
     "@microsoft.azure/autorest.testserver": "3.3.48",
-    "autorest": "3.6.3"
+    "autorest": "3.7.1"
   }
 }


### PR DESCRIPTION
# Description
Bump `autorest` in generator to `3.7.1`, since `azure-sdk-for-net` is already using `3.7.1` in CI.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first