### PR TITLE
update the version of azure identity so that we do not have the annoying warning of 1.11.0 contains a security concern

### DIFF
--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <PackageReference Update="Azure.Identity" Version="1.11.0" />
+    <PackageReference Update="Azure.Identity" Version="1.11.4" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>


### PR DESCRIPTION
# Description

Bumps version of Azure.Identity to 1.11.4 to remove the warning.
![image](https://github.com/Azure/autorest.csharp/assets/10554446/e8be8415-d315-40e7-acd8-aae2faf171fe)


# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first