### PR TITLE
Skip "Type" from output properties of XXXResourceData

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -56,8 +56,7 @@ namespace AutoRest.CSharp.Mgmt.Output
         protected override IEnumerable<ObjectTypeProperty> BuildProperties()
         {
             var parentProperties = GetParentPropertyNames();
-            var properties = base.BuildProperties().ToArray();
-            foreach (var property in properties)
+            foreach (var property in base.BuildProperties())
             {
                 if (!parentProperties.Contains(property.Declaration.Name))
                 {

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -49,8 +49,14 @@ namespace AutoRest.CSharp.Mgmt.Output
             return EnumerateHierarchy()
                 .Skip(1)
                 .SelectMany(type => type.Properties)
-                .Select(p => p.Declaration.Name)
+                .Select(p => isResourceType(p) ? "Type" : p.Declaration.Name)
                 .ToHashSet();
+
+            // In common-types, "Type" is a property for "ResourceType"
+            // In ResourceData, this property is named as "ResourceType"
+            // Return "Type" as property name for it to skip it in the output properties
+            bool isResourceType(ObjectTypeProperty property)
+                => property.Declaration.Type.Name == "ResourceType" && property.Declaration.Name == "ResourceType";
         }
 
         protected override IEnumerable<ObjectTypeProperty> BuildProperties()

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -63,8 +63,8 @@ namespace AutoRest.CSharp.Mgmt.Output
                 {
                     var propertyType = CreatePropertyType(property);
 
-                    // If "type" property is "ResourceType" and the current output model inherits ResourceData
-                    // skip it since it is same as ResourceData.ResourceType
+                    // If "type" property is "ResourceType" and the current output model inherits ResourceData, skip it since it is same as ResourceData.ResourceType
+                    // This only applies for TypeSpec input, for swagger input we have renamed "type" to "resourceType"in FrameworkTypeUpdater.ValidateAndUpdate
                     if (property.SerializedName == "type" && property?.ValueType.Name == "ResourceType" && Inherits?.Name == "ResourceData")
                     {
                         continue;

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtObjectType.cs
@@ -52,8 +52,8 @@ namespace AutoRest.CSharp.Mgmt.Output
                 .Select(p => isResourceType(p) ? "Type" : p.Declaration.Name)
                 .ToHashSet();
 
-            // In common-types, "Type" is a property for "ResourceType"
-            // In ResourceData, this property is named as "ResourceType"
+            // In common-types, "type" is a property to represent resource type
+            // In ResourceManager.ResourceData, this property is named as "ResourceType"
             // Return "Type" as property name for it to skip it in the output properties
             bool isResourceType(ObjectTypeProperty property)
                 => property.Declaration.Type.Name == "ResourceType" && property.Declaration.Name == "ResourceType";


### PR DESCRIPTION
For `XXXResourceData`, property `type` is same as `ResourceData.ResourceType` in inherits, we should skip it.