### PR TITLE
Call `ExtractResponse` in `ClientPipelineExtensions.cs` when `message.BufferResponse` is `false`

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Expressions/KnownValueExpressions/System/PipelineMessageExpression.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/KnownValueExpressions/System/PipelineMessageExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ClientModel.Primitives;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 
@@ -11,5 +12,9 @@ namespace AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions.System
         public PipelineRequestExpression Request => new(Property(nameof(PipelineMessage.Request)));
 
         public PipelineResponseExpression Response => new(Property(nameof(PipelineMessage.Response)));
+
+        public BoolExpression BufferResponse => new(Property(nameof(PipelineMessage.BufferResponse)));
+
+        public PipelineResponseExpression ExtractResponse() => new(new InvokeInstanceMethodExpression(Untyped, nameof(PipelineMessage.ExtractResponse), Array.Empty<ValueExpression>(), false));
     }
 }

--- a/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.DeclarationStatements.cs
+++ b/src/AutoRest.CSharp/Common/Output/Expressions/Snippets.DeclarationStatements.cs
@@ -4,6 +4,7 @@
 using System;
 using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions;
 using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions.Azure;
+using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions.System;
 using AutoRest.CSharp.Common.Output.Expressions.Statements;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 using AutoRest.CSharp.Generation.Types;

--- a/src/AutoRest.CSharp/Common/Output/Models/Types/HelperTypeProviders/System/ClientPipelineExtensionsProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/HelperTypeProviders/System/ClientPipelineExtensionsProvider.cs
@@ -134,7 +134,8 @@ namespace AutoRest.CSharp.Output.Models.Types.System
                     Throw(New.Instance(typeof(ClientResultException), _message.Response))
                 },
                 EmptyLine,
-                Return(_message.Response)
+                Declare("response", new TypedValueExpression(typeof(PipelineResponse), new TernaryConditionalOperator(_message.BufferResponse, _message.Response, _message.ExtractResponse())), out var response),
+                Return(response)
             });
         }
 
@@ -169,7 +170,8 @@ namespace AutoRest.CSharp.Output.Models.Types.System
                     Throw(new InvokeStaticMethodExpression(typeof(ClientResultException), nameof(ClientResultException.CreateAsync), new[] { _message.Response }, CallAsAsync: true))
                 },
                 EmptyLine,
-                Return(_message.Response)
+                Declare("response", new TypedValueExpression(typeof(PipelineResponse), new TernaryConditionalOperator(_message.BufferResponse, _message.Response, _message.ExtractResponse())), out var response),
+                Return(response)
             });
         }
 

--- a/test/CadlRanchProjectsNonAzure/authentication/api-key/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/authentication/api-key/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Authentication.ApiKey
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Authentication.ApiKey
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/authentication/http/custom/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/authentication/http/custom/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Authentication.Http.Custom
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Authentication.Http.Custom
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/client/naming/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/client/naming/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Client.Naming
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Client.Naming
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/parameters/body-optionality/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/parameters/body-optionality/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Parameters.BodyOptionality
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Parameters.BodyOptionality
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/parameters/spread/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/parameters/spread/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Parameters.Spread
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Parameters.Spread
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/payload/content-negotiation/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/payload/content-negotiation/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Payload.ContentNegotiation
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Payload.ContentNegotiation
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/payload/multipart/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/payload/multipart/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Payload.MultiPart
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Payload.MultiPart
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/serialization/encoded-name/json/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/serialization/encoded-name/json/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Serialization.EncodedName.Json
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Serialization.EncodedName.Json
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/server/endpoint/not-defined/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/server/endpoint/not-defined/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.Server.Endpoint.NotDefined
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.Server.Endpoint.NotDefined
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/special-words/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/special-words/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm.SpecialWords
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm.SpecialWords
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/array/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/array/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type._Array
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type._Array
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/dictionary/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/dictionary/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type._Dictionary
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type._Dictionary
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/enum/extensible/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/enum/extensible/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type._Enum.Extensible
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type._Enum.Extensible
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/enum/fixed/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/enum/fixed/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type._Enum.Fixed
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type._Enum.Fixed
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/model/empty/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/empty/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type.Model.Empty
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type.Model.Empty
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/single-discriminator/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/single-discriminator/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type.Model.Inheritance.SingleDiscriminator
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type.Model.Inheritance.SingleDiscriminator
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/model/usage/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/usage/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type.Model.Usage
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type.Model.Usage
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/property/additional-properties/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/property/additional-properties/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type.Property.AdditionalProperties
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type.Property.AdditionalProperties
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/scalar/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/scalar/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type.Scalar
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type.Scalar
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/CadlRanchProjectsNonAzure/type/union/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/CadlRanchProjectsNonAzure/type/union/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace Scm._Type.Union
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace Scm._Type.Union
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/UnbrandedProjects/Customized-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/UnbrandedProjects/Customized-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace CustomizedTypeSpec
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace CustomizedTypeSpec
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace NoDocsUnbrandedTypeSpec
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace NoDocsUnbrandedTypeSpec
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/UnbrandedProjects/NoTest-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/UnbrandedProjects/NoTest-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace NoTestTypeSpec
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace NoTestTypeSpec
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace OpenAI
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace OpenAI
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)

--- a/test/UnbrandedProjects/Unbranded-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
+++ b/test/UnbrandedProjects/Unbranded-TypeSpec/src/Generated/Internal/ClientPipelineExtensions.cs
@@ -19,7 +19,8 @@ namespace UnbrandedTypeSpec
                 throw await ClientResultException.CreateAsync(message.Response).ConfigureAwait(false);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static PipelineResponse ProcessMessage(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
@@ -31,7 +32,8 @@ namespace UnbrandedTypeSpec
                 throw new ClientResultException(message.Response);
             }
 
-            return message.Response;
+            PipelineResponse response = message.BufferResponse ? message.Response : message.ExtractResponse();
+            return response;
         }
 
         public static async ValueTask<ClientResult<bool>> ProcessHeadAsBoolMessageAsync(this ClientPipeline pipeline, PipelineMessage message, RequestOptions options)


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/4709

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first