### PR TITLE
Always serialize discriminator in HLC

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Output/Builders/SerializationBuilder.cs
@@ -276,7 +276,7 @@ namespace AutoRest.CSharp.Output.Builders
 
                 var serializedName = serializationMapping?.SerializationPath?[^1] ?? schemaProperty.SerializedName;
                 var isRequired = schemaProperty.IsRequired;
-                var shouldExcludeInWireSerialization = schemaProperty.IsReadOnly;
+                var shouldExcludeInWireSerialization = (schemaProperty.IsDiscriminator == null || !schemaProperty.IsDiscriminator.Value) && property.InitializationValue is null && schemaProperty.IsReadOnly;
                 var serialization = BuildSerialization(schemaProperty.Schema, property.Declaration.Type, false);
 
                 var memberValueExpression = new TypedMemberExpression(null, property.Declaration.Name, property.Declaration.Type);


### PR DESCRIPTION
Implementation matches the one in DPG: 
https://github.com/Azure/autorest.csharp/blob/058eea4100ff5e8fa685be42ed45790f8bcca869/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProvider.cs#L250-L263
Changes in generated code are only in azure-sdk-for-net repo