### PR TITLE
build(azure.identity): bump to 1.11.0

### DIFF
--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <PackageReference Update="Azure.Identity" Version="1.10.4" />
+    <PackageReference Update="Azure.Identity" Version="1.11.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>


### PR DESCRIPTION
# Description
Need to bump Azure.Identity to 1.11.0 which fixes a security issue, otherwise VisualStudio refuses to build. `azure-sdk-for-net` has already bumped to version 1.11.0: https://github.com/Azure/azure-sdk-for-net/blob/5c0b7eaccde38895089a88005f8272bee470ba1e/eng/Packages.Data.props#L125


# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first