### PR TITLE
Fix npm list issue

### DIFF
--- a/eng/scripts/Initialize-Repository.ps1
+++ b/eng/scripts/Initialize-Repository.ps1
@@ -41,6 +41,7 @@ try {
         Write-Host "Using TypeSpec.Next"
         Invoke-LoggedCommand "npx -y @azure-tools/typespec-bump-deps@latest --add-npm-overrides package.json"
         Invoke-LoggedCommand "npx -y @azure-tools/typespec-bump-deps@latest --use-peer-ranges ./src/TypeSpec.Extension/Emitter.Csharp/package.json"
+        Invoke-LoggedCommand "npx -y @azure-tools/typespec-bump-deps@latest --add-npm-overrides ./test/UnbrandedProjects/package.json"
         Invoke-LoggedCommand "npm install"
     }
     else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,24 +2323,6 @@
         "@typespec/http": "~0.57.0"
       }
     },
-    "node_modules/@typespec/openapi3": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.57.0.tgz",
-      "integrity": "sha512-spNLzwCTduPISJBTWhqsMLTjuGC3Tdh/FVI1rTGnRunB7ZXjhRyz031o1bCe2BZeW1w1sacZGfe+ba8sXqgMxA==",
-      "dev": true,
-      "dependencies": {
-        "yaml": "~2.4.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0",
-        "@typespec/openapi": "~0.57.0",
-        "@typespec/versioning": "~0.57.0"
-      }
-    },
     "node_modules/@typespec/rest": {
       "version": "0.57.0",
       "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.57.0.tgz",
@@ -8190,8 +8172,7 @@
       "name": "@azure-tools/unbranded-tests",
       "dev": true,
       "devDependencies": {
-        "@typespec/openapi": "0.57.0",
-        "@typespec/openapi3": "0.57.0"
+        "@typespec/openapi": "0.57.0"
       }
     }
   },
@@ -8558,8 +8539,7 @@
     "@azure-tools/unbranded-tests": {
       "version": "file:test/UnbrandedProjects",
       "requires": {
-        "@typespec/openapi": "0.57.0",
-        "@typespec/openapi3": "0.57.0"
+        "@typespec/openapi": "0.57.0"
       }
     },
     "@azure/abort-controller": {
@@ -9760,15 +9740,6 @@
       "integrity": "sha512-35wK/BqjOXSlhWuGMwoYN3FSgIYFOKtw8ot4ErcgmxAGuKaS2GkUhZvtQJXUn2ByU0Fl4jqslPmTz8SEcz7rbw==",
       "dev": true,
       "requires": {}
-    },
-    "@typespec/openapi3": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.57.0.tgz",
-      "integrity": "sha512-spNLzwCTduPISJBTWhqsMLTjuGC3Tdh/FVI1rTGnRunB7ZXjhRyz031o1bCe2BZeW1w1sacZGfe+ba8sXqgMxA==",
-      "dev": true,
-      "requires": {
-        "yaml": "~2.4.2"
-      }
     },
     "@typespec/rest": {
       "version": "0.57.0",

--- a/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/completions/models.tsp
+++ b/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/completions/models.tsp
@@ -111,7 +111,6 @@ alias SharedCompletionProperties = {
   stream?: boolean | null = true;
 };
 
-@oneOf
 union Stop {
   string,
   StopSequences,
@@ -361,7 +360,6 @@ model CreateCompletionRequest {
   best_of?: safeint | null = 1;
 }
 
-@oneOf
 union Prompt {
   string,
   string[],

--- a/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/main.tsp
+++ b/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/main.tsp
@@ -1,5 +1,4 @@
 import "@typespec/http";
-import "@typespec/openapi3";
 import "@typespec/openapi";
 
 import "./audio";

--- a/test/UnbrandedProjects/package.json
+++ b/test/UnbrandedProjects/package.json
@@ -3,8 +3,7 @@
     "private": true,
     "description": "Preserve the dependencies for unbranded tests.",
     "devDependencies": {
-      "@typespec/openapi": "0.57.0",
-      "@typespec/openapi3": "0.57.0"
+      "@typespec/openapi": "0.57.0"
     }
   }
   


### PR DESCRIPTION
1. Nightly build reports error from "npm list -a" because we don't bump the version in ./test/UnbrandedProjects/package.json This PR is to fix it.
2. Remove `@typespec/openapi3` from test because if we want to bump version of ./test/UnbrandedProjects/package.json we need to add package opanaip3 to bump tool, which I got some feedback from [this](https://github.com/Azure/cadl-ranch/pull/633#issuecomment-2230203940).