### PR TITLE
Pin typespec-autorest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8898,7 +8898,7 @@
         "json-serialize-refs": "0.1.0-0"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.42.1 <1.0.0",
+        "@azure-tools/typespec-autorest": "0.42.1",
         "@azure-tools/typespec-azure-core": "0.42.0",
         "@azure-tools/typespec-azure-resource-manager": "0.42.1",
         "@azure-tools/typespec-azure-rulesets": "0.42.1",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -54,7 +54,7 @@
         "@azure-tools/typespec-client-generator-core": "0.42.3",
         "@azure-tools/typespec-azure-resource-manager": "0.42.1",
         "@azure-tools/typespec-azure-rulesets": "0.42.1",
-        "@azure-tools/typespec-autorest": ">=0.42.1 <1.0.0",
+        "@azure-tools/typespec-autorest": "0.42.1",
         "@eslint/js": "^9.2.0",
         "@types/lodash.isequal": "^4.5.6",
         "@types/mocha": "~9.1.0",


### PR DESCRIPTION
To prevent version conflicts in emitter-package.json, we need to pin all floating peer dependencies