### PR TITLE
Fix the question mark issue in `ClientUriBuilder` for SCM libraries

### DIFF
--- a/src/AutoRest.CSharp/Common/Output/Models/Types/HelperTypeProviders/System/ClientUriBuilderProvider.cs
+++ b/src/AutoRest.CSharp/Common/Output/Models/Types/HelperTypeProviders/System/ClientUriBuilderProvider.cs
@@ -222,9 +222,10 @@ namespace AutoRest.CSharp.Output.Models.Types.System
                 Argument.AssertNotNullOrWhiteSpace(name),
                 Argument.AssertNotNullOrWhiteSpace(value),
                 EmptyLine,
-                new IfElseStatement(Equal(queryBuilder.Length, Int(0)),
-                    queryBuilder.Append(Literal('?')),
-                    queryBuilder.Append(Literal('&'))),
+                new IfStatement(GreaterThan(queryBuilder.Length, Int(0)))
+                {
+                    queryBuilder.Append(Literal('&'))
+                },
                 EmptyLine,
                 new IfStatement(escape)
                 {

--- a/test/CadlRanchProjectsNonAzure/authentication/api-key/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/authentication/api-key/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Authentication.ApiKey
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/authentication/http/custom/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/authentication/http/custom/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Authentication.Http.Custom
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/client/naming/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/client/naming/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Client.Naming
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/parameters/body-optionality/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/parameters/body-optionality/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Parameters.BodyOptionality
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/parameters/spread/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/parameters/spread/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Parameters.Spread
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/payload/content-negotiation/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/payload/content-negotiation/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Payload.ContentNegotiation
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/payload/multipart/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/payload/multipart/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Payload.MultiPart
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/serialization/encoded-name/json/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/serialization/encoded-name/json/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Serialization.EncodedName.Json
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/server/endpoint/not-defined/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/server/endpoint/not-defined/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.Server.Endpoint.NotDefined
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/special-words/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/special-words/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm.SpecialWords
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/array/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/array/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type._Array
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/dictionary/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/dictionary/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type._Dictionary
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/enum/extensible/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/enum/extensible/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type._Enum.Extensible
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/enum/fixed/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/enum/fixed/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type._Enum.Fixed
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/model/empty/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/empty/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Model.Empty
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/enum-discriminator/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/enum-discriminator/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Model.Inheritance.EnumDiscriminator
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/not-discriminated/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/not-discriminated/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Model.Inheritance.NotDiscriminated
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/recursive/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/recursive/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Model.Inheritance.Recursive
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/single-discriminator/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/single-discriminator/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Model.Inheritance.SingleDiscriminator
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/model/usage/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/model/usage/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Model.Usage
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/property/additional-properties/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/property/additional-properties/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Property.AdditionalProperties
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/property/nullable/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/property/nullable/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Property.Nullable
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/property/optionality/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/property/optionality/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Property.Optionality
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/property/value-types/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/property/value-types/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Property.ValueTypes
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/scalar/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/scalar/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Scalar
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/CadlRanchProjectsNonAzure/type/union/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/CadlRanchProjectsNonAzure/type/union/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace Scm._Type.Union
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/UnbrandedProjects/Customized-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/UnbrandedProjects/Customized-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace CustomizedTypeSpec
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace NoDocsUnbrandedTypeSpec
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/UnbrandedProjects/NoTest-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/UnbrandedProjects/NoTest-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace NoTestTypeSpec
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace OpenAI
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }

--- a/test/UnbrandedProjects/Unbranded-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
+++ b/test/UnbrandedProjects/Unbranded-TypeSpec/src/Generated/Internal/ClientUriBuilder.cs
@@ -105,11 +105,7 @@ namespace UnbrandedTypeSpec
             Argument.AssertNotNullOrWhiteSpace(name, nameof(name));
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
-            if (QueryBuilder.Length == 0)
-            {
-                QueryBuilder.Append('?');
-            }
-            else
+            if (QueryBuilder.Length > 0)
             {
                 QueryBuilder.Append('&');
             }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/4815

# Description

As stated here: https://learn.microsoft.com/en-us/dotnet/api/system.uribuilder.query?view=net-8.0#remarks
A question mark will always be added in .Net framework
A question mark will be added if absent in .Net 5.0 or higher
Therefore we are taking the way that both versions could be happy: let the uriBuilder to add the question mark.

We did not find the issue because despite we have test cases for `ClientUriBuilder` which cover quite a few scenarios, but it only runs on net7.0. We need to make the test cases to run on multiple platforms.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first