### PR TITLE
consolidate union types from TCGC

### DIFF
--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -40,7 +40,7 @@ namespace AutoRest.CSharp.Generation.Types
         public CSharpType CreateType(InputType inputType) => inputType switch
         {
             InputLiteralType literalType => CSharpType.FromLiteral(CreateType(literalType.ValueType), literalType.Value),
-            InputUnionType unionType => CSharpType.FromUnion(unionType.UnionItemTypes.Select(CreateType).ToArray(), unionType.IsNullable),
+            InputUnionType unionType => CSharpType.FromUnion(unionType.ItemTypes.Select(CreateType).ToArray(), unionType.IsNullable),
             InputListType { IsEmbeddingsVector: true } listType => new CSharpType(typeof(ReadOnlyMemory<>), listType.IsNullable, CreateType(listType.ElementType)),
             InputListType listType => new CSharpType(typeof(IList<>), listType.IsNullable, CreateType(listType.ElementType)),
             InputDictionaryType dictionaryType => new CSharpType(typeof(IDictionary<,>), inputType.IsNullable, typeof(string), CreateType(dictionaryType.ValueType)),

--- a/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
+++ b/src/AutoRest.CSharp/Common/Generation/Types/TypeFactory.cs
@@ -40,7 +40,7 @@ namespace AutoRest.CSharp.Generation.Types
         public CSharpType CreateType(InputType inputType) => inputType switch
         {
             InputLiteralType literalType => CSharpType.FromLiteral(CreateType(literalType.ValueType), literalType.Value),
-            InputUnionType unionType => CSharpType.FromUnion(unionType.ItemTypes.Select(CreateType).ToArray(), unionType.IsNullable),
+            InputUnionType unionType => CSharpType.FromUnion(unionType.VariantTypes.Select(CreateType).ToArray(), unionType.IsNullable),
             InputListType { IsEmbeddingsVector: true } listType => new CSharpType(typeof(ReadOnlyMemory<>), listType.IsNullable, CreateType(listType.ElementType)),
             InputListType listType => new CSharpType(typeof(IList<>), listType.IsNullable, CreateType(listType.ElementType)),
             InputDictionaryType dictionaryType => new CSharpType(typeof(IDictionary<,>), inputType.IsNullable, typeof(string), CreateType(dictionaryType.ValueType)),

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Examples/ExampleMockValueBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Examples/ExampleMockValueBuilder.cs
@@ -62,7 +62,7 @@ namespace AutoRest.CSharp.Common.Input.Examples
                     // when it is constant, it could have DefaultValue
                     value = InputExampleValue.Value(parameter.Type, parameter.DefaultValue.Value);
                 }
-                else if (parameter.Type is InputUnionType unionType && unionType.UnionItemTypes[0] is InputLiteralType literalType)
+                else if (parameter.Type is InputUnionType unionType && unionType.ItemTypes[0] is InputLiteralType literalType)
                 {
                     // or it could be a union of literal types
                     value = InputExampleValue.Value(parameter.Type, literalType.Value);
@@ -105,7 +105,7 @@ namespace AutoRest.CSharp.Common.Input.Examples
             InputPrimitiveType primitiveType => BuildPrimitiveExampleValue(primitiveType, hint),
             InputLiteralType literalType => InputExampleValue.Value(literalType, literalType.Value),
             InputModelType modelType => BuildModelExampleValue(modelType, useAllParameters, visitedModels),
-            InputUnionType unionType => BuildExampleValue(unionType.UnionItemTypes.First(), hint, useAllParameters, visitedModels),
+            InputUnionType unionType => BuildExampleValue(unionType.ItemTypes.First(), hint, useAllParameters, visitedModels),
             InputDateTimeType dateTimeType => BuildDateTimeExampleValue(dateTimeType),
             InputDurationType durationType => BuildDurationExampleValue(durationType),
             _ => InputExampleValue.Object(type, new Dictionary<string, InputExampleValue>())

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Examples/ExampleMockValueBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Examples/ExampleMockValueBuilder.cs
@@ -105,7 +105,7 @@ namespace AutoRest.CSharp.Common.Input.Examples
             InputPrimitiveType primitiveType => BuildPrimitiveExampleValue(primitiveType, hint),
             InputLiteralType literalType => InputExampleValue.Value(literalType, literalType.Value),
             InputModelType modelType => BuildModelExampleValue(modelType, useAllParameters, visitedModels),
-            InputUnionType unionType => BuildExampleValue(unionType.VariantTypes.First(), hint, useAllParameters, visitedModels),
+            InputUnionType unionType => BuildExampleValue(unionType.VariantTypes[0], hint, useAllParameters, visitedModels),
             InputDateTimeType dateTimeType => BuildDateTimeExampleValue(dateTimeType),
             InputDurationType durationType => BuildDurationExampleValue(durationType),
             _ => InputExampleValue.Object(type, new Dictionary<string, InputExampleValue>())

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Examples/ExampleMockValueBuilder.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Examples/ExampleMockValueBuilder.cs
@@ -62,7 +62,7 @@ namespace AutoRest.CSharp.Common.Input.Examples
                     // when it is constant, it could have DefaultValue
                     value = InputExampleValue.Value(parameter.Type, parameter.DefaultValue.Value);
                 }
-                else if (parameter.Type is InputUnionType unionType && unionType.ItemTypes[0] is InputLiteralType literalType)
+                else if (parameter.Type is InputUnionType unionType && unionType.VariantTypes[0] is InputLiteralType literalType)
                 {
                     // or it could be a union of literal types
                     value = InputExampleValue.Value(parameter.Type, literalType.Value);
@@ -105,7 +105,7 @@ namespace AutoRest.CSharp.Common.Input.Examples
             InputPrimitiveType primitiveType => BuildPrimitiveExampleValue(primitiveType, hint),
             InputLiteralType literalType => InputExampleValue.Value(literalType, literalType.Value),
             InputModelType modelType => BuildModelExampleValue(modelType, useAllParameters, visitedModels),
-            InputUnionType unionType => BuildExampleValue(unionType.ItemTypes.First(), hint, useAllParameters, visitedModels),
+            InputUnionType unionType => BuildExampleValue(unionType.VariantTypes.First(), hint, useAllParameters, visitedModels),
             InputDateTimeType dateTimeType => BuildDateTimeExampleValue(dateTimeType),
             InputDurationType durationType => BuildDurationExampleValue(durationType),
             _ => InputExampleValue.Object(type, new Dictionary<string, InputExampleValue>())

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/InputUnionType.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/InputUnionType.cs
@@ -5,4 +5,4 @@ using System.Collections.Generic;
 
 namespace AutoRest.CSharp.Common.Input;
 
-internal record InputUnionType(string Name, IReadOnlyList<InputType> ItemTypes, bool IsNullable) : InputType(Name, IsNullable);
+internal record InputUnionType(string Name, IReadOnlyList<InputType> VariantTypes, bool IsNullable) : InputType(Name, IsNullable);

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/InputUnionType.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/InputUnionType.cs
@@ -5,4 +5,4 @@ using System.Collections.Generic;
 
 namespace AutoRest.CSharp.Common.Input;
 
-internal record InputUnionType(string Name, IReadOnlyList<InputType> UnionItemTypes, bool IsNullable) : InputType(Name, IsNullable);
+internal record InputUnionType(string Name, IReadOnlyList<InputType> ItemTypes, bool IsNullable) : InputType(Name, IsNullable);

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputTypeConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputTypeConverter.cs
@@ -50,7 +50,7 @@ namespace AutoRest.CSharp.Common.Input
         }
 
         private const string LiteralKind = "constant";
-        private const string UnionKind = "Union";
+        private const string UnionKind = "union";
         private const string ModelKind = "Model";
         private const string EnumKind = "enum";
         private const string ArrayKind = "Array";

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputUnionTypeConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputUnionTypeConverter.cs
@@ -31,19 +31,10 @@ namespace AutoRest.CSharp.Common.Input
             {
                 var isKnownProperty = reader.TryReadReferenceId(ref isFirstProperty, ref id)
                     || reader.TryReadString(nameof(InputUnionType.Name), ref name)
-                    || reader.TryReadBoolean(nameof(InputUnionType.IsNullable), ref isNullable);
+                    || reader.TryReadBoolean(nameof(InputUnionType.IsNullable), ref isNullable)
+                    || reader.TryReadWithConverter(nameof(InputUnionType.VariantTypes), options, ref variantTypes);
 
-                if (isKnownProperty)
-                {
-                    continue;
-                }
-
-                if (reader.GetString() == nameof(InputUnionType.VariantTypes))
-                {
-                    reader.Read();
-                    CreateUnionItemTypes(ref reader, variantTypes, options);
-                }
-                else
+                if (!isKnownProperty)
                 {
                     reader.SkipProperty();
                 }
@@ -61,22 +52,6 @@ namespace AutoRest.CSharp.Common.Input
                 resolver.AddReference(id, unionType);
             }
             return unionType;
-        }
-
-        private static void CreateUnionItemTypes(ref Utf8JsonReader reader, ICollection<InputType> itemTypes, JsonSerializerOptions options)
-        {
-            if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                throw new JsonException();
-            }
-            reader.Read();
-
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                var type = reader.ReadWithConverter<InputType>(options);
-                itemTypes.Add(type ?? throw new JsonException($"null {nameof(InputType)} isn't allowed"));
-            }
-            reader.Read();
         }
     }
 }

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputUnionTypeConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputUnionTypeConverter.cs
@@ -40,7 +40,7 @@ namespace AutoRest.CSharp.Common.Input
                     continue;
                 }
 
-                if (reader.GetString() == nameof(InputUnionType.UnionItemTypes))
+                if (reader.GetString() == nameof(InputUnionType.ItemTypes))
                 {
                     reader.Read();
                     CreateUnionItemTypes(ref reader, unionItemTypes, options);

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputUnionTypeConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputUnionTypeConverter.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.CodeAnalysis;
 
 namespace AutoRest.CSharp.Common.Input
 {
@@ -28,7 +26,7 @@ namespace AutoRest.CSharp.Common.Input
         {
             var isFirstProperty = id == null;
             bool isNullable = false;
-            var unionItemTypes = new List<InputType>();
+            var variantTypes = new List<InputType>();
             while (reader.TokenType != JsonTokenType.EndObject)
             {
                 var isKnownProperty = reader.TryReadReferenceId(ref isFirstProperty, ref id)
@@ -40,10 +38,10 @@ namespace AutoRest.CSharp.Common.Input
                     continue;
                 }
 
-                if (reader.GetString() == nameof(InputUnionType.ItemTypes))
+                if (reader.GetString() == nameof(InputUnionType.VariantTypes))
                 {
                     reader.Read();
-                    CreateUnionItemTypes(ref reader, unionItemTypes, options);
+                    CreateUnionItemTypes(ref reader, variantTypes, options);
                 }
                 else
                 {
@@ -51,13 +49,13 @@ namespace AutoRest.CSharp.Common.Input
                 }
             }
 
-            name = name ?? throw new JsonException($"{nameof(InputLiteralType)} must have a name.");
-            if (unionItemTypes == null || unionItemTypes.Count == 0)
+            name = name ?? throw new JsonException($"{nameof(InputUnionType)} must have a name.");
+            if (variantTypes == null || variantTypes.Count == 0)
             {
-                throw new JsonException("Union must have a least one union type");
+                throw new JsonException("Union must have variant types.");
             }
 
-            var unionType = new InputUnionType(name, unionItemTypes, isNullable);
+            var unionType = new InputUnionType(name, variantTypes, isNullable);
             if (id != null)
             {
                 resolver.AddReference(id, unionType);

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/converter.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/converter.ts
@@ -343,7 +343,7 @@ function fromUnionType(
     return {
         Kind: "union",
         Name: union.name,
-        ItemTypes: itemTypes,
+        VariantTypes: itemTypes,
         IsNullable: false
     };
 }

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/converter.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/converter.ts
@@ -334,16 +334,16 @@ function fromUnionType(
     models: Map<string, InputModelType>,
     enums: Map<string, InputEnumType>
 ): InputUnionType {
-    const itemTypes: InputType[] = [];
+    const variantTypes: InputType[] = [];
     for (const value of union.values) {
-        const valueType = fromSdkType(value, context, models, enums);
-        itemTypes.push(valueType);
+        const variantType = fromSdkType(value, context, models, enums);
+        variantTypes.push(variantType);
     }
 
     return {
         Kind: "union",
         Name: union.name,
-        VariantTypes: itemTypes,
+        VariantTypes: variantTypes,
         IsNullable: false
     };
 }

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/converter.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/converter.ts
@@ -333,21 +333,19 @@ function fromUnionType(
     context: SdkContext,
     models: Map<string, InputModelType>,
     enums: Map<string, InputEnumType>
-): InputUnionType | InputType {
+): InputUnionType {
     const itemTypes: InputType[] = [];
     for (const value of union.values) {
-        const inputType = fromSdkType(value, context, models, enums);
-        itemTypes.push(inputType);
+        const valueType = fromSdkType(value, context, models, enums);
+        itemTypes.push(valueType);
     }
 
-    return itemTypes.length > 1
-        ? {
-              Kind: InputTypeKind.Union,
-              Name: InputTypeKind.Union,
-              UnionItemTypes: itemTypes,
-              IsNullable: false
-          }
-        : itemTypes[0];
+    return {
+        Kind: "union",
+        Name: union.name,
+        ItemTypes: itemTypes,
+        IsNullable: false
+    };
 }
 
 function fromSdkConstantType(

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
@@ -173,7 +173,7 @@ export function loadOperation(
         if (isInputLiteralType(contentTypeParameter.Type)) {
             mediaTypes.push(contentTypeParameter.DefaultValue?.Value);
         } else if (isInputUnionType(contentTypeParameter.Type)) {
-            for (const unionItem of contentTypeParameter.Type.ItemTypes) {
+            for (const unionItem of contentTypeParameter.Type.VariantTypes) {
                 if (isInputLiteralType(unionItem)) {
                     mediaTypes.push(unionItem.Value as string);
                 } else {

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
@@ -173,7 +173,7 @@ export function loadOperation(
         if (isInputLiteralType(contentTypeParameter.Type)) {
             mediaTypes.push(contentTypeParameter.DefaultValue?.Value);
         } else if (isInputUnionType(contentTypeParameter.Type)) {
-            for (const unionItem of contentTypeParameter.Type.UnionItemTypes) {
+            for (const unionItem of contentTypeParameter.Type.ItemTypes) {
                 if (isInputLiteralType(unionItem)) {
                     mediaTypes.push(unionItem.Value as string);
                 } else {

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/type/input-type-kind.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/type/input-type-kind.ts
@@ -2,11 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 export enum InputTypeKind {
-    // Primitive = "Primitive",
-    // Literal = "Literal",
-    Union = "Union",
     Model = "Model",
-    // Enum = "Enum",
     Array = "Array",
     Dictionary = "Dictionary",
     Intrinsic = "Intrinsic"

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/type/input-type.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/type/input-type.ts
@@ -64,13 +64,13 @@ export interface InputDurationType extends InputTypeBase {
 }
 
 export interface InputUnionType extends InputTypeBase {
-    Kind: InputTypeKind.Union; // TODO -- will change to TCGC value in future refactor
-    Name: InputTypeKind.Union; // union type does not really have a name right now, we just use its kind
-    UnionItemTypes: InputType[];
+    Kind: "union";
+    Name: string;
+    ItemTypes: InputType[];
 }
 
 export function isInputUnionType(type: InputType): type is InputUnionType {
-    return type.Kind === InputTypeKind.Union;
+    return type.Kind === "union";
 }
 
 export interface InputModelType extends InputTypeBase {

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/type/input-type.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/type/input-type.ts
@@ -66,7 +66,7 @@ export interface InputDurationType extends InputTypeBase {
 export interface InputUnionType extends InputTypeBase {
     Kind: "union";
     Name: string;
-    ItemTypes: InputType[];
+    VariantTypes: InputType[];
 }
 
 export function isInputUnionType(type: InputType): type is InputUnionType {

--- a/test/CadlRanchProjects/type/property/additional-properties/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/property/additional-properties/src/Generated/tspCodeModel.json
@@ -1150,9 +1150,9 @@
     },
     "ValueType": {
      "$id": "155",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "MultipleSpreadRecordAdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "156",
        "Kind": "string",
@@ -1203,9 +1203,9 @@
     },
     "ValueType": {
      "$id": "163",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForUnionAdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "164",
        "Kind": "string",
@@ -1256,9 +1256,9 @@
     },
     "ValueType": {
      "$id": "171",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "WidgetData",
+     "VariantTypes": [
       {
        "$id": "172",
        "Kind": "Model",
@@ -1410,9 +1410,9 @@
     },
     "ValueType": {
      "$id": "191",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForNonDiscriminatedUnionAdditionalProperty",
+     "VariantTypes": [
       {
        "$ref": "172"
       },
@@ -1459,9 +1459,9 @@
     },
     "ValueType": {
      "$id": "197",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForNonDiscriminatedUnion2AdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "198",
        "Kind": "Model",
@@ -1548,9 +1548,9 @@
     },
     "ValueType": {
      "$id": "208",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForNonDiscriminatedUnion3AdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "209",
        "Kind": "Array",

--- a/test/CadlRanchProjects/type/union/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/union/src/Generated/tspCodeModel.json
@@ -437,9 +437,9 @@
      "Description": "",
      "Type": {
       "$id": "57",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "GetResponseProp",
+      "VariantTypes": [
        {
         "$id": "58",
         "Kind": "Model",
@@ -515,9 +515,9 @@
      "Description": "",
      "Type": {
       "$id": "66",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "GetResponseProp",
+      "VariantTypes": [
        {
         "$ref": "58"
        },
@@ -634,9 +634,9 @@
         "Description": "This should be receive/send the string variant",
         "Type": {
          "$id": "78",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "StringAndArrayCasesString",
+         "VariantTypes": [
           {
            "$id": "79",
            "Kind": "string",
@@ -666,9 +666,9 @@
         "Description": "This should be receive/send the array variant",
         "Type": {
          "$id": "83",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "StringAndArrayCasesArray",
+         "VariantTypes": [
           {
            "$id": "84",
            "Kind": "string",
@@ -750,9 +750,9 @@
         "Description": "This should be receive/send the \"a\" variant",
         "Type": {
          "$id": "93",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "94",
            "Kind": "constant",
@@ -810,9 +810,9 @@
         "Description": "This should be receive/send the 2 variant",
         "Type": {
          "$id": "103",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "104",
            "Kind": "constant",
@@ -870,9 +870,9 @@
         "Description": "This should be receive/send the 3.3 variant",
         "Type": {
          "$id": "113",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "114",
            "Kind": "constant",
@@ -930,9 +930,9 @@
         "Description": "This should be receive/send the true variant",
         "Type": {
          "$id": "123",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "124",
            "Kind": "constant",
@@ -1042,9 +1042,9 @@
         "Description": "This should be receive/send the Cat variant",
         "Type": {
          "$id": "138",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1082,9 +1082,9 @@
         "Description": "This should be receive/send the \"a\" variant",
         "Type": {
          "$id": "144",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1122,9 +1122,9 @@
         "Description": "This should be receive/send the int variant",
         "Type": {
          "$id": "150",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1162,9 +1162,9 @@
         "Description": "This should be receive/send the boolean variant",
         "Type": {
          "$id": "156",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1206,9 +1206,9 @@
          "Name": "Array",
          "ElementType": {
           "$id": "163",
-          "Kind": "Union",
-          "Name": "Union",
-          "UnionItemTypes": [
+          "Kind": "union",
+          "Name": "MixedTypesCasesModel",
+          "VariantTypes": [
            {
             "$ref": "58"
            },

--- a/test/CadlRanchProjects/versioning/added/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/added/src/Generated/tspCodeModel.json
@@ -123,9 +123,9 @@
      "Description": "",
      "Type": {
       "$id": "18",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "UnionV1",
+      "VariantTypes": [
        {
         "$id": "19",
         "Kind": "string",
@@ -183,9 +183,9 @@
      "Description": "",
      "Type": {
       "$id": "26",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "UnionV2",
+      "VariantTypes": [
        {
         "$id": "27",
         "Kind": "string",

--- a/test/CadlRanchProjects/versioning/removed/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/removed/src/Generated/tspCodeModel.json
@@ -97,9 +97,9 @@
      "Description": "",
      "Type": {
       "$id": "14",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "UnionV2",
+      "VariantTypes": [
        {
         "$id": "15",
         "Kind": "string",

--- a/test/CadlRanchProjects/versioning/renamedFrom/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/renamedFrom/src/Generated/tspCodeModel.json
@@ -97,9 +97,9 @@
      "Description": "",
      "Type": {
       "$id": "14",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "NewUnion",
+      "VariantTypes": [
        {
         "$id": "15",
         "Kind": "string",

--- a/test/CadlRanchProjectsNonAzure/type/property/additional-properties/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/property/additional-properties/src/Generated/tspCodeModel.json
@@ -1150,9 +1150,9 @@
     },
     "ValueType": {
      "$id": "155",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "MultipleSpreadRecordAdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "156",
        "Kind": "string",
@@ -1203,9 +1203,9 @@
     },
     "ValueType": {
      "$id": "163",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForUnionAdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "164",
        "Kind": "string",
@@ -1256,9 +1256,9 @@
     },
     "ValueType": {
      "$id": "171",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "WidgetData",
+     "VariantTypes": [
       {
        "$id": "172",
        "Kind": "Model",
@@ -1410,9 +1410,9 @@
     },
     "ValueType": {
      "$id": "191",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForNonDiscriminatedUnionAdditionalProperty",
+     "VariantTypes": [
       {
        "$ref": "172"
       },
@@ -1459,9 +1459,9 @@
     },
     "ValueType": {
      "$id": "197",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForNonDiscriminatedUnion2AdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "198",
        "Kind": "Model",
@@ -1548,9 +1548,9 @@
     },
     "ValueType": {
      "$id": "208",
-     "Kind": "Union",
-     "Name": "Union",
-     "UnionItemTypes": [
+     "Kind": "union",
+     "Name": "SpreadRecordForNonDiscriminatedUnion3AdditionalProperty",
+     "VariantTypes": [
       {
        "$id": "209",
        "Kind": "Array",

--- a/test/CadlRanchProjectsNonAzure/type/union/src/Generated/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/union/src/Generated/tspCodeModel.json
@@ -437,9 +437,9 @@
      "Description": "",
      "Type": {
       "$id": "57",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "GetResponseProp",
+      "VariantTypes": [
        {
         "$id": "58",
         "Kind": "Model",
@@ -515,9 +515,9 @@
      "Description": "",
      "Type": {
       "$id": "66",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "GetResponseProp",
+      "VariantTypes": [
        {
         "$ref": "58"
        },
@@ -634,9 +634,9 @@
         "Description": "This should be receive/send the string variant",
         "Type": {
          "$id": "78",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "StringAndArrayCasesString",
+         "VariantTypes": [
           {
            "$id": "79",
            "Kind": "string",
@@ -666,9 +666,9 @@
         "Description": "This should be receive/send the array variant",
         "Type": {
          "$id": "83",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "StringAndArrayCasesArray",
+         "VariantTypes": [
           {
            "$id": "84",
            "Kind": "string",
@@ -750,9 +750,9 @@
         "Description": "This should be receive/send the \"a\" variant",
         "Type": {
          "$id": "93",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "94",
            "Kind": "constant",
@@ -810,9 +810,9 @@
         "Description": "This should be receive/send the 2 variant",
         "Type": {
          "$id": "103",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "104",
            "Kind": "constant",
@@ -870,9 +870,9 @@
         "Description": "This should be receive/send the 3.3 variant",
         "Type": {
          "$id": "113",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "114",
            "Kind": "constant",
@@ -930,9 +930,9 @@
         "Description": "This should be receive/send the true variant",
         "Type": {
          "$id": "123",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedLiteralsCasesStringLiteral",
+         "VariantTypes": [
           {
            "$id": "124",
            "Kind": "constant",
@@ -1042,9 +1042,9 @@
         "Description": "This should be receive/send the Cat variant",
         "Type": {
          "$id": "138",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1082,9 +1082,9 @@
         "Description": "This should be receive/send the \"a\" variant",
         "Type": {
          "$id": "144",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1122,9 +1122,9 @@
         "Description": "This should be receive/send the int variant",
         "Type": {
          "$id": "150",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1162,9 +1162,9 @@
         "Description": "This should be receive/send the boolean variant",
         "Type": {
          "$id": "156",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "MixedTypesCasesModel",
+         "VariantTypes": [
           {
            "$ref": "58"
           },
@@ -1206,9 +1206,9 @@
          "Name": "Array",
          "ElementType": {
           "$id": "163",
-          "Kind": "Union",
-          "Name": "Union",
-          "UnionItemTypes": [
+          "Kind": "union",
+          "Name": "MixedTypesCasesModel",
+          "VariantTypes": [
            {
             "$ref": "58"
            },

--- a/test/TestProjects/FirstTest-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/FirstTest-TypeSpec/src/Generated/tspCodeModel.json
@@ -502,9 +502,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "76",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "ItemTypes": [
        {
         "$id": "77",
         "Kind": "string",
@@ -1500,9 +1500,9 @@
       "Name": "Array",
       "ElementType": {
        "$id": "203",
-       "Kind": "Union",
-       "Name": "Union",
-       "UnionItemTypes": [
+       "Kind": "union",
+       "Name": "RoundTripModelUnionList",
+       "ItemTypes": [
         {
          "$id": "204",
          "Kind": "string",

--- a/test/TestProjects/FirstTest-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/FirstTest-TypeSpec/src/Generated/tspCodeModel.json
@@ -504,7 +504,7 @@
       "$id": "76",
       "Kind": "union",
       "Name": "ThingRequiredUnion",
-      "ItemTypes": [
+      "VariantTypes": [
        {
         "$id": "77",
         "Kind": "string",
@@ -1502,7 +1502,7 @@
        "$id": "203",
        "Kind": "union",
        "Name": "RoundTripModelUnionList",
-       "ItemTypes": [
+       "VariantTypes": [
         {
          "$id": "204",
          "Kind": "string",

--- a/test/TestProjects/NoDocs-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/NoDocs-TypeSpec/src/Generated/tspCodeModel.json
@@ -502,9 +502,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "76",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "VariantTypes": [
        {
         "$id": "77",
         "Kind": "string",
@@ -1437,9 +1437,9 @@
       "Name": "Array",
       "ElementType": {
        "$id": "194",
-       "Kind": "Union",
-       "Name": "Union",
-       "UnionItemTypes": [
+       "Kind": "union",
+       "Name": "RoundTripModelUnionList",
+       "VariantTypes": [
         {
          "$id": "195",
          "Kind": "string",

--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/src/Generated/tspCodeModel.json
@@ -415,9 +415,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "63",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "VariantTypes": [
        {
         "$id": "64",
         "Kind": "string",

--- a/test/UnbrandedProjects/Customized-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/UnbrandedProjects/Customized-TypeSpec/src/Generated/tspCodeModel.json
@@ -195,9 +195,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "27",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "VariantTypes": [
        {
         "$id": "28",
         "Kind": "string",

--- a/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/src/Generated/tspCodeModel.json
@@ -172,9 +172,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "24",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "VariantTypes": [
        {
         "$id": "25",
         "Kind": "string",

--- a/test/UnbrandedProjects/NoTest-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/UnbrandedProjects/NoTest-TypeSpec/src/Generated/tspCodeModel.json
@@ -172,9 +172,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "24",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "VariantTypes": [
        {
         "$id": "25",
         "Kind": "string",

--- a/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/src/Generated/tspCodeModel.json
@@ -1365,9 +1365,9 @@
      "Description": "Controls how the model responds to function calls. `none` means the model does not call a\nfunction, and responds to the end-user. `auto` means the model can pick between an end-user or\ncalling a function.  Specifying a particular function via `{\\\"name\":\\ \\\"my_function\\\"}` forces the\nmodel to call that function. `none` is the default when no functions are present. `auto` is the\ndefault if functions are present.",
      "Type": {
       "$id": "208",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "CreateChatCompletionRequestFunctionCall",
+      "VariantTypes": [
        {
         "$id": "209",
         "Kind": "constant",
@@ -1478,9 +1478,9 @@
      "Description": "Up to 4 sequences where the API will stop generating further tokens.",
      "Type": {
       "$id": "225",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "Stop",
+      "VariantTypes": [
        {
         "$id": "226",
         "Kind": "string",
@@ -1934,9 +1934,9 @@
         "Description": "The number of epochs to train the model for. An epoch refers to one full cycle through the\ntraining dataset.",
         "Type": {
          "$id": "285",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "CreateFineTuningJobRequestHyperparametersNEpochs",
+         "VariantTypes": [
           {
            "$id": "286",
            "Kind": "constant",
@@ -2128,9 +2128,9 @@
         "Description": "The number of epochs to train the model for. An epoch refers to one full cycle through the\ntraining dataset.\n\n\"Auto\" decides the optimal number of epochs based on the size of the dataset. If setting the\nnumber manually, we support any number between 1 and 50 epochs.",
         "Type": {
          "$id": "312",
-         "Kind": "Union",
-         "Name": "Union",
-         "UnionItemTypes": [
+         "Kind": "union",
+         "Name": "FineTuningJobHyperparametersNEpochs",
+         "VariantTypes": [
           {
            "$id": "313",
            "Kind": "constant",
@@ -2479,9 +2479,9 @@
      "Description": "The prompt(s) to generate completions for, encoded as a string, array of strings, array of\ntokens, or array of token arrays.\n\nNote that <|endoftext|> is the document separator that the model sees during training, so if a\nprompt is not specified the model will generate as if from the beginning of a new document.",
      "Type": {
       "$id": "359",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "Prompt",
+      "VariantTypes": [
        {
         "$id": "360",
         "Kind": "string",
@@ -2604,9 +2604,9 @@
      "Description": "Up to 4 sequences where the API will stop generating further tokens.",
      "Type": {
       "$id": "379",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "Stop",
+      "VariantTypes": [
        {
         "$id": "380",
         "Kind": "string",
@@ -3232,9 +3232,9 @@
      "Description": "Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a\nsingle request, pass an array of strings or array of token arrays. Each input must not exceed\nthe max input tokens for the model (8191 tokens for `text-embedding-ada-002`) and cannot be an empty string.\n[Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)\nfor counting tokens.",
      "Type": {
       "$id": "466",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "CreateEmbeddingRequestInput",
+      "VariantTypes": [
        {
         "$id": "467",
         "Kind": "string",
@@ -4844,9 +4844,9 @@
      "Description": "The input text to classify",
      "Type": {
       "$id": "685",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "CreateModerationRequestInput",
+      "VariantTypes": [
        {
         "$id": "686",
         "Kind": "string",

--- a/test/UnbrandedProjects/Unbranded-TypeSpec/src/Generated/tspCodeModel.json
+++ b/test/UnbrandedProjects/Unbranded-TypeSpec/src/Generated/tspCodeModel.json
@@ -415,9 +415,9 @@
      "Description": "required Union",
      "Type": {
       "$id": "63",
-      "Kind": "Union",
-      "Name": "Union",
-      "UnionItemTypes": [
+      "Kind": "union",
+      "Name": "ThingRequiredUnion",
+      "VariantTypes": [
        {
         "$id": "64",
         "Kind": "string",


### PR DESCRIPTION
Fixes #4785 

# Description

This PR consolidates the shape of our InputUnionType with the shape of `SdkUnionType` in TCGC

An exception is that in TCGC, the `SdkUnionType` has `values` to represent the sibling types, which does not really make sense (see [this issue](https://github.com/Azure/typespec-azure/issues/933)), therefore here we name it as `VariantTypes`.
And when TCGC decides to change it or not to change it, we could align when it happens.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first