### PR TITLE
fix(emitter): wrong package name in trace logs

### DIFF
--- a/eng/Generation.psm1
+++ b/eng/Generation.psm1
@@ -89,7 +89,7 @@ function Invoke-TypeSpec($baseOutput, $projectName, $mainFile, $arguments="", $s
         Try
         {
             $typespecFileName = $mainFile ? $mainFile : "$baseOutput/$projectName.tsp"
-            $emitCommand = "npx tsp compile $typespecFileName --trace @typespec/http-client-csharp --emit @azure-tools/typespec-csharp --option @azure-tools/typespec-csharp.emitter-output-dir=$outputPath --option @azure-tools/typespec-csharp.csharpGeneratorPath=$autorestCsharpBinPath $arguments"
+            $emitCommand = "npx tsp compile $typespecFileName --trace @azure-tools/typespec-csharp --emit @azure-tools/typespec-csharp --option @azure-tools/typespec-csharp.emitter-output-dir=$outputPath --option @azure-tools/typespec-csharp.csharpGeneratorPath=$autorestCsharpBinPath $arguments"
             Invoke $emitCommand $outputPath
         }
         Finally 

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/constants.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/constants.ts
@@ -7,3 +7,4 @@ export const projectedNameClientKey = "client";
 export const mockApiVersion = "0000-00-00";
 export const tspOutputFileName = "tspCodeModel.json";
 export const configurationFileName = "Configuration.json";
+export const packageName = "@azure-tools/typespec-csharp";

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/emitter.ts
@@ -13,7 +13,11 @@ import { execSync } from "child_process";
 import fs, { existsSync } from "fs";
 import { PreserveType, stringifyRefs } from "json-serialize-refs";
 import path from "node:path";
-import { configurationFileName, tspOutputFileName } from "./constants.js";
+import {
+    configurationFileName,
+    tspOutputFileName,
+    packageName
+} from "./constants.js";
 import { createModel } from "./lib/client-model-builder.js";
 import { LoggerLevel } from "./lib/log-level.js";
 import { Logger } from "./lib/logger.js";
@@ -34,10 +38,7 @@ export async function $onEmit(context: EmitContext<NetEmitterOptions>) {
 
     if (!program.compilerOptions.noEmit && !program.hasError()) {
         // Write out the dotnet model to the output path
-        const sdkContext = createSdkContext(
-            context,
-            "@azure-tools/typespec-csharp"
-        );
+        const sdkContext = createSdkContext(context, packageName);
         const root = createModel(sdkContext);
         if (
             context.program.diagnostics.length > 0 &&

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/lib.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/lib.ts
@@ -5,7 +5,7 @@ import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 import { NetEmitterOptionsSchema } from "../options.js";
 
 const $lib = createTypeSpecLibrary({
-    name: "@typespec/http-client-csharp",
+    name: "@azure-tools/typespec-csharp",
     diagnostics: {
         "no-apiVersion": {
             severity: "error",

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/lib.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/lib.ts
@@ -3,9 +3,10 @@
 
 import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 import { NetEmitterOptionsSchema } from "../options.js";
+import { packageName } from "../constants.js";
 
 const $lib = createTypeSpecLibrary({
-    name: "@azure-tools/typespec-csharp",
+    name: packageName,
     diagnostics: {
         "no-apiVersion": {
             severity: "error",


### PR DESCRIPTION
# Description

fix a regression when back porting changes from `microsoft/typespec` in pr: https://github.com/Azure/autorest.csharp/pull/4705

fix #4751

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first