### PR TITLE
Support void type body

### DIFF
--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
@@ -104,14 +104,14 @@ export function loadOperation(
 
     if (
         typespecParameters.body?.parameter &&
-        !isVoidBody(typespecParameters.body.type)
+        !isVoidType(typespecParameters.body.type)
     ) {
         parameters.push(
             loadBodyParameter(sdkContext, typespecParameters.body?.parameter)
         );
     } else if (
         typespecParameters.body?.type &&
-        !isVoidBody(typespecParameters.body.type)
+        !isVoidType(typespecParameters.body.type)
     ) {
         const effectiveBodyType = getEffectiveSchemaType(
             sdkContext,
@@ -255,7 +255,7 @@ export function loadOperation(
         GenerateConvenienceMethod: generateConvenience
     } as InputOperation;
 
-    function isVoidBody(type: Type): boolean {
+    function isVoidType(type: Type): boolean {
         return type.kind === "Intrinsic" && type.name === "void";
     }
 

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib/operation.ts
@@ -17,7 +17,8 @@ import {
     Model,
     ModelProperty,
     Namespace,
-    Operation
+    Operation,
+    Type
 } from "@typespec/compiler";
 import { getResourceOperation } from "@typespec/rest";
 import {
@@ -101,11 +102,17 @@ export function loadOperation(
         parameters.push(loadOperationParameter(sdkContext, p));
     }
 
-    if (typespecParameters.body?.parameter) {
+    if (
+        typespecParameters.body?.parameter &&
+        !isVoidBody(typespecParameters.body.type)
+    ) {
         parameters.push(
             loadBodyParameter(sdkContext, typespecParameters.body?.parameter)
         );
-    } else if (typespecParameters.body?.type) {
+    } else if (
+        typespecParameters.body?.type &&
+        !isVoidBody(typespecParameters.body.type)
+    ) {
         const effectiveBodyType = getEffectiveSchemaType(
             sdkContext,
             typespecParameters.body.type
@@ -247,6 +254,10 @@ export function loadOperation(
         GenerateProtocolMethod: generateProtocol,
         GenerateConvenienceMethod: generateConvenience
     } as InputOperation;
+
+    function isVoidBody(type: Type): boolean {
+        return type.kind === "Intrinsic" && type.name === "void";
+    }
 
     function loadOperationParameter(
         context: SdkContext<NetEmitterOptions>,


### PR DESCRIPTION
We cannot support such tsp whose body is a `void`
```
register is ArmResourceActionSync<ExtendedZone, void, ExtendedZone>;
```