### PR TITLE
Use different build number format for -peview pipeline

### DIFF
--- a/eng/pipelines/preview.yml
+++ b/eng/pipelines/preview.yml
@@ -29,6 +29,8 @@ pool:
   name: azsdk-pool-mms-win-2022-general
   vmImage: windows-2022
 
+name: $(Date:yyyyMMdd).$(Rev:r).x
+
 extends:
   template: eng/pipelines/templates/stages/archetype-autorest-preview.yml@azure-sdk-tools
   parameters:

--- a/eng/scripts/Build-Packages.ps1
+++ b/eng/scripts/Build-Packages.ps1
@@ -33,11 +33,11 @@ if ($BuildNumber) {
     $versionTag = $Prerelease ? "-alpha" : "-beta"
 
     # TODO: Remove 'x' suffix before merge    
-    $generatorVersion = "$generatorVersion$versionTag.$BuildNumber.x"
+    $generatorVersion = "$generatorVersion$versionTag.$BuildNumber"
     Write-Host "Setting output variable 'generatorVersion' to $generatorVersion"
     Write-Host "##vso[task.setvariable variable=generatorVersion;isoutput=true]$generatorVersion"
 
-    $emitterVersion = "$emitterVersion$versionTag.$BuildNumber.x"
+    $emitterVersion = "$emitterVersion$versionTag.$BuildNumber"
     Write-Host "Setting output variable 'emitterVersion' to $emitterVersion"
     Write-Host "##vso[task.setvariable variable=emitterVersion;isoutput=true]$emitterVersion"
 }


### PR DESCRIPTION
The "autorest.csharp - preview" and "Autorest Regen Preview" pipelines use the same buildnumber format causing conflicts in the auto-generated branches for preview PRs.  We're temporarily changing the -preview pipeline's build numbers until the Autorest Regen Preview pipeline is deprecated.