### PR TITLE
Add typespec rulesets package as emitter dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -349,7 +349,6 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.42.1.tgz",
       "integrity": "sha512-vUqmHWS9OrN+16jXfpgUdUXXa1RLrr8Pkrzb1HFQGmdXuRxMZZtLCRcyyEHZJIMYE4RmmpPoB3JJeqiGWxlegQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0"
@@ -8901,6 +8900,7 @@
       },
       "devDependencies": {
         "@azure-tools/typespec-azure-core": "0.42.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.42.1",
         "@azure-tools/typespec-azure-rulesets": "0.42.1",
         "@azure-tools/typespec-client-generator-core": "0.42.3",
         "@eslint/js": "^9.2.0",
@@ -8928,6 +8928,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.36.0 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.36.0 <1.0.0",
         "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
         "@typespec/compiler": ">=0.50.0 <1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@azure-tools/typespec-autorest": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.42.1.tgz",
+      "integrity": "sha512-egWR2Ljxde5PvyDwuVu/8Rq8cSW6FW+qMbvwHfzrtm/sULdSnA6k+VnGD/PQ+dk+1SmFeKG1b+0MlaFuBVz1Hw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@azure-tools/typespec-client-generator-core": "~0.42.0",
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/openapi": "~0.56.0",
+        "@typespec/rest": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
+      }
+    },
     "node_modules/@azure-tools/typespec-azure-core": {
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.42.0.tgz",
@@ -323,6 +342,44 @@
         "@typespec/compiler": "~0.56.0",
         "@typespec/http": "~0.56.0",
         "@typespec/rest": "~0.56.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-resource-manager": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.42.1.tgz",
+      "integrity": "sha512-vUqmHWS9OrN+16jXfpgUdUXXa1RLrr8Pkrzb1HFQGmdXuRxMZZtLCRcyyEHZJIMYE4RmmpPoB3JJeqiGWxlegQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "change-case": "~5.4.4",
+        "pluralize": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-autorest": "~0.42.1",
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/openapi": "~0.56.0",
+        "@typespec/rest": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.42.1.tgz",
+      "integrity": "sha512-GRiMErWJ96DvDBQMVgGI1sgMTOegXxpx7w6enZyEF0BaodxGfObJyl1TrMb9Pj6NAZfV5Q6uJAfXFbpF1MVDCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.42.1",
+        "@azure-tools/typespec-client-generator-core": "~0.42.3",
+        "@typespec/compiler": "~0.56.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
@@ -8844,6 +8901,7 @@
       },
       "devDependencies": {
         "@azure-tools/typespec-azure-core": "0.42.0",
+        "@azure-tools/typespec-azure-rulesets": "0.42.1",
         "@azure-tools/typespec-client-generator-core": "0.42.3",
         "@eslint/js": "^9.2.0",
         "@types/lodash.isequal": "^4.5.6",
@@ -8870,6 +8928,7 @@
       },
       "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.36.0 <1.0.0",
         "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
         "@typespec/compiler": ">=0.50.0 <1.0.0",
         "@typespec/http": ">=0.50.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -40,6 +40,7 @@
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
         "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
+        "@azure-tools/typespec-azure-rulesets": ">=0.36.0 <1.0.0",
         "@typespec/compiler": ">=0.50.0 <1.0.0",
         "@typespec/http": ">=0.50.0 <1.0.0",
         "@typespec/openapi": ">=0.50.0 <1.0.0",
@@ -49,6 +50,7 @@
     "devDependencies": {
         "@azure-tools/typespec-azure-core": "0.42.0",
         "@azure-tools/typespec-client-generator-core": "0.42.3",
+        "@azure-tools/typespec-azure-rulesets": "0.42.1",
         "@eslint/js": "^9.2.0",
         "@types/lodash.isequal": "^4.5.6",
         "@types/mocha": "~9.1.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -40,6 +40,7 @@
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
         "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.36.0 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.36.0 <1.0.0",
         "@typespec/compiler": ">=0.50.0 <1.0.0",
         "@typespec/http": ">=0.50.0 <1.0.0",
@@ -50,6 +51,7 @@
     "devDependencies": {
         "@azure-tools/typespec-azure-core": "0.42.0",
         "@azure-tools/typespec-client-generator-core": "0.42.3",
+        "@azure-tools/typespec-azure-resource-manager": "0.42.1",
         "@azure-tools/typespec-azure-rulesets": "0.42.1",
         "@eslint/js": "^9.2.0",
         "@types/lodash.isequal": "^4.5.6",


### PR DESCRIPTION
This change transitively adds typespec-azure-rulesets as a dependency to azure-sdk-for-net's emitter-package.json by adding a pinned peer dependency to the emitter's package.json file.

The constructed emitter-package.json:
```json
{
  "main": "dist/src/index.js",
  "dependencies": {
    "@azure-tools/typespec-csharp": "0.2.0"
  },
  "devDependencies": {
    "@azure-tools/typespec-azure-core": "0.42.0",
    "@azure-tools/typespec-azure-resource-manager": "0.42.1",
    "@azure-tools/typespec-azure-rulesets": "0.42.1",
    "@azure-tools/typespec-client-generator-core": "0.42.3",
    "@typespec/compiler": "0.56.0",
    "@typespec/http": "0.56.0",
    "@typespec/openapi": "0.56.0",
    "@typespec/rest": "0.56.0",
    "@typespec/versioning": "0.56.0"
  }
}
```