### PR TITLE
fix(generator): do not keep azure.core models

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/ModelTypeProvider.cs
@@ -48,6 +48,9 @@ namespace AutoRest.CSharp.Output.Models.Types
         protected override bool IsAbstract => !Configuration.SuppressAbstractBaseClasses.Contains(DefaultName) && _inputModel.DiscriminatorPropertyName is not null && _inputModel.DiscriminatorValue is null;
 
         public ModelTypeProviderFields Fields => _fields ??= EnsureFields();
+
+        public string? Namespace => _inputModel.Namespace;
+
         private ConstructorSignature InitializationConstructorSignature => _publicConstructor ??= EnsurePublicConstructorSignature();
         private ConstructorSignature SerializationConstructorSignature => _serializationConstructor ??= EnsureSerializationConstructorSignature();
 

--- a/src/AutoRest.CSharp/LowLevel/AutoRest/DpgOutputLibrary.cs
+++ b/src/AutoRest.CSharp/LowLevel/AutoRest/DpgOutputLibrary.cs
@@ -58,7 +58,7 @@ namespace AutoRest.CSharp.Output.Models.Types
 
         private IEnumerable<string>? _accessOverriddenModels;
         public IEnumerable<string> AccessOverriddenModels => _accessOverriddenModels ??= Enums.Where(e => e.IsAccessibilityOverridden).Select(e => e.Declaration.Name)
-            .Concat(Models.Where(m => m.IsAccessibilityOverridden).Select(m => m.Declaration.Name));
+            .Concat(Models.Where(m => m.IsAccessibilityOverridden && (m.Namespace == null || !m.Namespace.StartsWith("Azure.Core"))).Select(m => m.Declaration.Name));
 
         private AspDotNetExtensionTypeProvider? _aspDotNetExtension;
         public AspDotNetExtensionTypeProvider AspDotNetExtension => _aspDotNetExtension ??= new AspDotNetExtensionTypeProvider(RestClients, Configuration.Namespace, _sourceInputModel);


### PR DESCRIPTION
# Description

Even the accessibility is set, we should not keep them since they should be referenced from Azure.Core

resolve #4597

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first