### PR TITLE
Support parameter overrides in bicep serialization

### DIFF
--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -49,4 +49,9 @@
     <PackageReference Update="NuGet.Configuration" Version="6.8.0" />
     <PackageReference Update="Microsoft.Build" Version="16.11.0" />
   </ItemGroup>
+  
+  <!-- Override Client Model version for tests projects. Can be reverted once autorest.csharp is updated to consume 1.1.0.-->
+  <ItemGroup Condition="'$(IsTestGenerationSrcProject)' == 'true'">
+    <PackageReference Update="System.ClientModel" Version="1.0.0" />
+  </ItemGroup>
 </Project>

--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -34,9 +34,9 @@
   <ItemGroup>
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="System.ClientModel" Version="1.0.0-beta.3" />
-    <PackageReference Update="Azure.Core" Version="1.36.0" />
+    <PackageReference Update="Azure.Core" Version="1.37.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.18" />
-    <PackageReference Update="Azure.ResourceManager" Version="1.9.0" />
+    <PackageReference Update="Azure.ResourceManager" Version="1.11.0-alpha.20240210.4" />
     <PackageReference Update="Azure.Core.Expressions.DataFactory" Version="1.0.0-beta.4" />
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="6.0.1" />

--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -50,7 +50,7 @@
     <PackageReference Update="Microsoft.Build" Version="16.11.0" />
   </ItemGroup>
   
-  <!-- Override Client Model version for tests projects. Can be reverted once autorest.csharp is updated to consume 1.1.0.-->
+  <!-- Override Client Model version for tests projects. Can be reverted once autorest.csharp is updated to consume 1.1.0. https://github.com/Azure/autorest.csharp/issues/4216-->
   <ItemGroup Condition="'$(IsTestGenerationSrcProject)' == 'true'">
     <PackageReference Update="System.ClientModel" Version="1.0.0" />
   </ItemGroup>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Version>3.0.0</Version>
     <TargetFramework>net7.0</TargetFramework>
-<!--    Can be reverted once autorest.csharp is updated to consume System.ClientModel 1.1.0 -->
+<!--    Can be reverted once autorest.csharp is updated to consume System.ClientModel 1.1.0 https://github.com/Azure/autorest.csharp/issues/4216-->
     <NoWarn>NU1605</NoWarn>
 <!--    End Temp-->
     <Nullable>enable</Nullable>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -5,6 +5,9 @@
     <OutputType>Exe</OutputType>
     <Version>3.0.0</Version>
     <TargetFramework>net7.0</TargetFramework>
+<!--    Will not be merged - temporary until autorest.csharp is updated to consume latest Azure.Core -->
+    <NoWarn>NU1605</NoWarn>
+<!--    End Temp-->
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
@@ -54,6 +57,10 @@
     <None Include="readme.md" CopyToOutputDirectory="PreserveNewest" />
     <None Include="index.d.ts" CopyToOutputDirectory="PreserveNewest" />
     <None Include="index.mjs" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\azure-sdk-for-net\sdk\resourcemanager\Azure.ResourceManager\src\Azure.ResourceManager.csproj" />
   </ItemGroup>
 
   <Target Name="PreparePropsFile" BeforeTargets="GenerateNuspec;_GetPackageFiles" DependsOnTargets="GenerateSourceLinkFile" Condition="'$(TargetFrameworks)' == '' or '$(IsCrossTargetingBuild)' == 'true'" Outputs="$(_SourcePackagePropsFilePath)">

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -58,11 +58,7 @@
     <None Include="index.d.ts" CopyToOutputDirectory="PreserveNewest" />
     <None Include="index.mjs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\azure-sdk-for-net\sdk\resourcemanager\Azure.ResourceManager\src\Azure.ResourceManager.csproj" />
-  </ItemGroup>
-
+  
   <Target Name="PreparePropsFile" BeforeTargets="GenerateNuspec;_GetPackageFiles" DependsOnTargets="GenerateSourceLinkFile" Condition="'$(TargetFrameworks)' == '' or '$(IsCrossTargetingBuild)' == 'true'" Outputs="$(_SourcePackagePropsFilePath)">
 
     <PropertyGroup>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Version>3.0.0</Version>
     <TargetFramework>net7.0</TargetFramework>
-<!--    Will not be merged - temporary until autorest.csharp is updated to consume latest Azure.Core -->
+<!--    Can be reverted once autorest.csharp is updated to consume System.ClientModel 1.1.0 -->
     <NoWarn>NU1605</NoWarn>
 <!--    End Temp-->
     <Nullable>enable</Nullable>

--- a/src/AutoRest.CSharp/AutoRest.CSharp.csproj
+++ b/src/AutoRest.CSharp/AutoRest.CSharp.csproj
@@ -58,7 +58,7 @@
     <None Include="index.d.ts" CopyToOutputDirectory="PreserveNewest" />
     <None Include="index.mjs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <Target Name="PreparePropsFile" BeforeTargets="GenerateNuspec;_GetPackageFiles" DependsOnTargets="GenerateSourceLinkFile" Condition="'$(TargetFrameworks)' == '' or '$(IsCrossTargetingBuild)' == 'true'" Outputs="$(_SourcePackagePropsFilePath)">
 
     <PropertyGroup>

--- a/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Writers/CodeWriterExtensions.Methods.cs
@@ -303,6 +303,10 @@ namespace AutoRest.CSharp.Generation.Writers
                     writer.WriteValueExpression(cast.Inner);
                     writer.AppendRaw(")");
                     break;
+                case AsExpression asExpression:
+                    writer.WriteValueExpression(asExpression.Inner);
+                    writer.Append($" as {asExpression.Type}");
+                    break;
                 case CollectionInitializerExpression(var items):
                     writer.AppendRaw("{ ");
                     foreach (var item in items)

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
@@ -24,13 +24,8 @@ namespace AutoRest.CSharp.Common.Output.Models
             public static ValueExpression ToList(ValueExpression collection) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToListName, new[] { collection });
             public static ValueExpression ToNullable(ValueExpression optional) => new InvokeStaticMethodExpression(Configuration.ApiTypes.OptionalType, Configuration.ApiTypes.OptionalToNullableName, new[] { optional });
 
-            public static MethodBodyStatement WrapInIsDefined(PropertySerialization serialization, MethodBodyStatement statement, bool forceCheck = false)
+            public static MethodBodyStatement WrapInIsDefined(PropertySerialization serialization, MethodBodyStatement statement)
             {
-                if (!forceCheck && serialization.IsRequired)
-                {
-                    return statement;
-                }
-
                 return TypeFactory.IsCollectionType(serialization.Value.Type) && !TypeFactory.IsReadOnlyMemory(serialization.Value.Type)
                     ? new IfStatement(IsCollectionDefined(serialization.Value)) { statement }
                     : new IfStatement(IsDefined(serialization.Value)) { statement };

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
@@ -30,13 +30,6 @@ namespace AutoRest.CSharp.Common.Output.Models
                     ? new IfStatement(IsCollectionDefined(serialization.Value)) { statement }
                     : new IfStatement(IsDefined(serialization.Value)) { statement };
             }
-
-            public static MethodBodyStatement WrapInIsNotEmpty(PropertySerialization serialization, MethodBodyStatement statement)
-            {
-                return TypeFactory.IsCollectionType(serialization.Value.Type) && !TypeFactory.IsReadOnlyMemory(serialization.Value.Type)
-                    ? new IfStatement(new BoolExpression(InvokeStaticMethodExpression.Extension(typeof(Enumerable), nameof(Enumerable.Any), serialization.Value))) { statement }
-                    : statement;
-            }
         }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.Optional.cs
@@ -26,6 +26,11 @@ namespace AutoRest.CSharp.Common.Output.Models
 
             public static MethodBodyStatement WrapInIsDefined(PropertySerialization serialization, MethodBodyStatement statement)
             {
+                if (serialization.IsRequired)
+                {
+                    return statement;
+                }
+
                 return TypeFactory.IsCollectionType(serialization.Value.Type) && !TypeFactory.IsReadOnlyMemory(serialization.Value.Type)
                     ? new IfStatement(IsCollectionDefined(serialization.Value)) { statement }
                     : new IfStatement(IsDefined(serialization.Value)) { statement };

--- a/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/AsExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/ValueExpressions/AsExpression.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.CSharp.Generation.Types;
+
+namespace AutoRest.CSharp.Common.Output.Expressions.ValueExpressions
+{
+    internal record AsExpression(ValueExpression Inner, CSharpType Type) : ValueExpression;
+}

--- a/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
+++ b/test/AutoRest.Shared.Tests/AutoRest.Shared.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>annotations</Nullable>
-    <NoWarn>SA1649;SA1633</NoWarn>
+    <NoWarn>SA1649;SA1633;NU1605</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
+++ b/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>annotations</Nullable>
-    <NoWarn>SA1649;SA1633;CS0618</NoWarn>
+    <NoWarn>SA1649;SA1633;CS0618;NU1605</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +26,8 @@
     <PackageReference Include="Moq" Version="4.20.69" />
 
     <ProjectReference Include="../../src/AutoRest.CSharp/AutoRest.CSharp.csproj" />
+
+    <ProjectReference Include="..\..\..\azure-sdk-for-net\sdk\resourcemanager\Azure.ResourceManager\src\Azure.ResourceManager.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
+++ b/test/AutoRest.TestServer.Tests/AutoRest.TestServer.Tests.csproj
@@ -26,8 +26,6 @@
     <PackageReference Include="Moq" Version="4.20.69" />
 
     <ProjectReference Include="../../src/AutoRest.CSharp/AutoRest.CSharp.csproj" />
-
-    <ProjectReference Include="..\..\..\azure-sdk-for-net\sdk\resourcemanager\Azure.ResourceManager\src\Azure.ResourceManager.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/ArtifactData.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/ArtifactData.Serialization.cs
@@ -30,22 +30,19 @@ namespace MgmtDiscriminator
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(Id))
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToString());
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W" && Optional.IsDefined(Name))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W" && Optional.IsDefined(ResourceType))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/ArtifactData.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/ArtifactData.Serialization.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using MgmtDiscriminator.Models;
 
 namespace MgmtDiscriminator
@@ -28,19 +30,22 @@ namespace MgmtDiscriminator
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToString());
+            }
+            if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(ResourceType))
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -102,38 +107,76 @@ namespace MgmtDiscriminator
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                if (Name.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Name}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Name}'");
+                    if (Name.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Name}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Name}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Kind.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(Id))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
             {
                 builder.Append("  id:");
-                builder.AppendLine($" '{Id.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Id.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(SystemData))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(SystemData), out propertyOverride);
+            if (Optional.IsDefined(SystemData) || hasPropertyOverride)
             {
                 builder.Append("  systemData:");
-                builder.AppendLine($" '{SystemData.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{SystemData.ToString()}'");
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/ArtifactList.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/ArtifactList.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using MgmtDiscriminator;
 
 namespace MgmtDiscriminator.Models
@@ -119,33 +120,55 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsCollectionDefined(Value))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Value), out propertyOverride);
+            if (Optional.IsCollectionDefined(Value) || hasPropertyOverride)
             {
-                if (Value.Any())
+                if (Value.Any() || hasPropertyOverride)
                 {
                     builder.Append("  value:");
-                    builder.AppendLine(" [");
-                    foreach (var item in Value)
+                    if (hasPropertyOverride)
                     {
-                        AppendChildObject(builder, item, options, 4, true);
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("  ]");
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in Value)
+                        {
+                            AppendChildObject(builder, item, options, 4, true);
+                        }
+                        builder.AppendLine("  ]");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(NextLink))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(NextLink), out propertyOverride);
+            if (Optional.IsDefined(NextLink) || hasPropertyOverride)
             {
                 builder.Append("  nextLink:");
-                if (NextLink.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{NextLink}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{NextLink}'");
+                    if (NextLink.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{NextLink}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{NextLink}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/BaseModel.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/BaseModel.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -92,19 +93,33 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(OptionalString))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(OptionalString), out propertyOverride);
+            if (Optional.IsDefined(OptionalString) || hasPropertyOverride)
             {
                 builder.Append("  optionalString:");
-                if (OptionalString.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{OptionalString}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{OptionalString}'");
+                    if (OptionalString.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{OptionalString}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{OptionalString}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheExpirationActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheExpirationActionParameters.Serialization.cs
@@ -28,21 +28,12 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(CacheBehavior))
-            {
-                writer.WritePropertyName("cacheBehavior"u8);
-                writer.WriteStringValue(CacheBehavior.ToString());
-            }
-            if (Optional.IsDefined(CacheType))
-            {
-                writer.WritePropertyName("cacheType"u8);
-                writer.WriteStringValue(CacheType.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("cacheBehavior"u8);
+            writer.WriteStringValue(CacheBehavior.ToString());
+            writer.WritePropertyName("cacheType"u8);
+            writer.WriteStringValue(CacheType.ToString());
             if (Optional.IsDefined(CacheDuration))
             {
                 if (CacheDuration != null)

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheExpirationActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheExpirationActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,12 +28,21 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("cacheBehavior"u8);
-            writer.WriteStringValue(CacheBehavior.ToString());
-            writer.WritePropertyName("cacheType"u8);
-            writer.WriteStringValue(CacheType.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(CacheBehavior))
+            {
+                writer.WritePropertyName("cacheBehavior"u8);
+                writer.WriteStringValue(CacheBehavior.ToString());
+            }
+            if (Optional.IsDefined(CacheType))
+            {
+                writer.WritePropertyName("cacheType"u8);
+                writer.WriteStringValue(CacheType.ToString());
+            }
             if (Optional.IsDefined(CacheDuration))
             {
                 if (CacheDuration != null)
@@ -128,31 +138,69 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(CacheBehavior))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CacheBehavior), out propertyOverride);
+            if (Optional.IsDefined(CacheBehavior) || hasPropertyOverride)
             {
                 builder.Append("  cacheBehavior:");
-                builder.AppendLine($" '{CacheBehavior.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{CacheBehavior.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(CacheType))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CacheType), out propertyOverride);
+            if (Optional.IsDefined(CacheType) || hasPropertyOverride)
             {
                 builder.Append("  cacheType:");
-                builder.AppendLine($" '{CacheType.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{CacheType.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(CacheDuration))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CacheDuration), out propertyOverride);
+            if (Optional.IsDefined(CacheDuration) || hasPropertyOverride)
             {
                 builder.Append("  cacheDuration:");
-                var formattedTimeSpan = TypeFormatters.ToString(CacheDuration.Value, "P");
-                builder.AppendLine($" '{formattedTimeSpan}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var formattedTimeSpan = TypeFormatters.ToString(CacheDuration.Value, "P");
+                    builder.AppendLine($" '{formattedTimeSpan}'");
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheKeyQueryStringActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheKeyQueryStringActionParameters.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(QueryStringBehavior))
-            {
-                writer.WritePropertyName("queryStringBehavior"u8);
-                writer.WriteStringValue(QueryStringBehavior.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("queryStringBehavior"u8);
+            writer.WriteStringValue(QueryStringBehavior.ToString());
             if (Optional.IsDefined(QueryParameters))
             {
                 if (QueryParameters != null)

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheKeyQueryStringActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/CacheKeyQueryStringActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,10 +28,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("queryStringBehavior"u8);
-            writer.WriteStringValue(QueryStringBehavior.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(QueryStringBehavior))
+            {
+                writer.WritePropertyName("queryStringBehavior"u8);
+                writer.WriteStringValue(QueryStringBehavior.ToString());
+            }
             if (Optional.IsDefined(QueryParameters))
             {
                 if (QueryParameters != null)
@@ -120,31 +127,61 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
-            }
-
-            if (Optional.IsDefined(QueryStringBehavior))
-            {
-                builder.Append("  queryStringBehavior:");
-                builder.AppendLine($" '{QueryStringBehavior.ToString()}'");
-            }
-
-            if (Optional.IsDefined(QueryParameters))
-            {
-                builder.Append("  queryParameters:");
-                if (QueryParameters.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{QueryParameters}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{QueryParameters}'");
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(QueryStringBehavior), out propertyOverride);
+            if (Optional.IsDefined(QueryStringBehavior) || hasPropertyOverride)
+            {
+                builder.Append("  queryStringBehavior:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{QueryStringBehavior.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(QueryParameters), out propertyOverride);
+            if (Optional.IsDefined(QueryParameters) || hasPropertyOverride)
+            {
+                builder.Append("  queryParameters:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (QueryParameters.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{QueryParameters}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{QueryParameters}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/Cat.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/Cat.Serialization.cs
@@ -33,11 +33,8 @@ namespace MgmtDiscriminator.Models
                 writer.WritePropertyName("meow"u8);
                 writer.WriteStringValue(Meow);
             }
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToSerialString());
-            }
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToSerialString());
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/Cat.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/Cat.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -32,8 +33,11 @@ namespace MgmtDiscriminator.Models
                 writer.WritePropertyName("meow"u8);
                 writer.WriteStringValue(Meow);
             }
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToSerialString());
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToSerialString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
@@ -111,39 +115,69 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Meow))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Meow), out propertyOverride);
+            if (Optional.IsDefined(Meow) || hasPropertyOverride)
             {
                 builder.Append("  meow:");
-                if (Meow.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Meow}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Meow}'");
+                    if (Meow.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Meow}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Meow}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToSerialString()}'");
-            }
-
-            if (Optional.IsDefined(Id))
-            {
-                builder.Append("  id:");
-                if (Id.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Id}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Id}'");
+                    builder.AppendLine($" '{Kind.ToSerialString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
+            {
+                builder.Append("  id:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Id.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Id}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Id}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleAction.Serialization.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -26,8 +28,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name.ToString());
+            if (Optional.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name.ToString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);
@@ -92,25 +97,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                builder.AppendLine($" '{Name.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Foo))
-            {
-                builder.Append("  foo:");
-                if (Foo.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Foo}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Foo}'");
+                    builder.AppendLine($" '{Name.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Foo), out propertyOverride);
+            if (Optional.IsDefined(Foo) || hasPropertyOverride)
+            {
+                builder.Append("  foo:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Foo.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Foo}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Foo}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleAction.Serialization.cs
@@ -28,11 +28,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCacheExpirationAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCacheExpirationAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCacheKeyQueryStringAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCacheKeyQueryStringAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCondition.Serialization.cs
@@ -29,11 +29,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleCondition.Serialization.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,8 +29,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name.ToString());
+            if (Optional.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name.ToString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);
@@ -87,25 +92,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                builder.AppendLine($" '{Name.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Foo))
-            {
-                builder.Append("  foo:");
-                if (Foo.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Foo}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Foo}'");
+                    builder.AppendLine($" '{Name.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Foo), out propertyOverride);
+            if (Optional.IsDefined(Foo) || hasPropertyOverride)
+            {
+                builder.Append("  foo:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Foo.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Foo}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Foo}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleData.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleData.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using Azure.ResourceManager.Models;
 using MgmtDiscriminator.Models;
 
@@ -69,17 +70,17 @@ namespace MgmtDiscriminator
                 writer.WritePropertyName("properties"u8);
                 writer.WriteObjectValue(Properties);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(ResourceType))
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -251,83 +252,177 @@ namespace MgmtDiscriminator
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                if (Name.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Name}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Name}'");
+                    if (Name.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Name}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Name}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Location))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Location), out propertyOverride);
+            if (Optional.IsDefined(Location) || hasPropertyOverride)
             {
                 builder.Append("  location:");
-                builder.AppendLine($" '{Location.Value.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Location.Value.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(BoolProperty))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(BoolProperty), out propertyOverride);
+            if (Optional.IsDefined(BoolProperty) || hasPropertyOverride)
             {
                 builder.Append("  boolProperty:");
-                var boolValue = BoolProperty.Value == true ? "true" : "false";
-                builder.AppendLine($" {boolValue}");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var boolValue = BoolProperty.Value == true ? "true" : "false";
+                    builder.AppendLine($" {boolValue}");
+                }
             }
 
-            if (Optional.IsDefined(LocationWithCustomSerialization))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(LocationWithCustomSerialization), out propertyOverride);
+            if (Optional.IsDefined(LocationWithCustomSerialization) || hasPropertyOverride)
             {
                 builder.Append("  locationWithCustomSerialization:");
-                SerializeLocation(builder);
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    SerializeLocation(builder);
+                }
             }
 
-            if (Optional.IsDefined(DateTimeProperty))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(DateTimeProperty), out propertyOverride);
+            if (Optional.IsDefined(DateTimeProperty) || hasPropertyOverride)
             {
                 builder.Append("  dateTimeProperty:");
-                var formattedDateTimeString = TypeFormatters.ToString(DateTimeProperty.Value, "o");
-                builder.AppendLine($" '{formattedDateTimeString}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var formattedDateTimeString = TypeFormatters.ToString(DateTimeProperty.Value, "o");
+                    builder.AppendLine($" '{formattedDateTimeString}'");
+                }
             }
 
-            if (Optional.IsDefined(Duration))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Duration), out propertyOverride);
+            if (Optional.IsDefined(Duration) || hasPropertyOverride)
             {
                 builder.Append("  duration:");
-                var formattedTimeSpan = TypeFormatters.ToString(Duration.Value, "P");
-                builder.AppendLine($" '{formattedTimeSpan}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var formattedTimeSpan = TypeFormatters.ToString(Duration.Value, "P");
+                    builder.AppendLine($" '{formattedTimeSpan}'");
+                }
             }
 
-            if (Optional.IsDefined(Number))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Number), out propertyOverride);
+            if (Optional.IsDefined(Number) || hasPropertyOverride)
             {
                 builder.Append("  number:");
-                builder.AppendLine($" {Number.Value}");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" {Number.Value}");
+                }
             }
 
-            if (Optional.IsDefined(Uri))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Uri), out propertyOverride);
+            if (Optional.IsDefined(Uri) || hasPropertyOverride)
             {
                 builder.Append("  uri:");
-                builder.AppendLine($" '{Uri.AbsoluteUri}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Uri.AbsoluteUri}'");
+                }
             }
 
-            if (Optional.IsDefined(Properties))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Properties), out propertyOverride);
+            if (Optional.IsDefined(Properties) || hasPropertyOverride)
             {
                 builder.Append("  properties:");
-                AppendChildObject(builder, Properties, options, 2, false);
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    AppendChildObject(builder, Properties, options, 2, false);
+                }
             }
 
-            if (Optional.IsDefined(Id))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
             {
                 builder.Append("  id:");
-                builder.AppendLine($" '{Id.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Id.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(SystemData))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(SystemData), out propertyOverride);
+            if (Optional.IsDefined(SystemData) || hasPropertyOverride)
             {
                 builder.Append("  systemData:");
-                builder.AppendLine($" '{SystemData.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{SystemData.ToString()}'");
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleData.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleData.Serialization.cs
@@ -70,17 +70,17 @@ namespace MgmtDiscriminator
                 writer.WritePropertyName("properties"u8);
                 writer.WriteObjectValue(Properties);
             }
-            if (options.Format != "W" && Optional.IsDefined(Id))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W" && Optional.IsDefined(Name))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W" && Optional.IsDefined(ResourceType))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleListResult.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleListResult.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using MgmtDiscriminator;
 
 namespace MgmtDiscriminator.Models
@@ -108,19 +109,33 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsCollectionDefined(Value))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Value), out propertyOverride);
+            if (Optional.IsCollectionDefined(Value) || hasPropertyOverride)
             {
-                if (Value.Any())
+                if (Value.Any() || hasPropertyOverride)
                 {
                     builder.Append("  value:");
-                    builder.AppendLine(" [");
-                    foreach (var item in Value)
+                    if (hasPropertyOverride)
                     {
-                        AppendChildObject(builder, item, options, 4, true);
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("  ]");
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in Value)
+                        {
+                            AppendChildObject(builder, item, options, 4, true);
+                        }
+                        builder.AppendLine("  ]");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleProperties.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleProperties.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -189,66 +190,120 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Order))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Order), out propertyOverride);
+            if (Optional.IsDefined(Order) || hasPropertyOverride)
             {
                 builder.Append("  order:");
-                builder.AppendLine($" {Order.Value}");
-            }
-
-            if (Optional.IsDefined(Conditions))
-            {
-                builder.Append("  conditions:");
-                AppendChildObject(builder, Conditions, options, 2, false);
-            }
-
-            if (Optional.IsCollectionDefined(Actions))
-            {
-                if (Actions.Any())
+                if (hasPropertyOverride)
                 {
-                    builder.Append("  actions:");
-                    builder.AppendLine(" [");
-                    foreach (var item in Actions)
-                    {
-                        AppendChildObject(builder, item, options, 4, true);
-                    }
-                    builder.AppendLine("  ]");
-                }
-            }
-
-            if (Optional.IsCollectionDefined(ExtraMappingInfo))
-            {
-                if (ExtraMappingInfo.Any())
-                {
-                    builder.Append("  extraMappingInfo:");
-                    builder.AppendLine(" {");
-                    foreach (var item in ExtraMappingInfo)
-                    {
-                        builder.Append($"    {item.Key}:");
-                        AppendChildObject(builder, item.Value, options, 4, false);
-                    }
-                    builder.AppendLine("  }");
-                }
-            }
-
-            if (Optional.IsDefined(Pet))
-            {
-                builder.Append("  pet:");
-                AppendChildObject(builder, Pet, options, 2, false);
-            }
-
-            if (Optional.IsDefined(Foo))
-            {
-                builder.Append("  foo:");
-                if (Foo.Contains(Environment.NewLine))
-                {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Foo}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Foo}'");
+                    builder.AppendLine($" {Order.Value}");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Conditions), out propertyOverride);
+            if (Optional.IsDefined(Conditions) || hasPropertyOverride)
+            {
+                builder.Append("  conditions:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    AppendChildObject(builder, Conditions, options, 2, false);
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Actions), out propertyOverride);
+            if (Optional.IsCollectionDefined(Actions) || hasPropertyOverride)
+            {
+                if (Actions.Any() || hasPropertyOverride)
+                {
+                    builder.Append("  actions:");
+                    if (hasPropertyOverride)
+                    {
+                        builder.AppendLine($" {propertyOverride}");
+                    }
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in Actions)
+                        {
+                            AppendChildObject(builder, item, options, 4, true);
+                        }
+                        builder.AppendLine("  ]");
+                    }
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ExtraMappingInfo), out propertyOverride);
+            if (Optional.IsCollectionDefined(ExtraMappingInfo) || hasPropertyOverride)
+            {
+                if (ExtraMappingInfo.Any() || hasPropertyOverride)
+                {
+                    builder.Append("  extraMappingInfo:");
+                    if (hasPropertyOverride)
+                    {
+                        builder.AppendLine($" {propertyOverride}");
+                    }
+                    else
+                    {
+                        builder.AppendLine(" {");
+                        foreach (var item in ExtraMappingInfo)
+                        {
+                            builder.Append($"    {item.Key}:");
+                            AppendChildObject(builder, item.Value, options, 4, false);
+                        }
+                        builder.AppendLine("  }");
+                    }
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Pet), out propertyOverride);
+            if (Optional.IsDefined(Pet) || hasPropertyOverride)
+            {
+                builder.Append("  pet:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    AppendChildObject(builder, Pet, options, 2, false);
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Foo), out propertyOverride);
+            if (Optional.IsDefined(Foo) || hasPropertyOverride)
+            {
+                builder.Append("  foo:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Foo.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Foo}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Foo}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleQueryStringCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleQueryStringCondition.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRemoteAddressCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRemoteAddressCondition.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRequestHeaderAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRequestHeaderAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRequestMethodCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRequestMethodCondition.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleResponseHeaderAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleResponseHeaderAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRouteConfigurationOverrideAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DeliveryRuleRouteConfigurationOverrideAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/DerivedModel.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/DerivedModel.Serialization.cs
@@ -29,16 +29,13 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsCollectionDefined(RequiredCollection))
+            writer.WritePropertyName("requiredCollection"u8);
+            writer.WriteStartArray();
+            foreach (var item in RequiredCollection)
             {
-                writer.WritePropertyName("requiredCollection"u8);
-                writer.WriteStartArray();
-                foreach (var item in RequiredCollection)
-                {
-                    writer.WriteStringValue(item);
-                }
-                writer.WriteEndArray();
+                writer.WriteStringValue(item);
             }
+            writer.WriteEndArray();
             if (Optional.IsDefined(OptionalString))
             {
                 writer.WritePropertyName("optionalString"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/Dog.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/Dog.Serialization.cs
@@ -38,11 +38,8 @@ namespace MgmtDiscriminator.Models
                 writer.WritePropertyName("dogKind"u8);
                 writer.WriteStringValue(DogKind.Value.ToSerialString());
             }
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToSerialString());
-            }
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToSerialString());
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/Dog.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/Dog.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -37,8 +38,11 @@ namespace MgmtDiscriminator.Models
                 writer.WritePropertyName("dogKind"u8);
                 writer.WriteStringValue(DogKind.Value.ToSerialString());
             }
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToSerialString());
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToSerialString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
@@ -126,45 +130,83 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Bark))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Bark), out propertyOverride);
+            if (Optional.IsDefined(Bark) || hasPropertyOverride)
             {
                 builder.Append("  bark:");
-                if (Bark.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Bark}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Bark}'");
+                    if (Bark.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Bark}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Bark}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(DogKind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(DogKind), out propertyOverride);
+            if (Optional.IsDefined(DogKind) || hasPropertyOverride)
             {
                 builder.Append("  dogKind:");
-                builder.AppendLine($" '{DogKind.Value.ToSerialString()}'");
-            }
-
-            if (Optional.IsDefined(Kind))
-            {
-                builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToSerialString()}'");
-            }
-
-            if (Optional.IsDefined(Id))
-            {
-                builder.Append("  id:");
-                if (Id.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Id}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Id}'");
+                    builder.AppendLine($" '{DogKind.Value.ToSerialString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
+            {
+                builder.Append("  kind:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Kind.ToSerialString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
+            {
+                builder.Append("  id:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Id.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Id}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Id}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/HeaderActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/HeaderActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,12 +28,21 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("headerAction"u8);
-            writer.WriteStringValue(HeaderAction.ToString());
-            writer.WritePropertyName("headerName"u8);
-            writer.WriteStringValue(HeaderName);
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(HeaderAction))
+            {
+                writer.WritePropertyName("headerAction"u8);
+                writer.WriteStringValue(HeaderAction.ToString());
+            }
+            if (Optional.IsDefined(HeaderName))
+            {
+                writer.WritePropertyName("headerName"u8);
+                writer.WriteStringValue(HeaderName);
+            }
             if (Optional.IsDefined(Value))
             {
                 writer.WritePropertyName("value"u8);
@@ -116,45 +126,83 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(HeaderAction))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(HeaderAction), out propertyOverride);
+            if (Optional.IsDefined(HeaderAction) || hasPropertyOverride)
             {
                 builder.Append("  headerAction:");
-                builder.AppendLine($" '{HeaderAction.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{HeaderAction.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(HeaderName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(HeaderName), out propertyOverride);
+            if (Optional.IsDefined(HeaderName) || hasPropertyOverride)
             {
                 builder.Append("  headerName:");
-                if (HeaderName.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{HeaderName}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{HeaderName}'");
+                    if (HeaderName.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{HeaderName}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{HeaderName}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Value))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Value), out propertyOverride);
+            if (Optional.IsDefined(Value) || hasPropertyOverride)
             {
                 builder.Append("  value:");
-                if (Value.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Value}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Value}'");
+                    if (Value.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Value}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Value}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/HeaderActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/HeaderActionParameters.Serialization.cs
@@ -28,21 +28,12 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(HeaderAction))
-            {
-                writer.WritePropertyName("headerAction"u8);
-                writer.WriteStringValue(HeaderAction.ToString());
-            }
-            if (Optional.IsDefined(HeaderName))
-            {
-                writer.WritePropertyName("headerName"u8);
-                writer.WriteStringValue(HeaderName);
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("headerAction"u8);
+            writer.WriteStringValue(HeaderAction.ToString());
+            writer.WritePropertyName("headerName"u8);
+            writer.WriteStringValue(HeaderName);
             if (Optional.IsDefined(Value))
             {
                 writer.WritePropertyName("value"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverride.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverride.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using Azure.ResourceManager.Resources.Models;
 
 namespace MgmtDiscriminator.Models
@@ -112,18 +113,40 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(OriginGroup))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(OriginGroup), out propertyOverride);
+            if (Optional.IsDefined(OriginGroup) || hasPropertyOverride)
             {
                 builder.Append("  originGroup:");
-                AppendChildObject(builder, OriginGroup, options, 2, false);
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    AppendChildObject(builder, OriginGroup, options, 2, false);
+                }
             }
 
-            if (Optional.IsDefined(ForwardingProtocol))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ForwardingProtocol), out propertyOverride);
+            if (Optional.IsDefined(ForwardingProtocol) || hasPropertyOverride)
             {
                 builder.Append("  forwardingProtocol:");
-                builder.AppendLine($" '{ForwardingProtocol.Value.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{ForwardingProtocol.Value.ToString()}'");
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverrideAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverrideAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverrideActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverrideActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using Azure.ResourceManager.Resources.Models;
 
 namespace MgmtDiscriminator.Models
@@ -28,10 +29,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("originGroup"u8);
-            JsonSerializer.Serialize(writer, OriginGroup);
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(OriginGroup))
+            {
+                writer.WritePropertyName("originGroup"u8);
+                JsonSerializer.Serialize(writer, OriginGroup);
+            }
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
                 foreach (var item in _serializedAdditionalRawData)
@@ -98,18 +105,40 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(OriginGroup))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(OriginGroup), out propertyOverride);
+            if (Optional.IsDefined(OriginGroup) || hasPropertyOverride)
             {
                 builder.Append("  originGroup:");
-                AppendChildObject(builder, OriginGroup, options, 2, false);
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    AppendChildObject(builder, OriginGroup, options, 2, false);
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverrideActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/OriginGroupOverrideActionParameters.Serialization.cs
@@ -29,16 +29,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(OriginGroup))
-            {
-                writer.WritePropertyName("originGroup"u8);
-                JsonSerializer.Serialize(writer, OriginGroup);
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("originGroup"u8);
+            JsonSerializer.Serialize(writer, OriginGroup);
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
                 foreach (var item in _serializedAdditionalRawData)

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/Pet.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/Pet.Serialization.cs
@@ -29,11 +29,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToSerialString());
-            }
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToSerialString());
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/Pet.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/Pet.Serialization.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,8 +29,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToSerialString());
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToSerialString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
@@ -86,25 +91,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToSerialString()}'");
-            }
-
-            if (Optional.IsDefined(Id))
-            {
-                builder.Append("  id:");
-                if (Id.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Id}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Id}'");
+                    builder.AppendLine($" '{Kind.ToSerialString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
+            {
+                builder.Append("  id:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Id.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Id}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Id}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/QueryStringMatchConditionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/QueryStringMatchConditionParameters.Serialization.cs
@@ -29,16 +29,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(Operator))
-            {
-                writer.WritePropertyName("operator"u8);
-                writer.WriteStringValue(Operator.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("operator"u8);
+            writer.WriteStringValue(Operator.ToString());
             if (Optional.IsDefined(NegateCondition))
             {
                 writer.WritePropertyName("negateCondition"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/QueryStringMatchConditionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/QueryStringMatchConditionParameters.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -28,10 +29,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("operator"u8);
-            writer.WriteStringValue(Operator.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(Operator))
+            {
+                writer.WritePropertyName("operator"u8);
+                writer.WriteStringValue(Operator.ToString());
+            }
             if (Optional.IsDefined(NegateCondition))
             {
                 writer.WritePropertyName("negateCondition"u8);
@@ -163,65 +170,111 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Operator))
-            {
-                builder.Append("  operator:");
-                builder.AppendLine($" '{Operator.ToString()}'");
-            }
-
-            if (Optional.IsDefined(NegateCondition))
-            {
-                builder.Append("  negateCondition:");
-                var boolValue = NegateCondition.Value == true ? "true" : "false";
-                builder.AppendLine($" {boolValue}");
-            }
-
-            if (Optional.IsCollectionDefined(MatchValues))
-            {
-                if (MatchValues.Any())
+                if (hasPropertyOverride)
                 {
-                    builder.Append("  matchValues:");
-                    builder.AppendLine(" [");
-                    foreach (var item in MatchValues)
-                    {
-                        if (item == null)
-                        {
-                            builder.Append("null");
-                            continue;
-                        }
-                        if (item.Contains(Environment.NewLine))
-                        {
-                            builder.AppendLine("    '''");
-                            builder.AppendLine($"{item}'''");
-                        }
-                        else
-                        {
-                            builder.AppendLine($"    '{item}'");
-                        }
-                    }
-                    builder.AppendLine("  ]");
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
                 }
             }
 
-            if (Optional.IsCollectionDefined(Transforms))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Operator), out propertyOverride);
+            if (Optional.IsDefined(Operator) || hasPropertyOverride)
             {
-                if (Transforms.Any())
+                builder.Append("  operator:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Operator.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(NegateCondition), out propertyOverride);
+            if (Optional.IsDefined(NegateCondition) || hasPropertyOverride)
+            {
+                builder.Append("  negateCondition:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var boolValue = NegateCondition.Value == true ? "true" : "false";
+                    builder.AppendLine($" {boolValue}");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(MatchValues), out propertyOverride);
+            if (Optional.IsCollectionDefined(MatchValues) || hasPropertyOverride)
+            {
+                if (MatchValues.Any() || hasPropertyOverride)
+                {
+                    builder.Append("  matchValues:");
+                    if (hasPropertyOverride)
+                    {
+                        builder.AppendLine($" {propertyOverride}");
+                    }
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in MatchValues)
+                        {
+                            if (item == null)
+                            {
+                                builder.Append("null");
+                                continue;
+                            }
+                            if (item.Contains(Environment.NewLine))
+                            {
+                                builder.AppendLine("    '''");
+                                builder.AppendLine($"{item}'''");
+                            }
+                            else
+                            {
+                                builder.AppendLine($"    '{item}'");
+                            }
+                        }
+                        builder.AppendLine("  ]");
+                    }
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Transforms), out propertyOverride);
+            if (Optional.IsCollectionDefined(Transforms) || hasPropertyOverride)
+            {
+                if (Transforms.Any() || hasPropertyOverride)
                 {
                     builder.Append("  transforms:");
-                    builder.AppendLine(" [");
-                    foreach (var item in Transforms)
+                    if (hasPropertyOverride)
                     {
-                        builder.AppendLine($"    '{item.ToString()}'");
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("  ]");
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in Transforms)
+                        {
+                            builder.AppendLine($"    '{item.ToString()}'");
+                        }
+                        builder.AppendLine("  ]");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RemoteAddressMatchConditionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RemoteAddressMatchConditionParameters.Serialization.cs
@@ -29,16 +29,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(Operator))
-            {
-                writer.WritePropertyName("operator"u8);
-                writer.WriteStringValue(Operator.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("operator"u8);
+            writer.WriteStringValue(Operator.ToString());
             if (Optional.IsDefined(NegateCondition))
             {
                 writer.WritePropertyName("negateCondition"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RemoteAddressMatchConditionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RemoteAddressMatchConditionParameters.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -28,10 +29,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("operator"u8);
-            writer.WriteStringValue(Operator.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(Operator))
+            {
+                writer.WritePropertyName("operator"u8);
+                writer.WriteStringValue(Operator.ToString());
+            }
             if (Optional.IsDefined(NegateCondition))
             {
                 writer.WritePropertyName("negateCondition"u8);
@@ -163,65 +170,111 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Operator))
-            {
-                builder.Append("  operator:");
-                builder.AppendLine($" '{Operator.ToString()}'");
-            }
-
-            if (Optional.IsDefined(NegateCondition))
-            {
-                builder.Append("  negateCondition:");
-                var boolValue = NegateCondition.Value == true ? "true" : "false";
-                builder.AppendLine($" {boolValue}");
-            }
-
-            if (Optional.IsCollectionDefined(MatchValues))
-            {
-                if (MatchValues.Any())
+                if (hasPropertyOverride)
                 {
-                    builder.Append("  matchValues:");
-                    builder.AppendLine(" [");
-                    foreach (var item in MatchValues)
-                    {
-                        if (item == null)
-                        {
-                            builder.Append("null");
-                            continue;
-                        }
-                        if (item.Contains(Environment.NewLine))
-                        {
-                            builder.AppendLine("    '''");
-                            builder.AppendLine($"{item}'''");
-                        }
-                        else
-                        {
-                            builder.AppendLine($"    '{item}'");
-                        }
-                    }
-                    builder.AppendLine("  ]");
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
                 }
             }
 
-            if (Optional.IsCollectionDefined(Transforms))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Operator), out propertyOverride);
+            if (Optional.IsDefined(Operator) || hasPropertyOverride)
             {
-                if (Transforms.Any())
+                builder.Append("  operator:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Operator.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(NegateCondition), out propertyOverride);
+            if (Optional.IsDefined(NegateCondition) || hasPropertyOverride)
+            {
+                builder.Append("  negateCondition:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var boolValue = NegateCondition.Value == true ? "true" : "false";
+                    builder.AppendLine($" {boolValue}");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(MatchValues), out propertyOverride);
+            if (Optional.IsCollectionDefined(MatchValues) || hasPropertyOverride)
+            {
+                if (MatchValues.Any() || hasPropertyOverride)
+                {
+                    builder.Append("  matchValues:");
+                    if (hasPropertyOverride)
+                    {
+                        builder.AppendLine($" {propertyOverride}");
+                    }
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in MatchValues)
+                        {
+                            if (item == null)
+                            {
+                                builder.Append("null");
+                                continue;
+                            }
+                            if (item.Contains(Environment.NewLine))
+                            {
+                                builder.AppendLine("    '''");
+                                builder.AppendLine($"{item}'''");
+                            }
+                            else
+                            {
+                                builder.AppendLine($"    '{item}'");
+                            }
+                        }
+                        builder.AppendLine("  ]");
+                    }
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Transforms), out propertyOverride);
+            if (Optional.IsCollectionDefined(Transforms) || hasPropertyOverride)
+            {
+                if (Transforms.Any() || hasPropertyOverride)
                 {
                     builder.Append("  transforms:");
-                    builder.AppendLine(" [");
-                    foreach (var item in Transforms)
+                    if (hasPropertyOverride)
                     {
-                        builder.AppendLine($"    '{item.ToString()}'");
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("  ]");
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in Transforms)
+                        {
+                            builder.AppendLine($"    '{item.ToString()}'");
+                        }
+                        builder.AppendLine("  ]");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RequestMethodMatchConditionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RequestMethodMatchConditionParameters.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -28,10 +29,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("operator"u8);
-            writer.WriteStringValue(Operator.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(Operator))
+            {
+                writer.WritePropertyName("operator"u8);
+                writer.WriteStringValue(Operator.ToString());
+            }
             if (Optional.IsDefined(NegateCondition))
             {
                 writer.WritePropertyName("negateCondition"u8);
@@ -163,52 +170,98 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Operator))
-            {
-                builder.Append("  operator:");
-                builder.AppendLine($" '{Operator.ToString()}'");
-            }
-
-            if (Optional.IsDefined(NegateCondition))
-            {
-                builder.Append("  negateCondition:");
-                var boolValue = NegateCondition.Value == true ? "true" : "false";
-                builder.AppendLine($" {boolValue}");
-            }
-
-            if (Optional.IsCollectionDefined(Transforms))
-            {
-                if (Transforms.Any())
+                if (hasPropertyOverride)
                 {
-                    builder.Append("  transforms:");
-                    builder.AppendLine(" [");
-                    foreach (var item in Transforms)
-                    {
-                        builder.AppendLine($"    '{item.ToString()}'");
-                    }
-                    builder.AppendLine("  ]");
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
                 }
             }
 
-            if (Optional.IsCollectionDefined(MatchValues))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Operator), out propertyOverride);
+            if (Optional.IsDefined(Operator) || hasPropertyOverride)
             {
-                if (MatchValues.Any())
+                builder.Append("  operator:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Operator.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(NegateCondition), out propertyOverride);
+            if (Optional.IsDefined(NegateCondition) || hasPropertyOverride)
+            {
+                builder.Append("  negateCondition:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var boolValue = NegateCondition.Value == true ? "true" : "false";
+                    builder.AppendLine($" {boolValue}");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Transforms), out propertyOverride);
+            if (Optional.IsCollectionDefined(Transforms) || hasPropertyOverride)
+            {
+                if (Transforms.Any() || hasPropertyOverride)
+                {
+                    builder.Append("  transforms:");
+                    if (hasPropertyOverride)
+                    {
+                        builder.AppendLine($" {propertyOverride}");
+                    }
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in Transforms)
+                        {
+                            builder.AppendLine($"    '{item.ToString()}'");
+                        }
+                        builder.AppendLine("  ]");
+                    }
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(MatchValues), out propertyOverride);
+            if (Optional.IsCollectionDefined(MatchValues) || hasPropertyOverride)
+            {
+                if (MatchValues.Any() || hasPropertyOverride)
                 {
                     builder.Append("  matchValues:");
-                    builder.AppendLine(" [");
-                    foreach (var item in MatchValues)
+                    if (hasPropertyOverride)
                     {
-                        builder.AppendLine($"    '{item.ToString()}'");
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("  ]");
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in MatchValues)
+                        {
+                            builder.AppendLine($"    '{item.ToString()}'");
+                        }
+                        builder.AppendLine("  ]");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RequestMethodMatchConditionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RequestMethodMatchConditionParameters.Serialization.cs
@@ -29,16 +29,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(Operator))
-            {
-                writer.WritePropertyName("operator"u8);
-                writer.WriteStringValue(Operator.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("operator"u8);
+            writer.WriteStringValue(Operator.ToString());
             if (Optional.IsDefined(NegateCondition))
             {
                 writer.WritePropertyName("negateCondition"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RoleAssignmentArtifact.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RoleAssignmentArtifact.Serialization.cs
@@ -29,22 +29,19 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(Id))
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToString());
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W" && Optional.IsDefined(Name))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W" && Optional.IsDefined(ResourceType))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -56,23 +53,17 @@ namespace MgmtDiscriminator.Models
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
-            if (Optional.IsDefined(RoleDefinitionId))
-            {
-                writer.WritePropertyName("roleDefinitionId"u8);
-                writer.WriteStringValue(RoleDefinitionId);
-            }
-            if (Optional.IsDefined(PrincipalIds))
-            {
-                writer.WritePropertyName("principalIds"u8);
+            writer.WritePropertyName("roleDefinitionId"u8);
+            writer.WriteStringValue(RoleDefinitionId);
+            writer.WritePropertyName("principalIds"u8);
 #if NET6_0_OR_GREATER
 				writer.WriteRawValue(PrincipalIds);
 #else
-                using (JsonDocument document = JsonDocument.Parse(PrincipalIds))
-                {
-                    JsonSerializer.Serialize(writer, document.RootElement);
-                }
-#endif
+            using (JsonDocument document = JsonDocument.Parse(PrincipalIds))
+            {
+                JsonSerializer.Serialize(writer, document.RootElement);
             }
+#endif
             if (Optional.IsDefined(ResourceGroup))
             {
                 writer.WritePropertyName("resourceGroup"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RoleAssignmentArtifact.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RoleAssignmentArtifact.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using Azure.ResourceManager.Models;
 
 namespace MgmtDiscriminator.Models
@@ -28,19 +29,22 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToString());
+            }
+            if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(ResourceType))
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -52,17 +56,23 @@ namespace MgmtDiscriminator.Models
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
-            writer.WritePropertyName("roleDefinitionId"u8);
-            writer.WriteStringValue(RoleDefinitionId);
-            writer.WritePropertyName("principalIds"u8);
+            if (Optional.IsDefined(RoleDefinitionId))
+            {
+                writer.WritePropertyName("roleDefinitionId"u8);
+                writer.WriteStringValue(RoleDefinitionId);
+            }
+            if (Optional.IsDefined(PrincipalIds))
+            {
+                writer.WritePropertyName("principalIds"u8);
 #if NET6_0_OR_GREATER
 				writer.WriteRawValue(PrincipalIds);
 #else
-            using (JsonDocument document = JsonDocument.Parse(PrincipalIds))
-            {
-                JsonSerializer.Serialize(writer, document.RootElement);
-            }
+                using (JsonDocument document = JsonDocument.Parse(PrincipalIds))
+                {
+                    JsonSerializer.Serialize(writer, document.RootElement);
+                }
 #endif
+            }
             if (Optional.IsDefined(ResourceGroup))
             {
                 writer.WritePropertyName("resourceGroup"u8);
@@ -187,73 +197,135 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                if (Name.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Name}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Name}'");
+                    if (Name.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Name}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Name}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Kind.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(Id))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
             {
                 builder.Append("  id:");
-                builder.AppendLine($" '{Id.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Id.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(SystemData))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(SystemData), out propertyOverride);
+            if (Optional.IsDefined(SystemData) || hasPropertyOverride)
             {
                 builder.Append("  systemData:");
-                builder.AppendLine($" '{SystemData.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{SystemData.ToString()}'");
+                }
             }
 
             builder.Append("  properties:");
             builder.AppendLine(" {");
-            if (Optional.IsDefined(RoleDefinitionId))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(RoleDefinitionId), out propertyOverride);
+            if (Optional.IsDefined(RoleDefinitionId) || hasPropertyOverride)
             {
                 builder.Append("    roleDefinitionId:");
-                if (RoleDefinitionId.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{RoleDefinitionId}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{RoleDefinitionId}'");
+                    if (RoleDefinitionId.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{RoleDefinitionId}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{RoleDefinitionId}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(PrincipalIds))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(PrincipalIds), out propertyOverride);
+            if (Optional.IsDefined(PrincipalIds) || hasPropertyOverride)
             {
                 builder.Append("    principalIds:");
-                builder.AppendLine($" '{PrincipalIds.ToString()}'");
-            }
-
-            if (Optional.IsDefined(ResourceGroup))
-            {
-                builder.Append("    resourceGroup:");
-                if (ResourceGroup.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{ResourceGroup}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{ResourceGroup}'");
+                    builder.AppendLine($" '{PrincipalIds.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ResourceGroup), out propertyOverride);
+            if (Optional.IsDefined(ResourceGroup) || hasPropertyOverride)
+            {
+                builder.Append("    resourceGroup:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (ResourceGroup.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{ResourceGroup}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{ResourceGroup}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RouteConfigurationOverrideActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RouteConfigurationOverrideActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,8 +28,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
             if (Optional.IsDefined(OriginGroupOverride))
             {
                 writer.WritePropertyName("originGroupOverride"u8);
@@ -104,18 +108,40 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(OriginGroupOverride))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(OriginGroupOverride), out propertyOverride);
+            if (Optional.IsDefined(OriginGroupOverride) || hasPropertyOverride)
             {
                 builder.Append("  originGroupOverride:");
-                AppendChildObject(builder, OriginGroupOverride, options, 2, false);
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    AppendChildObject(builder, OriginGroupOverride, options, 2, false);
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/RouteConfigurationOverrideActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/RouteConfigurationOverrideActionParameters.Serialization.cs
@@ -28,11 +28,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
             if (Optional.IsDefined(OriginGroupOverride))
             {
                 writer.WritePropertyName("originGroupOverride"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/TemplateArtifact.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/TemplateArtifact.Serialization.cs
@@ -30,22 +30,19 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(Id))
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToString());
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W" && Optional.IsDefined(Name))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W" && Optional.IsDefined(ResourceType))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -57,46 +54,40 @@ namespace MgmtDiscriminator.Models
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
-            if (Optional.IsDefined(Template))
-            {
-                writer.WritePropertyName("template"u8);
+            writer.WritePropertyName("template"u8);
 #if NET6_0_OR_GREATER
 				writer.WriteRawValue(Template);
 #else
-                using (JsonDocument document = JsonDocument.Parse(Template))
-                {
-                    JsonSerializer.Serialize(writer, document.RootElement);
-                }
-#endif
+            using (JsonDocument document = JsonDocument.Parse(Template))
+            {
+                JsonSerializer.Serialize(writer, document.RootElement);
             }
+#endif
             if (Optional.IsDefined(ResourceGroup))
             {
                 writer.WritePropertyName("resourceGroup"u8);
                 writer.WriteStringValue(ResourceGroup);
             }
-            if (Optional.IsCollectionDefined(Parameters))
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteStartObject();
+            foreach (var item in Parameters)
             {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteStartObject();
-                foreach (var item in Parameters)
+                writer.WritePropertyName(item.Key);
+                if (item.Value == null)
                 {
-                    writer.WritePropertyName(item.Key);
-                    if (item.Value == null)
-                    {
-                        writer.WriteNullValue();
-                        continue;
-                    }
+                    writer.WriteNullValue();
+                    continue;
+                }
 #if NET6_0_OR_GREATER
 				writer.WriteRawValue(item.Value);
 #else
-                    using (JsonDocument document = JsonDocument.Parse(item.Value))
-                    {
-                        JsonSerializer.Serialize(writer, document.RootElement);
-                    }
-#endif
+                using (JsonDocument document = JsonDocument.Parse(item.Value))
+                {
+                    JsonSerializer.Serialize(writer, document.RootElement);
                 }
-                writer.WriteEndObject();
+#endif
             }
+            writer.WriteEndObject();
             writer.WriteEndObject();
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/TemplateArtifact.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/TemplateArtifact.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using Azure.ResourceManager.Models;
 
 namespace MgmtDiscriminator.Models
@@ -29,19 +30,22 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToString());
+            }
+            if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(ResourceType))
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -53,40 +57,46 @@ namespace MgmtDiscriminator.Models
             }
             writer.WritePropertyName("properties"u8);
             writer.WriteStartObject();
-            writer.WritePropertyName("template"u8);
+            if (Optional.IsDefined(Template))
+            {
+                writer.WritePropertyName("template"u8);
 #if NET6_0_OR_GREATER
 				writer.WriteRawValue(Template);
 #else
-            using (JsonDocument document = JsonDocument.Parse(Template))
-            {
-                JsonSerializer.Serialize(writer, document.RootElement);
-            }
-#endif
-            if (Optional.IsDefined(ResourceGroup))
-            {
-                writer.WritePropertyName("resourceGroup"u8);
-                writer.WriteStringValue(ResourceGroup);
-            }
-            writer.WritePropertyName("parameters"u8);
-            writer.WriteStartObject();
-            foreach (var item in Parameters)
-            {
-                writer.WritePropertyName(item.Key);
-                if (item.Value == null)
-                {
-                    writer.WriteNullValue();
-                    continue;
-                }
-#if NET6_0_OR_GREATER
-				writer.WriteRawValue(item.Value);
-#else
-                using (JsonDocument document = JsonDocument.Parse(item.Value))
+                using (JsonDocument document = JsonDocument.Parse(Template))
                 {
                     JsonSerializer.Serialize(writer, document.RootElement);
                 }
 #endif
             }
-            writer.WriteEndObject();
+            if (Optional.IsDefined(ResourceGroup))
+            {
+                writer.WritePropertyName("resourceGroup"u8);
+                writer.WriteStringValue(ResourceGroup);
+            }
+            if (Optional.IsCollectionDefined(Parameters))
+            {
+                writer.WritePropertyName("parameters"u8);
+                writer.WriteStartObject();
+                foreach (var item in Parameters)
+                {
+                    writer.WritePropertyName(item.Key);
+                    if (item.Value == null)
+                    {
+                        writer.WriteNullValue();
+                        continue;
+                    }
+#if NET6_0_OR_GREATER
+				writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+                writer.WriteEndObject();
+            }
             writer.WriteEndObject();
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
@@ -218,79 +228,141 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                if (Name.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Name}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Name}'");
+                    if (Name.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Name}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Name}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Kind.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(Id))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
             {
                 builder.Append("  id:");
-                builder.AppendLine($" '{Id.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Id.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(SystemData))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(SystemData), out propertyOverride);
+            if (Optional.IsDefined(SystemData) || hasPropertyOverride)
             {
                 builder.Append("  systemData:");
-                builder.AppendLine($" '{SystemData.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{SystemData.ToString()}'");
+                }
             }
 
             builder.Append("  properties:");
             builder.AppendLine(" {");
-            if (Optional.IsDefined(Template))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Template), out propertyOverride);
+            if (Optional.IsDefined(Template) || hasPropertyOverride)
             {
                 builder.Append("    template:");
-                builder.AppendLine($" '{Template.ToString()}'");
-            }
-
-            if (Optional.IsDefined(ResourceGroup))
-            {
-                builder.Append("    resourceGroup:");
-                if (ResourceGroup.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{ResourceGroup}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{ResourceGroup}'");
+                    builder.AppendLine($" '{Template.ToString()}'");
                 }
             }
 
-            if (Optional.IsCollectionDefined(Parameters))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ResourceGroup), out propertyOverride);
+            if (Optional.IsDefined(ResourceGroup) || hasPropertyOverride)
             {
-                if (Parameters.Any())
+                builder.Append("    resourceGroup:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (ResourceGroup.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{ResourceGroup}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{ResourceGroup}'");
+                    }
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Parameters), out propertyOverride);
+            if (Optional.IsCollectionDefined(Parameters) || hasPropertyOverride)
+            {
+                if (Parameters.Any() || hasPropertyOverride)
                 {
                     builder.Append("    parameters:");
-                    builder.AppendLine(" {");
-                    foreach (var item in Parameters)
+                    if (hasPropertyOverride)
                     {
-                        builder.Append($"        {item.Key}:");
-                        if (item.Value == null)
-                        {
-                            builder.Append("null");
-                            continue;
-                        }
-                        builder.AppendLine($" '{item.Value.ToString()}'");
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("    }");
+                    else
+                    {
+                        builder.AppendLine(" {");
+                        foreach (var item in Parameters)
+                        {
+                            builder.Append($"        {item.Key}:");
+                            if (item.Value == null)
+                            {
+                                builder.Append("null");
+                                continue;
+                            }
+                            builder.AppendLine($" '{item.Value.ToString()}'");
+                        }
+                        builder.AppendLine("    }");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownArtifact.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownArtifact.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 using Azure.ResourceManager.Models;
 using MgmtDiscriminator;
 
@@ -29,19 +30,22 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToString());
-            if (options.Format != "W")
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToString());
+            }
+            if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(Name))
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W")
+            if (options.Format != "W" && Optional.IsDefined(ResourceType))
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);
@@ -139,38 +143,76 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                if (Name.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Name}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Name}'");
+                    if (Name.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Name}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Name}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Kind.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(Id))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
             {
                 builder.Append("  id:");
-                builder.AppendLine($" '{Id.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Id.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(SystemData))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(SystemData), out propertyOverride);
+            if (Optional.IsDefined(SystemData) || hasPropertyOverride)
             {
                 builder.Append("  systemData:");
-                builder.AppendLine($" '{SystemData.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{SystemData.ToString()}'");
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownArtifact.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownArtifact.Serialization.cs
@@ -30,22 +30,19 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToString());
-            }
-            if (options.Format != "W" && Optional.IsDefined(Id))
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToString());
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("id"u8);
                 writer.WriteStringValue(Id);
             }
-            if (options.Format != "W" && Optional.IsDefined(Name))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("name"u8);
                 writer.WriteStringValue(Name);
             }
-            if (options.Format != "W" && Optional.IsDefined(ResourceType))
+            if (options.Format != "W")
             {
                 writer.WritePropertyName("type"u8);
                 writer.WriteStringValue(ResourceType);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleAction.Serialization.cs
@@ -28,11 +28,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleAction.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,8 +28,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name.ToString());
+            if (Optional.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name.ToString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);
@@ -100,25 +104,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                builder.AppendLine($" '{Name.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Foo))
-            {
-                builder.Append("  foo:");
-                if (Foo.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Foo}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Foo}'");
+                    builder.AppendLine($" '{Name.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Foo), out propertyOverride);
+            if (Optional.IsDefined(Foo) || hasPropertyOverride)
+            {
+                builder.Append("  foo:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Foo.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Foo}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Foo}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleCondition.Serialization.cs
@@ -28,11 +28,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleCondition.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownDeliveryRuleCondition.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,8 +28,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("name"u8);
-            writer.WriteStringValue(Name.ToString());
+            if (Optional.IsDefined(Name))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name.ToString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);
@@ -100,25 +104,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Name))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Name), out propertyOverride);
+            if (Optional.IsDefined(Name) || hasPropertyOverride)
             {
                 builder.Append("  name:");
-                builder.AppendLine($" '{Name.ToString()}'");
-            }
-
-            if (Optional.IsDefined(Foo))
-            {
-                builder.Append("  foo:");
-                if (Foo.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Foo}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Foo}'");
+                    builder.AppendLine($" '{Name.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Foo), out propertyOverride);
+            if (Optional.IsDefined(Foo) || hasPropertyOverride)
+            {
+                builder.Append("  foo:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Foo.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Foo}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Foo}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownPet.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownPet.Serialization.cs
@@ -28,11 +28,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Kind))
-            {
-                writer.WritePropertyName("kind"u8);
-                writer.WriteStringValue(Kind.ToSerialString());
-            }
+            writer.WritePropertyName("kind"u8);
+            writer.WriteStringValue(Kind.ToSerialString());
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownPet.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UnknownPet.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,8 +28,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("kind"u8);
-            writer.WriteStringValue(Kind.ToSerialString());
+            if (Optional.IsDefined(Kind))
+            {
+                writer.WritePropertyName("kind"u8);
+                writer.WriteStringValue(Kind.ToSerialString());
+            }
             if (options.Format != "W" && Optional.IsDefined(Id))
             {
                 writer.WritePropertyName("id"u8);
@@ -100,25 +104,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(Kind))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Kind), out propertyOverride);
+            if (Optional.IsDefined(Kind) || hasPropertyOverride)
             {
                 builder.Append("  kind:");
-                builder.AppendLine($" '{Kind.ToSerialString()}'");
-            }
-
-            if (Optional.IsDefined(Id))
-            {
-                builder.Append("  id:");
-                if (Id.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Id}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Id}'");
+                    builder.AppendLine($" '{Kind.ToSerialString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Id), out propertyOverride);
+            if (Optional.IsDefined(Id) || hasPropertyOverride)
+            {
+                builder.Append("  id:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (Id.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Id}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Id}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRedirectAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRedirectAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRedirectActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRedirectActionParameters.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(RedirectType))
-            {
-                writer.WritePropertyName("redirectType"u8);
-                writer.WriteStringValue(RedirectType.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("redirectType"u8);
+            writer.WriteStringValue(RedirectType.ToString());
             if (Optional.IsDefined(DestinationProtocol))
             {
                 writer.WritePropertyName("destinationProtocol"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRedirectActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRedirectActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,10 +28,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("redirectType"u8);
-            writer.WriteStringValue(RedirectType.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(RedirectType))
+            {
+                writer.WritePropertyName("redirectType"u8);
+                writer.WriteStringValue(RedirectType.ToString());
+            }
             if (Optional.IsDefined(DestinationProtocol))
             {
                 writer.WritePropertyName("destinationProtocol"u8);
@@ -156,79 +163,141 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(RedirectType))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(RedirectType), out propertyOverride);
+            if (Optional.IsDefined(RedirectType) || hasPropertyOverride)
             {
                 builder.Append("  redirectType:");
-                builder.AppendLine($" '{RedirectType.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{RedirectType.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(DestinationProtocol))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(DestinationProtocol), out propertyOverride);
+            if (Optional.IsDefined(DestinationProtocol) || hasPropertyOverride)
             {
                 builder.Append("  destinationProtocol:");
-                builder.AppendLine($" '{DestinationProtocol.Value.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{DestinationProtocol.Value.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(CustomPath))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CustomPath), out propertyOverride);
+            if (Optional.IsDefined(CustomPath) || hasPropertyOverride)
             {
                 builder.Append("  customPath:");
-                if (CustomPath.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{CustomPath}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{CustomPath}'");
+                    if (CustomPath.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{CustomPath}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{CustomPath}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(CustomHostname))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CustomHostname), out propertyOverride);
+            if (Optional.IsDefined(CustomHostname) || hasPropertyOverride)
             {
                 builder.Append("  customHostname:");
-                if (CustomHostname.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{CustomHostname}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{CustomHostname}'");
+                    if (CustomHostname.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{CustomHostname}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{CustomHostname}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(CustomQueryString))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CustomQueryString), out propertyOverride);
+            if (Optional.IsDefined(CustomQueryString) || hasPropertyOverride)
             {
                 builder.Append("  customQueryString:");
-                if (CustomQueryString.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{CustomQueryString}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{CustomQueryString}'");
+                    if (CustomQueryString.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{CustomQueryString}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{CustomQueryString}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(CustomFragment))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(CustomFragment), out propertyOverride);
+            if (Optional.IsDefined(CustomFragment) || hasPropertyOverride)
             {
                 builder.Append("  customFragment:");
-                if (CustomFragment.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{CustomFragment}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{CustomFragment}'");
+                    if (CustomFragment.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{CustomFragment}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{CustomFragment}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRewriteAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRewriteAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRewriteActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRewriteActionParameters.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,12 +28,21 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
-            writer.WritePropertyName("sourcePattern"u8);
-            writer.WriteStringValue(SourcePattern);
-            writer.WritePropertyName("destination"u8);
-            writer.WriteStringValue(Destination);
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
+            if (Optional.IsDefined(SourcePattern))
+            {
+                writer.WritePropertyName("sourcePattern"u8);
+                writer.WriteStringValue(SourcePattern);
+            }
+            if (Optional.IsDefined(Destination))
+            {
+                writer.WritePropertyName("destination"u8);
+                writer.WriteStringValue(Destination);
+            }
             if (Optional.IsDefined(PreserveUnmatchedPath))
             {
                 writer.WritePropertyName("preserveUnmatchedPath"u8);
@@ -120,47 +130,85 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(SourcePattern))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(SourcePattern), out propertyOverride);
+            if (Optional.IsDefined(SourcePattern) || hasPropertyOverride)
             {
                 builder.Append("  sourcePattern:");
-                if (SourcePattern.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{SourcePattern}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{SourcePattern}'");
+                    if (SourcePattern.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{SourcePattern}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{SourcePattern}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(Destination))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Destination), out propertyOverride);
+            if (Optional.IsDefined(Destination) || hasPropertyOverride)
             {
                 builder.Append("  destination:");
-                if (Destination.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{Destination}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{Destination}'");
+                    if (Destination.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{Destination}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{Destination}'");
+                    }
                 }
             }
 
-            if (Optional.IsDefined(PreserveUnmatchedPath))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(PreserveUnmatchedPath), out propertyOverride);
+            if (Optional.IsDefined(PreserveUnmatchedPath) || hasPropertyOverride)
             {
                 builder.Append("  preserveUnmatchedPath:");
-                var boolValue = PreserveUnmatchedPath.Value == true ? "true" : "false";
-                builder.AppendLine($" {boolValue}");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    var boolValue = PreserveUnmatchedPath.Value == true ? "true" : "false";
+                    builder.AppendLine($" {boolValue}");
+                }
             }
 
             builder.AppendLine("}");

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRewriteActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlRewriteActionParameters.Serialization.cs
@@ -28,21 +28,12 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
-            if (Optional.IsDefined(SourcePattern))
-            {
-                writer.WritePropertyName("sourcePattern"u8);
-                writer.WriteStringValue(SourcePattern);
-            }
-            if (Optional.IsDefined(Destination))
-            {
-                writer.WritePropertyName("destination"u8);
-                writer.WriteStringValue(Destination);
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
+            writer.WritePropertyName("sourcePattern"u8);
+            writer.WriteStringValue(SourcePattern);
+            writer.WritePropertyName("destination"u8);
+            writer.WriteStringValue(Destination);
             if (Optional.IsDefined(PreserveUnmatchedPath))
             {
                 writer.WritePropertyName("preserveUnmatchedPath"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningAction.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningAction.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(Parameters))
-            {
-                writer.WritePropertyName("parameters"u8);
-                writer.WriteObjectValue(Parameters);
-            }
-            if (Optional.IsDefined(Name))
-            {
-                writer.WritePropertyName("name"u8);
-                writer.WriteStringValue(Name.ToString());
-            }
+            writer.WritePropertyName("parameters"u8);
+            writer.WriteObjectValue(Parameters);
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name.ToString());
             if (options.Format != "W" && Optional.IsDefined(Foo))
             {
                 writer.WritePropertyName("foo"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningActionParameters.Serialization.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -28,8 +29,11 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("typeName"u8);
-            writer.WriteStringValue(TypeName.ToString());
+            if (Optional.IsDefined(TypeName))
+            {
+                writer.WritePropertyName("typeName"u8);
+                writer.WriteStringValue(TypeName.ToString());
+            }
             if (Optional.IsDefined(Algorithm))
             {
                 writer.WritePropertyName("algorithm"u8);
@@ -130,31 +134,61 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(TypeName))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(TypeName), out propertyOverride);
+            if (Optional.IsDefined(TypeName) || hasPropertyOverride)
             {
                 builder.Append("  typeName:");
-                builder.AppendLine($" '{TypeName.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{TypeName.ToString()}'");
+                }
             }
 
-            if (Optional.IsDefined(Algorithm))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(Algorithm), out propertyOverride);
+            if (Optional.IsDefined(Algorithm) || hasPropertyOverride)
             {
                 builder.Append("  algorithm:");
-                builder.AppendLine($" '{Algorithm.Value.ToString()}'");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    builder.AppendLine($" '{Algorithm.Value.ToString()}'");
+                }
             }
 
-            if (Optional.IsCollectionDefined(ParameterNameOverride))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ParameterNameOverride), out propertyOverride);
+            if (Optional.IsCollectionDefined(ParameterNameOverride) || hasPropertyOverride)
             {
-                if (ParameterNameOverride.Any())
+                if (ParameterNameOverride.Any() || hasPropertyOverride)
                 {
                     builder.Append("  parameterNameOverride:");
-                    builder.AppendLine(" [");
-                    foreach (var item in ParameterNameOverride)
+                    if (hasPropertyOverride)
                     {
-                        AppendChildObject(builder, item, options, 4, true);
+                        builder.AppendLine($" {propertyOverride}");
                     }
-                    builder.AppendLine("  ]");
+                    else
+                    {
+                        builder.AppendLine(" [");
+                        foreach (var item in ParameterNameOverride)
+                        {
+                            AppendChildObject(builder, item, options, 4, true);
+                        }
+                        builder.AppendLine("  ]");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningActionParameters.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningActionParameters.Serialization.cs
@@ -29,11 +29,8 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(TypeName))
-            {
-                writer.WritePropertyName("typeName"u8);
-                writer.WriteStringValue(TypeName.ToString());
-            }
+            writer.WritePropertyName("typeName"u8);
+            writer.WriteStringValue(TypeName.ToString());
             if (Optional.IsDefined(Algorithm))
             {
                 writer.WritePropertyName("algorithm"u8);

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningParamIdentifier.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningParamIdentifier.Serialization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Azure.Core;
+using Azure.ResourceManager;
 
 namespace MgmtDiscriminator.Models
 {
@@ -27,10 +28,16 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName("paramIndicator"u8);
-            writer.WriteStringValue(ParamIndicator.ToString());
-            writer.WritePropertyName("paramName"u8);
-            writer.WriteStringValue(ParamName);
+            if (Optional.IsDefined(ParamIndicator))
+            {
+                writer.WritePropertyName("paramIndicator"u8);
+                writer.WriteStringValue(ParamIndicator.ToString());
+            }
+            if (Optional.IsDefined(ParamName))
+            {
+                writer.WritePropertyName("paramName"u8);
+                writer.WriteStringValue(ParamName);
+            }
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
                 foreach (var item in _serializedAdditionalRawData)
@@ -97,25 +104,47 @@ namespace MgmtDiscriminator.Models
         private BinaryData SerializeBicep(ModelReaderWriterOptions options)
         {
             StringBuilder builder = new StringBuilder();
+            BicepModelReaderWriterOptions bicepOptions = options as BicepModelReaderWriterOptions;
+            IDictionary<string, string> propertyOverrides = null;
+            bool hasObjectOverride = bicepOptions != null && bicepOptions.ParameterOverrides.TryGetValue(this, out propertyOverrides);
+            bool hasPropertyOverride = false;
+            string propertyOverride = null;
+
             builder.AppendLine("{");
 
-            if (Optional.IsDefined(ParamIndicator))
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ParamIndicator), out propertyOverride);
+            if (Optional.IsDefined(ParamIndicator) || hasPropertyOverride)
             {
                 builder.Append("  paramIndicator:");
-                builder.AppendLine($" '{ParamIndicator.ToString()}'");
-            }
-
-            if (Optional.IsDefined(ParamName))
-            {
-                builder.Append("  paramName:");
-                if (ParamName.Contains(Environment.NewLine))
+                if (hasPropertyOverride)
                 {
-                    builder.AppendLine(" '''");
-                    builder.AppendLine($"{ParamName}'''");
+                    builder.AppendLine($" {propertyOverride}");
                 }
                 else
                 {
-                    builder.AppendLine($" '{ParamName}'");
+                    builder.AppendLine($" '{ParamIndicator.ToString()}'");
+                }
+            }
+
+            hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(ParamName), out propertyOverride);
+            if (Optional.IsDefined(ParamName) || hasPropertyOverride)
+            {
+                builder.Append("  paramName:");
+                if (hasPropertyOverride)
+                {
+                    builder.AppendLine($" {propertyOverride}");
+                }
+                else
+                {
+                    if (ParamName.Contains(Environment.NewLine))
+                    {
+                        builder.AppendLine(" '''");
+                        builder.AppendLine($"{ParamName}'''");
+                    }
+                    else
+                    {
+                        builder.AppendLine($" '{ParamName}'");
+                    }
                 }
             }
 

--- a/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningParamIdentifier.Serialization.cs
+++ b/test/TestProjects/MgmtDiscriminator/Generated/Models/UrlSigningParamIdentifier.Serialization.cs
@@ -28,16 +28,10 @@ namespace MgmtDiscriminator.Models
             }
 
             writer.WriteStartObject();
-            if (Optional.IsDefined(ParamIndicator))
-            {
-                writer.WritePropertyName("paramIndicator"u8);
-                writer.WriteStringValue(ParamIndicator.ToString());
-            }
-            if (Optional.IsDefined(ParamName))
-            {
-                writer.WritePropertyName("paramName"u8);
-                writer.WriteStringValue(ParamName);
-            }
+            writer.WritePropertyName("paramIndicator"u8);
+            writer.WriteStringValue(ParamIndicator.ToString());
+            writer.WritePropertyName("paramName"u8);
+            writer.WriteStringValue(ParamName);
             if (options.Format != "W" && _serializedAdditionalRawData != null)
             {
                 foreach (var item in _serializedAdditionalRawData)

--- a/test/TestProjects/MgmtDiscriminator/MgmtDiscriminator.csproj
+++ b/test/TestProjects/MgmtDiscriminator/MgmtDiscriminator.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>NU1605</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>annotations</Nullable>
     <IncludeManagementSharedCode>true</IncludeManagementSharedCode>
   </PropertyGroup>

--- a/test/TestProjects/MgmtDiscriminator/MgmtDiscriminator.csproj
+++ b/test/TestProjects/MgmtDiscriminator/MgmtDiscriminator.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>NU1605</NoWarn>
     <Nullable>annotations</Nullable>
     <IncludeManagementSharedCode>true</IncludeManagementSharedCode>
   </PropertyGroup>


### PR DESCRIPTION
This is blocked on upgrading autorest.csharp to consume latest System.ClientModel due to the updated version of Azure.ResourceManager.

It is also blocked on shipping a new version of Azure.ResourceManager with BicepModelReaderWriterOptions.