### PR TITLE
[Mgmt]Build enums from code model converter

### DIFF
--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
@@ -47,8 +47,10 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 }
                 else
                 {
-                    MgmtContext.Initialize(new BuildContext<MgmtOutputLibrary>(codeModel, sourceInputModel, schemaUsageProvider));
                     CodeModelTransformer.TransformForMgmt(codeModel);
+                    var codeModelConverter = new CodeModelConverter(codeModel, schemaUsageProvider);
+                    codeModelConverter.CreateNamespace();
+                    MgmtContext.Initialize(new BuildContext<MgmtOutputLibrary>(codeModel, sourceInputModel, schemaUsageProvider) { MgmtCodeModelConverter = codeModelConverter });
                     await MgmtTarget.ExecuteAsync(project, codeModel, sourceInputModel, schemaUsageProvider);
                     if (Configuration.MgmtTestConfiguration is not null && !Configuration.MgmtConfiguration.MgmtDebug.ReportOnly)
                         await MgmtTestTarget.ExecuteAsync(project, codeModel, sourceInputModel, schemaUsageProvider);

--- a/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
+++ b/src/AutoRest.CSharp/Common/AutoRest/Plugins/CSharpGen.cs
@@ -48,9 +48,7 @@ namespace AutoRest.CSharp.AutoRest.Plugins
                 else
                 {
                     CodeModelTransformer.TransformForMgmt(codeModel);
-                    var codeModelConverter = new CodeModelConverter(codeModel, schemaUsageProvider);
-                    codeModelConverter.CreateNamespace();
-                    MgmtContext.Initialize(new BuildContext<MgmtOutputLibrary>(codeModel, sourceInputModel, schemaUsageProvider) { MgmtCodeModelConverter = codeModelConverter });
+                    MgmtContext.Initialize(new BuildContext<MgmtOutputLibrary>(codeModel, sourceInputModel, schemaUsageProvider));
                     await MgmtTarget.ExecuteAsync(project, codeModel, sourceInputModel, schemaUsageProvider);
                     if (Configuration.MgmtTestConfiguration is not null && !Configuration.MgmtConfiguration.MgmtDebug.ReportOnly)
                         await MgmtTestTarget.ExecuteAsync(project, codeModel, sourceInputModel, schemaUsageProvider);

--- a/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
@@ -23,6 +23,9 @@ namespace AutoRest.CSharp.Common.Input
         private readonly Dictionary<ObjectSchema, List<InputModelProperty>> _modelPropertiesCache;
         private readonly Dictionary<ObjectSchema, List<InputModelType>> _derivedModelsCache;
 
+        // TO-REMOVE: A temporary solution
+        public Dictionary<Schema, InputEnumType> EnumsCache => _enumsCache;
+
         public CodeModelConverter(CodeModel codeModel, SchemaUsageProvider schemaUsages)
         {
             _codeModel = codeModel;

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/BuildContextOfT.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/BuildContextOfT.cs
@@ -38,11 +38,17 @@ namespace AutoRest.CSharp.Output.Models.Types
         public BuildContext(CodeModel codeModel, SourceInputModel? sourceInputModel, SchemaUsageProvider schemaUsageProvider)
             : base(codeModel, sourceInputModel, schemaUsageProvider)
         {
+            // TO-REMOVE: A temporary solution
+            if (Configuration.AzureArm)
+            {
+                MgmtCodeModelConverter = new CodeModelConverter(codeModel, schemaUsageProvider);
+                MgmtCodeModelConverter.CreateNamespace();
+            }
         }
 
         public override TypeFactory TypeFactory => _typeFactory ??= new TypeFactory(Library, typeof(BinaryData));
 
         // TO-REMOVE: A temporary solution
-        public CodeModelConverter? MgmtCodeModelConverter { get; set; }
+        public CodeModelConverter? MgmtCodeModelConverter { get; private set; }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/BuildContextOfT.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/BuildContextOfT.cs
@@ -42,6 +42,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         public override TypeFactory TypeFactory => _typeFactory ??= new TypeFactory(Library, typeof(BinaryData));
 
+        // TO-REMOVE: A temporary solution
         public CodeModelConverter? MgmtCodeModelConverter { get; set; }
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/BuildContextOfT.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/BuildContextOfT.cs
@@ -41,5 +41,7 @@ namespace AutoRest.CSharp.Output.Models.Types
         }
 
         public override TypeFactory TypeFactory => _typeFactory ??= new TypeFactory(Library, typeof(BinaryData));
+
+        public CodeModelConverter? MgmtCodeModelConverter { get; set; }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -102,7 +102,7 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
             // these dictionaries are initialized right now and they would not change later
             RawRequestPathToOperationSets = CategorizeOperationGroups();
             ResourceDataSchemaNameToOperationSets = DecorateOperationSets();
-            _schemaToInputEnumMap = new CodeModelConverter(MgmtContext.CodeModel, MgmtContext.Context.SchemaUsageProvider).CreateEnums();
+            _schemaToInputEnumMap = MgmtContext.Context.MgmtCodeModelConverter!.EnumsCache;
 
             // others are populated later
             OperationsToOperationGroups = new Lazy<IReadOnlyDictionary<Operation, OperationGroup>>(PopulateOperationsToOperationGroups);

--- a/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
+++ b/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs
@@ -813,6 +813,19 @@ namespace AutoRest.CSharp.Mgmt.AutoRest
             return ArmResources.Where(resource => resource.ResourceData == resourceData);
         }
 
+        // TO-DO: After we do below, we could remove _schemaToInputEnumMap, same as other exposed dictionaries introduced by ObjectSchema later
+        // Expected as pesuade code:
+        // private TypeProvider BuildModel(InputType inputType) => inputType switch
+        // {
+        //     InputEnumType enumType => new EnumType(enumType, MgmtContext.Context),
+        //     InputModelType modelType => switch (modelType.[some condition])
+        //     {
+        //         case [some condition]:
+        //             new MgmtObjectType(modelType, MgmtContext.Context),
+        //         case [some condition]:
+        //             new MgmtReferenceType(modelType, MgmtContext.Context),
+        //     };
+        // };
         private TypeProvider BuildModel(Schema schema) => schema switch
         {
             SealedChoiceSchema or ChoiceSchema => new EnumType(_schemaToInputEnumMap[schema], schema, MgmtContext.Context),


### PR DESCRIPTION
This PR is to gradually support code model conversion to input types with several PRs, instead of a huge PR at one time.

**Current behavior:**
We have
1. Different kinds of schemas in code model. (and operations)
2. Constructors for these schemas as `public TypeProvider(Schema schem){}`

**Final goal:**
We want:
1. Schame mapping to input type pseudo as `InputType inputType = CodeModelConverter.From(schema)`.
2. Constructors for these input types as `public TypeProvider(InputType inputType){}`

**Solution:**
We could support one kind of schema/input type pair at one time. For example, in this PR, it supports `ChoiceSchema/InputEnumType`. Therefore this PR would introduce (which actually already exists):
1. `InputEnumType inputType = CodeModelConverter.From(ChoiceSchema/SealedChoiceSchema)`.
2. `public EnumType(InputEnumType inputType){}`

To support one type at one time, we might need to expose `CodeModelConverter` and the mappings it builds temporarily as what this PR did. In the transition period, 
1. `CodeModelConverter` is exposed all the time.
2. We get type from input types if we support.
3. We get type from code model if we not support.

After we convert all the types to input types, we remove all the exposed things from `CodeModelConverter`.