### PR TITLE
Add `crossLanguageDefinitionId` for operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2271,9 +2271,8 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "0.1.9-alpha.20240731.6",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-0.1.9-alpha.20240731.6.tgz",
-      "integrity": "sha512-5tV2Xm4LKzdiPHh1MuWPgBGaXjYmXudjypd/1ReMf3My2SD7TocRSUE8BkI4KJ31aobotIHy2Yi3WsdSQyH5bw==",
+      "version": "0.1.9-alpha.20240801.3",
+      "resolved": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
       "dev": true,
       "dependencies": {
         "json-serialize-refs": "0.1.0-0"
@@ -8143,7 +8142,7 @@
       "license": "MIT",
       "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "0.1.9-alpha.20240731.6",
+        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
         "json-serialize-refs": "0.1.0-0"
       },
       "devDependencies": {
@@ -8556,7 +8555,7 @@
         "@types/prettier": "^2.6.3",
         "@typespec/compiler": "0.58.0",
         "@typespec/http": "0.58.0",
-        "@typespec/http-client-csharp": "0.1.9-alpha.20240731.6",
+        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
         "@typespec/json-schema": "0.58.0",
         "@typespec/library-linter": "0.58.0",
         "@typespec/openapi": "0.58.0",
@@ -9759,9 +9758,7 @@
       "requires": {}
     },
     "@typespec/http-client-csharp": {
-      "version": "0.1.9-alpha.20240731.6",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-0.1.9-alpha.20240731.6.tgz",
-      "integrity": "sha512-5tV2Xm4LKzdiPHh1MuWPgBGaXjYmXudjypd/1ReMf3My2SD7TocRSUE8BkI4KJ31aobotIHy2Yi3WsdSQyH5bw==",
+      "version": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
       "dev": true,
       "requires": {
         "json-serialize-refs": "0.1.0-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2271,20 +2271,20 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "0.1.9-alpha.20240801.3",
-      "resolved": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
+      "version": "0.1.9-alpha.20240804.3",
+      "resolved": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
       "dev": true,
       "dependencies": {
         "json-serialize-refs": "0.1.0-0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.36.0 <1.0.0",
-        "@typespec/compiler": ">=0.50.0 <1.0.0",
-        "@typespec/http": ">=0.50.0 <1.0.0",
-        "@typespec/openapi": ">=0.50.0 <1.0.0",
-        "@typespec/rest": ">=0.50.0 <1.0.0",
-        "@typespec/versioning": ">=0.50.0 <1.0.0"
+        "@azure-tools/typespec-azure-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.44.0 <1.0.0 || ~0.45.0-0 || ~0.46.0-0",
+        "@typespec/compiler": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+        "@typespec/http": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+        "@typespec/openapi": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+        "@typespec/rest": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0",
+        "@typespec/versioning": ">=0.58.0 <1.0.0 || ~0.59.0-0 || ~0.60.0-0"
       }
     },
     "node_modules/@typespec/json-schema": {
@@ -8142,7 +8142,7 @@
       "license": "MIT",
       "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
+        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
         "json-serialize-refs": "0.1.0-0"
       },
       "devDependencies": {
@@ -8555,7 +8555,7 @@
         "@types/prettier": "^2.6.3",
         "@typespec/compiler": "0.58.0",
         "@typespec/http": "0.58.0",
-        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
+        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
         "@typespec/json-schema": "0.58.0",
         "@typespec/library-linter": "0.58.0",
         "@typespec/openapi": "0.58.0",
@@ -9758,7 +9758,7 @@
       "requires": {}
     },
     "@typespec/http-client-csharp": {
-      "version": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz",
+      "version": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
       "dev": true,
       "requires": {
         "json-serialize-refs": "0.1.0-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2271,8 +2271,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "0.1.9-alpha.20240804.3",
-      "resolved": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
+      "version": "0.1.9-alpha.20240805.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-0.1.9-alpha.20240805.2.tgz",
+      "integrity": "sha512-okI6sFWIRNhZQL0DnhKnh9wQ6OD3FBjUkbmYzcV5pqiEuVPGEWYZrChJZmvH6G5AhUPQ2Nmsc4yHPqDCVwDlEw==",
       "dev": true,
       "dependencies": {
         "json-serialize-refs": "0.1.0-0"
@@ -8142,7 +8143,7 @@
       "license": "MIT",
       "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
+        "@typespec/http-client-csharp": "0.1.9-alpha.20240805.2",
         "json-serialize-refs": "0.1.0-0"
       },
       "devDependencies": {
@@ -8555,7 +8556,7 @@
         "@types/prettier": "^2.6.3",
         "@typespec/compiler": "0.58.0",
         "@typespec/http": "0.58.0",
-        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
+        "@typespec/http-client-csharp": "0.1.9-alpha.20240805.2",
         "@typespec/json-schema": "0.58.0",
         "@typespec/library-linter": "0.58.0",
         "@typespec/openapi": "0.58.0",
@@ -9758,7 +9759,9 @@
       "requires": {}
     },
     "@typespec/http-client-csharp": {
-      "version": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz",
+      "version": "0.1.9-alpha.20240805.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-0.1.9-alpha.20240805.2.tgz",
+      "integrity": "sha512-okI6sFWIRNhZQL0DnhKnh9wQ6OD3FBjUkbmYzcV5pqiEuVPGEWYZrChJZmvH6G5AhUPQ2Nmsc4yHPqDCVwDlEw==",
       "dev": true,
       "requires": {
         "json-serialize-refs": "0.1.0-0"

--- a/samples/AnomalyDetector/tspCodeModel.json
+++ b/samples/AnomalyDetector/tspCodeModel.json
@@ -2444,7 +2444,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Univariate.DetectUnivariateEntireSeries"
     },
     {
      "$id": "327",
@@ -2550,7 +2551,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Univariate.DetectUnivariateLastPoint"
     },
     {
      "$id": "336",
@@ -2656,7 +2658,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Univariate.DetectUnivariateChangePoint"
     }
    ],
    "Protocol": {
@@ -2805,7 +2808,8 @@
      "Path": "/multivariate/detect-batch/{resultId}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.GetMultivariateBatchDetectionResult"
     },
     {
      "$id": "360",
@@ -2924,7 +2928,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.TrainMultivariateModel"
     },
     {
      "$id": "371",
@@ -3030,7 +3035,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.ListMultivariateModels"
     },
     {
      "$id": "381",
@@ -3106,7 +3112,8 @@
      "Path": "/multivariate/models/{modelId}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.DeleteMultivariateModel"
     },
     {
      "$id": "388",
@@ -3188,7 +3195,8 @@
      "Path": "/multivariate/models/{modelId}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.GetMultivariateModel"
     },
     {
      "$id": "395",
@@ -3338,7 +3346,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.DetectMultivariateBatchAnomaly"
     },
     {
      "$id": "410",
@@ -3463,7 +3472,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AnomalyDetector.Multivariate.DetectMultivariateLastAnomaly"
     }
    ],
    "Protocol": {

--- a/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
@@ -154,7 +154,7 @@ namespace AutoRest.CSharp.Common.Input
                 paging: CreateOperationPaging(serviceRequest, operation),
                 generateProtocolMethod: true,
                 generateConvenienceMethod: false,
-                crossLanguageDefinitionId: GetCrossLanguageDefinitionId(operation),
+                crossLanguageDefinitionId: string.Empty, // in typespec input, this is to determine whether an operation has been renamed. We have separated configuration for that in swagger input, therefore we leave it empty here
                 keepClientDefaultValue: operationId is null ? false : Configuration.MethodsToKeepClientDefaultValue.Contains(operationId))
             {
                 SpecName = operation.Language.Default.SerializedName ?? operation.Language.Default.Name
@@ -742,24 +742,6 @@ namespace AutoRest.CSharp.Common.Input
         {
             var ns = schema.Extensions?.Namespace;
             var name = schema.Language.Default.Name;
-            if (ns == null)
-            {
-                return name;
-            }
-
-            return $"{ns}.{name}";
-        }
-
-        private static string GetCrossLanguageDefinitionId(Operation operation)
-        {
-            if (operation.OperationId != null)
-            {
-                return operation.OperationId.Replace('_', '.'); // borrow the operation id as the cross language definition id here since it should be unique as well across all operations.
-            }
-
-            var ns = operation.Extensions?.Namespace;
-            var name = operation.Language.Default.Name;
-
             if (ns == null)
             {
                 return name;

--- a/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/CodeModelConverter.cs
@@ -154,6 +154,7 @@ namespace AutoRest.CSharp.Common.Input
                 paging: CreateOperationPaging(serviceRequest, operation),
                 generateProtocolMethod: true,
                 generateConvenienceMethod: false,
+                crossLanguageDefinitionId: GetCrossLanguageDefinitionId(operation),
                 keepClientDefaultValue: operationId is null ? false : Configuration.MethodsToKeepClientDefaultValue.Contains(operationId))
             {
                 SpecName = operation.Language.Default.SerializedName ?? operation.Language.Default.Name
@@ -741,6 +742,24 @@ namespace AutoRest.CSharp.Common.Input
         {
             var ns = schema.Extensions?.Namespace;
             var name = schema.Language.Default.Name;
+            if (ns == null)
+            {
+                return name;
+            }
+
+            return $"{ns}.{name}";
+        }
+
+        private static string GetCrossLanguageDefinitionId(Operation operation)
+        {
+            if (operation.OperationId != null)
+            {
+                return operation.OperationId.Replace('_', '.'); // borrow the operation id as the cross language definition id here since it should be unique as well across all operations.
+            }
+
+            var ns = operation.Extensions?.Namespace;
+            var name = operation.Language.Default.Name;
+
             if (ns == null)
             {
                 return name;

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/InputOperation.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/InputOperation.cs
@@ -154,4 +154,6 @@ internal record InputOperation
     public string OperationId => ResourceName is null ? Name : $"{ResourceName}_{Name.FirstCharToUpperCase()}";
     //TODO: Remove this until the SDK nullable is enabled, traking in https://github.com/Azure/autorest.csharp/issues/4780
     internal string SpecName { get; init; }
+
+    internal bool IsNameChanged { get; init; }
 }

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/InputOperation.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/InputOperation.cs
@@ -32,6 +32,7 @@ internal record InputOperation
     OperationPaging? paging,
     bool generateProtocolMethod,
     bool generateConvenienceMethod,
+    string crossLanguageDefinitionId,
     bool keepClientDefaultValue)
     {
         Name = name;
@@ -54,6 +55,7 @@ internal record InputOperation
         Paging = paging;
         GenerateProtocolMethod = generateProtocolMethod;
         GenerateConvenienceMethod = generateConvenienceMethod;
+        CrossLanguageDefinitionId = crossLanguageDefinitionId;
         KeepClientDefaultValue = keepClientDefaultValue;
     }
 
@@ -77,6 +79,7 @@ internal record InputOperation
         paging: null,
         generateProtocolMethod: true,
         generateConvenienceMethod: false,
+        crossLanguageDefinitionId: string.Empty,
         keepClientDefaultValue: false)
     {
         SpecName = string.Empty;
@@ -104,6 +107,7 @@ internal record InputOperation
             operation.Paging,
             operation.GenerateProtocolMethod,
             operation.GenerateConvenienceMethod,
+            operation.CrossLanguageDefinitionId,
             operation.KeepClientDefaultValue)
         {
             SpecName = operation.SpecName
@@ -142,6 +146,7 @@ internal record InputOperation
     public OperationPaging? Paging { get; init; }
     public bool GenerateProtocolMethod { get; }
     public bool GenerateConvenienceMethod { get; }
+    public string CrossLanguageDefinitionId { get; }
     public bool KeepClientDefaultValue { get; }
     public string? OperationName { get; }
     public string? OperationVersion { get; }

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputOperationConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputOperationConverter.cs
@@ -105,14 +105,14 @@ namespace AutoRest.CSharp.Common.Input
 
             static bool IsNameChanged(string crossLanguageDefinitionId, string name)
             {
-                var span = crossLanguageDefinitionId.AsSpan();
-                int lastDotIndex = span.LastIndexOf('.');
+                int lastDotIndex = crossLanguageDefinitionId.LastIndexOf('.');
                 if (lastDotIndex < 0)
                 {
-                    return false;
+                    throw new JsonException($"The crossLanguageDefinitionId of {crossLanguageDefinitionId} does not contain a dot in it, this should be impossible to happen");
                 }
+                var span = crossLanguageDefinitionId.AsSpan(lastDotIndex + 1);
                 var nameSpan = name.AsSpan();
-                if (nameSpan.Equals(span.Slice(lastDotIndex + 1), StringComparison.Ordinal))
+                if (nameSpan.Equals(span, StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputOperationConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputOperationConverter.cs
@@ -93,12 +93,32 @@ namespace AutoRest.CSharp.Common.Input
             parameters = parameters ?? throw new JsonException("InputOperation must have parameters");
             responses = responses ?? throw new JsonException("InputOperation must have responses");
 
-            var inputOperation = new InputOperation(name, resourceName, summary, deprecated, description, accessibility, parameters, responses, httpMethod, requestBodyMediaType, uri, path, externalDocsUri, requestMediaTypes, bufferResponse, longRunning, paging, generateProtocolMethod, generateConvenienceMethod, crossLanguageDefinitionId, keepClientDefaultValue);
+            var inputOperation = new InputOperation(name, resourceName, summary, deprecated, description, accessibility, parameters, responses, httpMethod, requestBodyMediaType, uri, path, externalDocsUri, requestMediaTypes, bufferResponse, longRunning, paging, generateProtocolMethod, generateConvenienceMethod, crossLanguageDefinitionId, keepClientDefaultValue)
+            {
+                IsNameChanged = IsNameChanged(crossLanguageDefinitionId, name)
+            };
             if (id != null)
             {
                 resolver.AddReference(id, inputOperation);
             }
             return inputOperation;
+
+            static bool IsNameChanged(string crossLanguageDefinitionId, string name)
+            {
+                var span = crossLanguageDefinitionId.AsSpan();
+                int lastDotIndex = span.LastIndexOf('.');
+                if (lastDotIndex < 0)
+                {
+                    return false;
+                }
+                var nameSpan = name.AsSpan();
+                if (nameSpan.Equals(span.Slice(lastDotIndex + 1), StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputOperationConverter.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Serialization/TypeSpecInputOperationConverter.cs
@@ -47,6 +47,7 @@ namespace AutoRest.CSharp.Common.Input
             OperationPaging? paging = null;
             bool generateProtocolMethod = false;
             bool generateConvenienceMethod = false;
+            string? crossLanguageDefinitionId = null;
             bool keepClientDefaultValue = false;
 
             while (reader.TokenType != JsonTokenType.EndObject)
@@ -71,6 +72,7 @@ namespace AutoRest.CSharp.Common.Input
                     || reader.TryReadWithConverter(nameof(InputOperation.Paging), options, ref paging)
                     || reader.TryReadBoolean(nameof(InputOperation.GenerateProtocolMethod), ref generateProtocolMethod)
                     || reader.TryReadBoolean(nameof(InputOperation.GenerateConvenienceMethod), ref generateConvenienceMethod)
+                    || reader.TryReadString(nameof(InputOperation.CrossLanguageDefinitionId), ref crossLanguageDefinitionId)
                     || reader.TryReadBoolean(nameof(InputOperation.KeepClientDefaultValue), ref keepClientDefaultValue);
 
                 if (!isKnownProperty)
@@ -85,12 +87,13 @@ namespace AutoRest.CSharp.Common.Input
                 Console.Error.WriteLine($"[Warn]: InputOperation '{name}' does not have a description");
                 description = $"{name.Humanize()}.";
             }
+            crossLanguageDefinitionId = crossLanguageDefinitionId ?? throw new JsonException("InputOperation must have crossLanguageDefinitionId");
             uri = uri ?? throw new JsonException("InputOperation must have uri");
             path = path ?? throw new JsonException("InputOperation must have path");
             parameters = parameters ?? throw new JsonException("InputOperation must have parameters");
             responses = responses ?? throw new JsonException("InputOperation must have responses");
 
-            var inputOperation = new InputOperation(name, resourceName, summary, deprecated, description, accessibility, parameters, responses, httpMethod, requestBodyMediaType, uri, path, externalDocsUri, requestMediaTypes, bufferResponse, longRunning, paging, generateProtocolMethod, generateConvenienceMethod, keepClientDefaultValue);
+            var inputOperation = new InputOperation(name, resourceName, summary, deprecated, description, accessibility, parameters, responses, httpMethod, requestBodyMediaType, uri, path, externalDocsUri, requestMediaTypes, bufferResponse, longRunning, paging, generateProtocolMethod, generateConvenienceMethod, crossLanguageDefinitionId, keepClientDefaultValue);
             if (id != null)
             {
                 resolver.AddReference(id, inputOperation);

--- a/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
@@ -63,7 +63,36 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                     "OverrideOperationName", operation.Name, name);
                 return true;
             }
+
+            // TODO -- do we need a check for it is tsp input or not
+            if (IsNameChanged(operation))
+            {
+                name = operation.Name;
+                MgmtReport.Instance.TransformSection.AddTransformLogForApplyChange(
+                    new TransformItem(TransformTypeName.OverrideOperationName, operation.OperationId!, name),
+                    operation.GetFullSerializedName(),
+                    "OverrideOperationName", operation.Name, name);
+                return true;
+            }
+
             return false;
+
+            static bool IsNameChanged(InputOperation operation)
+            {
+                var span = operation.CrossLanguageDefinitionId.AsSpan();
+                int lastDotIndex = span.LastIndexOf('.');
+                if (lastDotIndex < 0)
+                {
+                    return false;
+                }
+                var nameSpan = operation.Name.AsSpan();
+                if (nameSpan.Equals(span.Slice(lastDotIndex + 1), StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         public static RequestPath GetRequestPath(this InputOperation operation, ResourceTypeSegment? hint = null)

--- a/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
+++ b/src/AutoRest.CSharp/Mgmt/Decorator/OperationExtensions.cs
@@ -64,8 +64,7 @@ namespace AutoRest.CSharp.Mgmt.Decorator
                 return true;
             }
 
-            // TODO -- do we need a check for it is tsp input or not
-            if (IsNameChanged(operation))
+            if (operation.IsNameChanged)
             {
                 name = operation.Name;
                 MgmtReport.Instance.TransformSection.AddTransformLogForApplyChange(
@@ -76,23 +75,6 @@ namespace AutoRest.CSharp.Mgmt.Decorator
             }
 
             return false;
-
-            static bool IsNameChanged(InputOperation operation)
-            {
-                var span = operation.CrossLanguageDefinitionId.AsSpan();
-                int lastDotIndex = span.LastIndexOf('.');
-                if (lastDotIndex < 0)
-                {
-                    return false;
-                }
-                var nameSpan = operation.Name.AsSpan();
-                if (nameSpan.Equals(span.Slice(lastDotIndex + 1), StringComparison.Ordinal))
-                {
-                    return false;
-                }
-
-                return true;
-            }
         }
 
         public static RequestPath GetRequestPath(this InputOperation operation, ResourceTypeSegment? hint = null)

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
         "json-serialize-refs": "0.1.0-0",
-        "@typespec/http-client-csharp": "0.1.9-alpha.20240731.6"
+        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz"
     },
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
         "json-serialize-refs": "0.1.0-0",
-        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAxNTMyMC9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240801.3.tgz"
+        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz"
     },
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
         "json-serialize-refs": "0.1.0-0",
-        "@typespec/http-client-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDAyMzA1NS9hcnRpZmFjdE5hbWUvYnVpbGRfYXJ0aWZhY3RzX2NzaGFycA2/content?format=file&subPath=%2fpackages%2ftypespec-http-client-csharp-0.1.9-alpha.20240804.3.tgz"
+        "@typespec/http-client-csharp": "0.1.9-alpha.20240805.2"
     },
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",

--- a/test/CadlRanchProjects/authentication/api-key/tspCodeModel.json
+++ b/test/CadlRanchProjects/authentication/api-key/tspCodeModel.json
@@ -89,7 +89,8 @@
      "Path": "/authentication/api-key/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.ApiKey.valid"
     },
     {
      "$id": "12",
@@ -142,7 +143,8 @@
      "Path": "/authentication/api-key/invalid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.ApiKey.invalid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/authentication/http/custom/tspCodeModel.json
+++ b/test/CadlRanchProjects/authentication/http/custom/tspCodeModel.json
@@ -89,7 +89,8 @@
      "Path": "/authentication/http/custom/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.Http.Custom.valid"
     },
     {
      "$id": "12",
@@ -142,7 +143,8 @@
      "Path": "/authentication/http/custom/invalid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.Http.Custom.invalid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/authentication/oauth2/tspCodeModel.json
+++ b/test/CadlRanchProjects/authentication/oauth2/tspCodeModel.json
@@ -89,7 +89,8 @@
      "Path": "/authentication/oauth2/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.OAuth2.valid"
     },
     {
      "$id": "12",
@@ -142,7 +143,8 @@
      "Path": "/authentication/oauth2/invalid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.OAuth2.invalid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/authentication/union/tspCodeModel.json
+++ b/test/CadlRanchProjects/authentication/union/tspCodeModel.json
@@ -65,7 +65,8 @@
      "Path": "/authentication/union/validkey",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.Union.validKey"
     },
     {
      "$id": "9",
@@ -95,7 +96,8 @@
      "Path": "/authentication/union/validtoken",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.Union.validToken"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/client-generator-core/access/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/client-generator-core/access/tspCodeModel.json
@@ -453,7 +453,8 @@
      "Path": "/azure/client-generator-core/access/publicOperation/noDecoratorInPublic",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.PublicOperation.noDecoratorInPublic"
     },
     {
      "$id": "56",
@@ -529,7 +530,8 @@
      "Path": "/azure/client-generator-core/access/publicOperation/publicDecoratorInPublic",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.PublicOperation.publicDecoratorInPublic"
     }
    ],
    "Protocol": {
@@ -647,7 +649,8 @@
      "Path": "/azure/client-generator-core/access/internalOperation/noDecoratorInInternal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.InternalOperation.noDecoratorInInternal"
     },
     {
      "$id": "76",
@@ -723,7 +726,8 @@
      "Path": "/azure/client-generator-core/access/internalOperation/internalDecoratorInInternal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.InternalOperation.internalDecoratorInInternal"
     },
     {
      "$id": "83",
@@ -799,7 +803,8 @@
      "Path": "/azure/client-generator-core/access/internalOperation/publicDecoratorInInternal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.InternalOperation.publicDecoratorInInternal"
     }
    ],
    "Protocol": {
@@ -917,7 +922,8 @@
      "Path": "/azure/client-generator-core/access/sharedModelInOperation/public",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.SharedModelInOperation.public"
     },
     {
      "$id": "103",
@@ -993,7 +999,8 @@
      "Path": "/azure/client-generator-core/access/sharedModelInOperation/internal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.SharedModelInOperation.internal"
     }
    ],
    "Protocol": {
@@ -1112,7 +1119,8 @@
      "Path": "/azure/client-generator-core/access/relativeModelInOperation/operation",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation.operation"
     },
     {
      "$id": "123",
@@ -1189,7 +1197,8 @@
      "Path": "/azure/client-generator-core/access/relativeModelInOperation/discriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Access.RelativeModelInOperation.discriminator"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/client-generator-core/usage/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/client-generator-core/usage/tspCodeModel.json
@@ -264,7 +264,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Usage.ModelInOperation.inputToInputOutput"
     },
     {
      "$id": "33",
@@ -323,7 +324,8 @@
      "Path": "/azure/client-generator-core/usage/outputToInputOutput",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Usage.ModelInOperation.outputToInputOutput"
     },
     {
      "$id": "38",
@@ -424,7 +426,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.ClientGenerator.Core.Usage.ModelInOperation.modelInReadOnlyProperty"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/core/basic/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/core/basic/tspCodeModel.json
@@ -637,7 +637,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.createOrUpdate"
     },
     {
      "$id": "79",
@@ -803,7 +804,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.createOrReplace"
     },
     {
      "$id": "95",
@@ -911,7 +913,8 @@
      "Path": "/azure/core/basic/users/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.get"
     },
     {
      "$id": "106",
@@ -1156,7 +1159,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.list"
     },
     {
      "$id": "133",
@@ -1249,7 +1253,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.listWithPage"
     },
     {
      "$id": "143",
@@ -1401,7 +1406,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.listWithParameters"
     },
     {
      "$id": "158",
@@ -1494,7 +1500,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.listWithCustomPageModel"
     },
     {
      "$id": "168",
@@ -1596,7 +1603,8 @@
      "Path": "/azure/core/basic/users/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.delete"
     },
     {
      "$id": "179",
@@ -1723,7 +1731,8 @@
      "Path": "/azure/core/basic/users/{id}:export",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.export"
     }
    ],
    "Protocol": {
@@ -1857,7 +1866,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.TwoModelsAsPageItem.listFirstItem"
     },
     {
      "$id": "208",
@@ -1950,7 +1960,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Basic.TwoModelsAsPageItem.listSecondItem"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/core/lro/standard/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/core/lro/standard/tspCodeModel.json
@@ -678,7 +678,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Lro.Standard.createOrReplace"
     },
     {
      "$id": "82",
@@ -816,7 +817,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Lro.Standard.delete"
     },
     {
      "$id": "98",
@@ -977,7 +979,8 @@
       "ResultPath": "result"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Lro.Standard.export"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/core/model/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/core/model/tspCodeModel.json
@@ -198,7 +198,8 @@
      "Path": "/azure/core/model/embeddingVector",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Model.AzureCoreEmbeddingVector.get"
     },
     {
      "$id": "27",
@@ -280,7 +281,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Model.AzureCoreEmbeddingVector.put"
     },
     {
      "$id": "35",
@@ -382,7 +384,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Model.AzureCoreEmbeddingVector.post"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/core/scalar/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/core/scalar/tspCodeModel.json
@@ -198,7 +198,8 @@
      "Path": "/azure/core/scalar/azureLocation",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Scalar.AzureLocationScalar.get"
     },
     {
      "$id": "27",
@@ -280,7 +281,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Scalar.AzureLocationScalar.put"
     },
     {
      "$id": "35",
@@ -382,7 +384,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Scalar.AzureLocationScalar.post"
     },
     {
      "$id": "44",
@@ -437,7 +440,8 @@
      "Path": "/azure/core/scalar/azureLocation/header",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Scalar.AzureLocationScalar.header"
     },
     {
      "$id": "49",
@@ -492,7 +496,8 @@
      "Path": "/azure/core/scalar/azureLocation/query",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Scalar.AzureLocationScalar.query"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/core/traits/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/core/traits/tspCodeModel.json
@@ -460,7 +460,8 @@
      "Path": "/azure/core/traits/user/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Traits.smokeTest"
     },
     {
      "$id": "58",
@@ -665,7 +666,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "_Specs_.Azure.Core.Traits.repeatableAction"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/resource-manager/models/common-types/managed-identity/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/resource-manager/models/common-types/managed-identity/tspCodeModel.json
@@ -886,7 +886,8 @@
      "Path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/{managedIdentityTrackedResourceName}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.CommonTypes.ManagedIdentity.ManagedIdentityTrackedResources.get"
     },
     {
      "$id": "113",
@@ -1089,7 +1090,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.CommonTypes.ManagedIdentity.ManagedIdentityTrackedResources.createWithSystemAssigned"
     },
     {
      "$id": "133",
@@ -1277,7 +1279,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.CommonTypes.ManagedIdentity.ManagedIdentityTrackedResources.updateWithUserAssignedAndSystemAssigned"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/resource-manager/models/resources/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/resource-manager/models/resources/tspCodeModel.json
@@ -944,7 +944,8 @@
      "Path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/{topLevelTrackedResourceName}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.TopLevelTrackedResources.get"
     },
     {
      "$id": "119",
@@ -1192,7 +1193,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.TopLevelTrackedResources.createOrReplace"
     },
     {
      "$id": "146",
@@ -1434,7 +1436,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.TopLevelTrackedResources.update"
     },
     {
      "$id": "173",
@@ -1624,7 +1627,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.TopLevelTrackedResources.delete"
     },
     {
      "$id": "196",
@@ -1761,7 +1765,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.TopLevelTrackedResources.listByResourceGroup"
     },
     {
      "$id": "211",
@@ -1879,7 +1884,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.TopLevelTrackedResources.listBySubscription"
     }
    ],
    "Protocol": {
@@ -2091,7 +2097,8 @@
      "Path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/{topLevelTrackedResourceName}/nestedProxyResources/{nextedProxyResourceName}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.NestedProxyResources.get"
     },
     {
      "$id": "248",
@@ -2358,7 +2365,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.NestedProxyResources.createOrReplace"
     },
     {
      "$id": "277",
@@ -2619,7 +2627,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.NestedProxyResources.update"
     },
     {
      "$id": "306",
@@ -2828,7 +2837,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.NestedProxyResources.delete"
     },
     {
      "$id": "331",
@@ -2984,7 +2994,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.ResourceManager.Models.Resources.NestedProxyResources.listByTopLevelTrackedResource"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/azure/special-headers/client-request-id/tspCodeModel.json
+++ b/test/CadlRanchProjects/azure/special-headers/client-request-id/tspCodeModel.json
@@ -83,7 +83,8 @@
      "Path": "/azure/special-headers/x-ms-client-request-id/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Azure.SpecialHeaders.XmsClientRequestId.get"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/client/naming/tspCodeModel.json
+++ b/test/CadlRanchProjects/client/naming/tspCodeModel.json
@@ -228,7 +228,8 @@
      "Path": "/client/naming/operation",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.operation"
     },
     {
      "$id": "31",
@@ -275,7 +276,8 @@
      "Path": "/client/naming/parameter",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.parameter"
     },
     {
      "$id": "35",
@@ -346,7 +348,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Property.client"
     },
     {
      "$id": "41",
@@ -417,7 +420,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Property.language"
     },
     {
      "$id": "47",
@@ -488,7 +492,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Property.compatibleWithEncodedName"
     },
     {
      "$id": "53",
@@ -535,7 +540,8 @@
      "Path": "/client/naming/header",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Header.request"
     },
     {
      "$id": "57",
@@ -576,7 +582,8 @@
      "Path": "/client/naming/header",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Header.response"
     }
    ],
    "Protocol": {
@@ -688,7 +695,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Model.client"
     },
     {
      "$id": "73",
@@ -759,7 +767,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Model.language"
     }
    ],
    "Protocol": {
@@ -872,7 +881,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.UnionEnum.unionEnumName"
     },
     {
      "$id": "91",
@@ -943,7 +953,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.UnionEnum.unionEnumMemberName"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/client/structure/default/tspCodeModel.json
+++ b/test/CadlRanchProjects/client/structure/default/tspCodeModel.json
@@ -110,7 +110,8 @@
      "Path": "/one",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.one"
     },
     {
      "$id": "14",
@@ -142,7 +143,8 @@
      "Path": "/two",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.two"
     }
    ],
    "Protocol": {
@@ -274,7 +276,8 @@
      "Path": "/seven",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Baz.Foo.seven"
     }
    ],
    "Protocol": {
@@ -357,7 +360,8 @@
      "Path": "/eight",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Qux.eight"
     }
    ],
    "Protocol": {
@@ -440,7 +444,8 @@
      "Path": "/nine",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Qux.Bar.nine"
     }
    ],
    "Protocol": {
@@ -523,7 +528,8 @@
      "Path": "/three",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Foo.three"
     },
     {
      "$id": "49",
@@ -555,7 +561,8 @@
      "Path": "/four",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Foo.four"
     }
    ],
    "Protocol": {
@@ -638,7 +645,8 @@
      "Path": "/five",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Bar.five"
     },
     {
      "$id": "58",
@@ -670,7 +678,8 @@
      "Path": "/six",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.Service.Bar.six"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/client/structure/multi-client/tspCodeModel.json
+++ b/test/CadlRanchProjects/client/structure/multi-client/tspCodeModel.json
@@ -109,7 +109,8 @@
      "Path": "/one",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.MultiClient.ClientA.renamedOne"
     },
     {
      "$id": "14",
@@ -141,7 +142,8 @@
      "Path": "/three",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.MultiClient.ClientA.renamedThree"
     },
     {
      "$id": "16",
@@ -173,7 +175,8 @@
      "Path": "/five",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.MultiClient.ClientA.renamedFive"
     }
    ],
    "Protocol": {
@@ -255,7 +258,8 @@
      "Path": "/two",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.MultiClient.ClientB.renamedTwo"
     },
     {
      "$id": "25",
@@ -287,7 +291,8 @@
      "Path": "/four",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.MultiClient.ClientB.renamedFour"
     },
     {
      "$id": "27",
@@ -319,7 +324,8 @@
      "Path": "/six",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.MultiClient.ClientB.renamedSix"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/client/structure/renamed-operation/tspCodeModel.json
+++ b/test/CadlRanchProjects/client/structure/renamed-operation/tspCodeModel.json
@@ -109,7 +109,8 @@
      "Path": "/one",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.RenamedOperation.renamedOne"
     },
     {
      "$id": "14",
@@ -141,7 +142,8 @@
      "Path": "/three",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.RenamedOperation.renamedThree"
     },
     {
      "$id": "16",
@@ -173,7 +175,8 @@
      "Path": "/five",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.RenamedOperation.renamedFive"
     }
    ],
    "Protocol": {
@@ -255,7 +258,8 @@
      "Path": "/two",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.RenamedOperation.Group.renamedTwo"
     },
     {
      "$id": "25",
@@ -287,7 +291,8 @@
      "Path": "/four",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.RenamedOperation.Group.renamedFour"
     },
     {
      "$id": "27",
@@ -319,7 +324,8 @@
      "Path": "/six",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.RenamedOperation.Group.renamedSix"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/client/structure/two-operation-group/tspCodeModel.json
+++ b/test/CadlRanchProjects/client/structure/two-operation-group/tspCodeModel.json
@@ -158,7 +158,8 @@
      "Path": "/one",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.TwoOperationGroup.Group1.one"
     },
     {
      "$id": "19",
@@ -190,7 +191,8 @@
      "Path": "/three",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.TwoOperationGroup.Group1.three"
     },
     {
      "$id": "21",
@@ -222,7 +224,8 @@
      "Path": "/four",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.TwoOperationGroup.Group1.four"
     }
    ],
    "Protocol": {
@@ -305,7 +308,8 @@
      "Path": "/two",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.TwoOperationGroup.Group2.two"
     },
     {
      "$id": "30",
@@ -337,7 +341,8 @@
      "Path": "/five",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.TwoOperationGroup.Group2.five"
     },
     {
      "$id": "32",
@@ -369,7 +374,8 @@
      "Path": "/six",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Structure.TwoOperationGroup.Group2.six"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/encode/bytes/tspCodeModel.json
+++ b/test/CadlRanchProjects/encode/bytes/tspCodeModel.json
@@ -233,7 +233,8 @@
      "Path": "/encode/bytes/query/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Query.default"
     },
     {
      "$id": "31",
@@ -281,7 +282,8 @@
      "Path": "/encode/bytes/query/base64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Query.base64"
     },
     {
      "$id": "35",
@@ -329,7 +331,8 @@
      "Path": "/encode/bytes/query/base64url",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Query.base64url"
     },
     {
      "$id": "39",
@@ -391,7 +394,8 @@
      "Path": "/encode/bytes/query/base64url-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Query.base64urlArray"
     }
    ],
    "Protocol": {
@@ -533,7 +537,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Property.default"
     },
     {
      "$id": "60",
@@ -633,7 +638,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Property.base64"
     },
     {
      "$id": "69",
@@ -733,7 +739,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Property.base64url"
     },
     {
      "$id": "78",
@@ -833,7 +840,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Property.base64urlArray"
     }
    ],
    "Protocol": {
@@ -923,7 +931,8 @@
      "Path": "/encode/bytes/header/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Header.default"
     },
     {
      "$id": "97",
@@ -971,7 +980,8 @@
      "Path": "/encode/bytes/header/base64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Header.base64"
     },
     {
      "$id": "101",
@@ -1019,7 +1029,8 @@
      "Path": "/encode/bytes/header/base64url",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Header.base64url"
     },
     {
      "$id": "105",
@@ -1081,7 +1092,8 @@
      "Path": "/encode/bytes/header/base64url-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.Header.base64urlArray"
     }
    ],
    "Protocol": {
@@ -1198,7 +1210,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.RequestBody.default"
     },
     {
      "$id": "124",
@@ -1272,7 +1285,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.RequestBody.octetStream"
     },
     {
      "$id": "131",
@@ -1346,7 +1360,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.RequestBody.customContentType"
     },
     {
      "$id": "138",
@@ -1421,7 +1436,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.RequestBody.base64"
     },
     {
      "$id": "145",
@@ -1496,7 +1512,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.RequestBody.base64url"
     }
    ],
    "Protocol": {
@@ -1600,7 +1617,8 @@
      "Path": "/encode/bytes/body/response/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.ResponseBody.default"
     },
     {
      "$id": "164",
@@ -1679,7 +1697,8 @@
      "Path": "/encode/bytes/body/response/octet-stream",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.ResponseBody.octetStream"
     },
     {
      "$id": "173",
@@ -1758,7 +1777,8 @@
      "Path": "/encode/bytes/body/response/custom-content-type",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.ResponseBody.customContentType"
     },
     {
      "$id": "182",
@@ -1820,7 +1840,8 @@
      "Path": "/encode/bytes/body/response/base64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.ResponseBody.base64"
     },
     {
      "$id": "188",
@@ -1889,7 +1910,8 @@
      "Path": "/encode/bytes/body/response/base64url",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Bytes.ResponseBody.base64url"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/encode/datetime/tspCodeModel.json
+++ b/test/CadlRanchProjects/encode/datetime/tspCodeModel.json
@@ -299,7 +299,8 @@
      "Path": "/encode/datetime/query/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Query.default"
     },
     {
      "$id": "41",
@@ -353,7 +354,8 @@
      "Path": "/encode/datetime/query/rfc3339",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Query.rfc3339"
     },
     {
      "$id": "46",
@@ -407,7 +409,8 @@
      "Path": "/encode/datetime/query/rfc7231",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Query.rfc7231"
     },
     {
      "$id": "51",
@@ -461,7 +464,8 @@
      "Path": "/encode/datetime/query/unix-timestamp",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Query.unixTimestamp"
     },
     {
      "$id": "56",
@@ -535,7 +539,8 @@
      "Path": "/encode/datetime/query/unix-timestamp-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Query.unixTimestampArray"
     }
    ],
    "Protocol": {
@@ -677,7 +682,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Property.default"
     },
     {
      "$id": "79",
@@ -777,7 +783,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Property.rfc3339"
     },
     {
      "$id": "88",
@@ -877,7 +884,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Property.rfc7231"
     },
     {
      "$id": "97",
@@ -977,7 +985,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Property.unixTimestamp"
     },
     {
      "$id": "106",
@@ -1077,7 +1086,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Property.unixTimestampArray"
     }
    ],
    "Protocol": {
@@ -1173,7 +1183,8 @@
      "Path": "/encode/datetime/header/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Header.default"
     },
     {
      "$id": "126",
@@ -1227,7 +1238,8 @@
      "Path": "/encode/datetime/header/rfc3339",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Header.rfc3339"
     },
     {
      "$id": "131",
@@ -1281,7 +1293,8 @@
      "Path": "/encode/datetime/header/rfc7231",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Header.rfc7231"
     },
     {
      "$id": "136",
@@ -1335,7 +1348,8 @@
      "Path": "/encode/datetime/header/unix-timestamp",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Header.unixTimestamp"
     },
     {
      "$id": "141",
@@ -1409,7 +1423,8 @@
      "Path": "/encode/datetime/header/unix-timestamp-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.Header.unixTimestampArray"
     }
    ],
    "Protocol": {
@@ -1499,7 +1514,8 @@
      "Path": "/encode/datetime/responseheader/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.ResponseHeader.default"
     },
     {
      "$id": "160",
@@ -1547,7 +1563,8 @@
      "Path": "/encode/datetime/responseheader/rfc3339",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.ResponseHeader.rfc3339"
     },
     {
      "$id": "165",
@@ -1595,7 +1612,8 @@
      "Path": "/encode/datetime/responseheader/rfc7231",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.ResponseHeader.rfc7231"
     },
     {
      "$id": "170",
@@ -1643,7 +1661,8 @@
      "Path": "/encode/datetime/responseheader/unix-timestamp",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Datetime.ResponseHeader.unixTimestamp"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/encode/duration/tspCodeModel.json
+++ b/test/CadlRanchProjects/encode/duration/tspCodeModel.json
@@ -329,7 +329,8 @@
      "Path": "/encode/duration/query/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Query.default"
     },
     {
      "$id": "45",
@@ -383,7 +384,8 @@
      "Path": "/encode/duration/query/iso8601",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Query.iso8601"
     },
     {
      "$id": "50",
@@ -437,7 +439,8 @@
      "Path": "/encode/duration/query/int32-seconds",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Query.int32Seconds"
     },
     {
      "$id": "55",
@@ -491,7 +494,8 @@
      "Path": "/encode/duration/query/float-seconds",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Query.floatSeconds"
     },
     {
      "$id": "60",
@@ -545,7 +549,8 @@
      "Path": "/encode/duration/query/float64-seconds",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Query.float64Seconds"
     },
     {
      "$id": "65",
@@ -619,7 +624,8 @@
      "Path": "/encode/duration/query/int32-seconds-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Query.int32SecondsArray"
     }
    ],
    "Protocol": {
@@ -761,7 +767,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Property.default"
     },
     {
      "$id": "88",
@@ -861,7 +868,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Property.iso8601"
     },
     {
      "$id": "97",
@@ -961,7 +969,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Property.int32Seconds"
     },
     {
      "$id": "106",
@@ -1061,7 +1070,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Property.floatSeconds"
     },
     {
      "$id": "115",
@@ -1161,7 +1171,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Property.float64Seconds"
     },
     {
      "$id": "124",
@@ -1261,7 +1272,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Property.floatSecondsArray"
     }
    ],
    "Protocol": {
@@ -1357,7 +1369,8 @@
      "Path": "/encode/duration/header/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Header.default"
     },
     {
      "$id": "144",
@@ -1411,7 +1424,8 @@
      "Path": "/encode/duration/header/iso8601",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Header.iso8601"
     },
     {
      "$id": "149",
@@ -1485,7 +1499,8 @@
      "Path": "/encode/duration/header/iso8601-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Header.iso8601Array"
     },
     {
      "$id": "157",
@@ -1539,7 +1554,8 @@
      "Path": "/encode/duration/header/int32-seconds",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Header.int32Seconds"
     },
     {
      "$id": "162",
@@ -1593,7 +1609,8 @@
      "Path": "/encode/duration/header/float-seconds",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Header.floatSeconds"
     },
     {
      "$id": "167",
@@ -1647,7 +1664,8 @@
      "Path": "/encode/duration/header/float64-seconds",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Encode.Duration.Header.float64Seconds"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/parameters/body-optionality/tspCodeModel.json
+++ b/test/CadlRanchProjects/parameters/body-optionality/tspCodeModel.json
@@ -153,7 +153,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.requiredExplicit"
     },
     {
      "$id": "19",
@@ -224,7 +225,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.requiredImplicit"
     }
    ],
    "Protocol": {
@@ -336,7 +338,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.OptionalExplicit.set"
     },
     {
      "$id": "37",
@@ -407,7 +410,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.OptionalExplicit.omit"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/parameters/collection-format/tspCodeModel.json
+++ b/test/CadlRanchProjects/parameters/collection-format/tspCodeModel.json
@@ -129,7 +129,8 @@
      "Path": "/parameters/collection-format/query/multi",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.CollectionFormat.Query.multi"
     },
     {
      "$id": "18",
@@ -184,7 +185,8 @@
      "Path": "/parameters/collection-format/query/ssv",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.CollectionFormat.Query.ssv"
     },
     {
      "$id": "23",
@@ -239,7 +241,8 @@
      "Path": "/parameters/collection-format/query/tsv",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.CollectionFormat.Query.tsv"
     },
     {
      "$id": "28",
@@ -294,7 +297,8 @@
      "Path": "/parameters/collection-format/query/pipes",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.CollectionFormat.Query.pipes"
     },
     {
      "$id": "33",
@@ -349,7 +353,8 @@
      "Path": "/parameters/collection-format/query/csv",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.CollectionFormat.Query.csv"
     }
    ],
    "Protocol": {
@@ -446,7 +451,8 @@
      "Path": "/parameters/collection-format/header/csv",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.CollectionFormat.Header.csv"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/parameters/spread/tspCodeModel.json
+++ b/test/CadlRanchProjects/parameters/spread/tspCodeModel.json
@@ -400,7 +400,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadAsRequestBody"
     },
     {
      "$id": "53",
@@ -471,7 +472,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequestOnlyWithBody"
     },
     {
      "$id": "59",
@@ -536,7 +538,8 @@
      "Path": "/parameters/spread/model/composite-request-without-body/{name}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequestWithoutBody"
     },
     {
      "$id": "65",
@@ -643,7 +646,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequest"
     },
     {
      "$id": "75",
@@ -750,7 +754,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequestMix"
     }
    ],
    "Protocol": {
@@ -863,7 +868,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadAsRequestBody"
     },
     {
      "$id": "97",
@@ -970,7 +976,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadParameterWithInnerModel"
     },
     {
      "$id": "107",
@@ -1077,7 +1084,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadAsRequestParameter"
     },
     {
      "$id": "117",
@@ -1184,7 +1192,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadWithMultipleParameters"
     },
     {
      "$id": "127",
@@ -1292,7 +1301,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadParameterWithInnerAlias"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/payload/content-negotiation/tspCodeModel.json
+++ b/test/CadlRanchProjects/payload/content-negotiation/tspCodeModel.json
@@ -179,7 +179,8 @@
      "Path": "/content-negotiation/same-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.SameBody.getAvatarAsPng"
     },
     {
      "$id": "25",
@@ -258,7 +259,8 @@
      "Path": "/content-negotiation/same-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.SameBody.getAvatarAsJpeg"
     }
    ],
    "Protocol": {
@@ -379,7 +381,8 @@
      "Path": "/content-negotiation/different-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.DifferentBody.getAvatarAsPng"
     },
     {
      "$id": "49",
@@ -454,7 +457,8 @@
      "Path": "/content-negotiation/different-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.DifferentBody.getAvatarAsJson"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/payload/media-type/tspCodeModel.json
+++ b/test/CadlRanchProjects/payload/media-type/tspCodeModel.json
@@ -148,7 +148,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MediaType.StringBody.sendAsText"
     },
     {
      "$id": "20",
@@ -226,7 +227,8 @@
      "Path": "/payload/media-type/string-body/getAsText",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MediaType.StringBody.getAsText"
     },
     {
      "$id": "29",
@@ -299,7 +301,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MediaType.StringBody.sendAsJson"
     },
     {
      "$id": "36",
@@ -377,7 +380,8 @@
      "Path": "/payload/media-type/string-body/getAsJson",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MediaType.StringBody.getAsJson"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/payload/multipart/tspCodeModel.json
+++ b/test/CadlRanchProjects/payload/multipart/tspCodeModel.json
@@ -478,7 +478,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.basic"
     },
     {
      "$id": "61",
@@ -549,7 +550,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.complex"
     },
     {
      "$id": "67",
@@ -620,7 +622,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.jsonPart"
     },
     {
      "$id": "73",
@@ -691,7 +694,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.binaryArrayParts"
     },
     {
      "$id": "79",
@@ -762,7 +766,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.jsonArrayParts"
     },
     {
      "$id": "85",
@@ -833,7 +838,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.multiBinaryParts"
     },
     {
      "$id": "91",
@@ -904,7 +910,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.checkFileNameAndContentType"
     },
     {
      "$id": "97",
@@ -975,7 +982,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.anonymousModel"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/payload/pageable/tspCodeModel.json
+++ b/test/CadlRanchProjects/payload/pageable/tspCodeModel.json
@@ -190,7 +190,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.Pageable.list"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/serialization/encoded-name/json/tspCodeModel.json
+++ b/test/CadlRanchProjects/serialization/encoded-name/json/tspCodeModel.json
@@ -170,7 +170,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Serialization.EncodedName.Json.Property.send"
     },
     {
      "$id": "22",
@@ -228,7 +229,8 @@
      "Path": "/serialization/encoded-name/json/property",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Serialization.EncodedName.Json.Property.get"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/server/endpoint/not-defined/tspCodeModel.json
+++ b/test/CadlRanchProjects/server/endpoint/not-defined/tspCodeModel.json
@@ -54,7 +54,8 @@
      "Path": "/server/endpoint/not-defined/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Endpoint.NotDefined.valid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/server/path/multiple/tspCodeModel.json
+++ b/test/CadlRanchProjects/server/path/multiple/tspCodeModel.json
@@ -108,7 +108,8 @@
      "Path": "/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Path.Multiple.noOperationParams"
     },
     {
      "$id": "13",
@@ -158,7 +159,8 @@
      "Path": "/{keyword}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Path.Multiple.withOperationPathParam"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/server/path/single-headAsBoolean/tspCodeModel.json
+++ b/test/CadlRanchProjects/server/path/single-headAsBoolean/tspCodeModel.json
@@ -55,7 +55,8 @@
      "Path": "/server/path/single/myOp",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Path.Single.myOp"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/server/path/single/tspCodeModel.json
+++ b/test/CadlRanchProjects/server/path/single/tspCodeModel.json
@@ -55,7 +55,8 @@
      "Path": "/server/path/single/myOp",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Path.Single.myOp"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/server/versions/not-versioned/tspCodeModel.json
+++ b/test/CadlRanchProjects/server/versions/not-versioned/tspCodeModel.json
@@ -55,7 +55,8 @@
      "Path": "/server/versions/not-versioned/without-api-version",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.NotVersioned.withoutApiVersion"
     },
     {
      "$id": "7",
@@ -102,7 +103,8 @@
      "Path": "/server/versions/not-versioned/with-query-api-version",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.NotVersioned.withQueryApiVersion"
     },
     {
      "$id": "11",
@@ -149,7 +151,8 @@
      "Path": "/server/versions/not-versioned/with-path-api-version/{apiVersion}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.NotVersioned.withPathApiVersion"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/server/versions/versioned/tspCodeModel.json
+++ b/test/CadlRanchProjects/server/versions/versioned/tspCodeModel.json
@@ -88,7 +88,8 @@
      "Path": "/server/versions/versioned/without-api-version",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.Versioned.withoutApiVersion"
     },
     {
      "$id": "11",
@@ -145,7 +146,8 @@
      "Path": "/server/versions/versioned/with-query-api-version",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.Versioned.withQueryApiVersion"
     },
     {
      "$id": "17",
@@ -202,7 +204,8 @@
      "Path": "/server/versions/versioned/with-path-api-version/{apiVersion}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.Versioned.withPathApiVersion"
     },
     {
      "$id": "23",
@@ -259,7 +262,8 @@
      "Path": "/server/versions/versioned/with-query-old-api-version",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Versions.Versioned.withQueryOldApiVersion"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/special-headers/conditional-request/tspCodeModel.json
+++ b/test/CadlRanchProjects/special-headers/conditional-request/tspCodeModel.json
@@ -84,7 +84,8 @@
      "Path": "/special-headers/conditional-request/if-match",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialHeaders.ConditionalRequest.postIfMatch"
     },
     {
      "$id": "11",
@@ -133,7 +134,8 @@
      "Path": "/special-headers/conditional-request/if-none-match",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialHeaders.ConditionalRequest.postIfNoneMatch"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/special-headers/repeatability/tspCodeModel.json
+++ b/test/CadlRanchProjects/special-headers/repeatability/tspCodeModel.json
@@ -145,7 +145,8 @@
      "Path": "/special-headers/repeatability/immediateSuccess",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialHeaders.Repeatability.immediateSuccess"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/special-words/tspCodeModel.json
+++ b/test/CadlRanchProjects/special-words/tspCodeModel.json
@@ -930,7 +930,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAnd"
     },
     {
      "$id": "121",
@@ -1001,7 +1002,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAs"
     },
     {
      "$id": "127",
@@ -1072,7 +1074,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAssert"
     },
     {
      "$id": "133",
@@ -1143,7 +1146,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAsync"
     },
     {
      "$id": "139",
@@ -1214,7 +1218,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAwait"
     },
     {
      "$id": "145",
@@ -1285,7 +1290,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withBreak"
     },
     {
      "$id": "151",
@@ -1356,7 +1362,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withClass"
     },
     {
      "$id": "157",
@@ -1427,7 +1434,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withConstructor"
     },
     {
      "$id": "163",
@@ -1498,7 +1506,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withContinue"
     },
     {
      "$id": "169",
@@ -1569,7 +1578,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withDef"
     },
     {
      "$id": "175",
@@ -1640,7 +1650,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withDel"
     },
     {
      "$id": "181",
@@ -1711,7 +1722,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withElif"
     },
     {
      "$id": "187",
@@ -1782,7 +1794,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withElse"
     },
     {
      "$id": "193",
@@ -1853,7 +1866,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withExcept"
     },
     {
      "$id": "199",
@@ -1924,7 +1938,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withExec"
     },
     {
      "$id": "205",
@@ -1995,7 +2010,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withFinally"
     },
     {
      "$id": "211",
@@ -2066,7 +2082,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withFor"
     },
     {
      "$id": "217",
@@ -2137,7 +2154,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withFrom"
     },
     {
      "$id": "223",
@@ -2208,7 +2226,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withGlobal"
     },
     {
      "$id": "229",
@@ -2279,7 +2298,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withIf"
     },
     {
      "$id": "235",
@@ -2350,7 +2370,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withImport"
     },
     {
      "$id": "241",
@@ -2421,7 +2442,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withIn"
     },
     {
      "$id": "247",
@@ -2492,7 +2514,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withIs"
     },
     {
      "$id": "253",
@@ -2563,7 +2586,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withLambda"
     },
     {
      "$id": "259",
@@ -2634,7 +2658,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withNot"
     },
     {
      "$id": "265",
@@ -2705,7 +2730,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withOr"
     },
     {
      "$id": "271",
@@ -2776,7 +2802,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withPass"
     },
     {
      "$id": "277",
@@ -2847,7 +2874,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withRaise"
     },
     {
      "$id": "283",
@@ -2918,7 +2946,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withReturn"
     },
     {
      "$id": "289",
@@ -2989,7 +3018,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withTry"
     },
     {
      "$id": "295",
@@ -3060,7 +3090,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withWhile"
     },
     {
      "$id": "301",
@@ -3131,7 +3162,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withWith"
     },
     {
      "$id": "307",
@@ -3202,7 +3234,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withYield"
     }
    ],
    "Protocol": {
@@ -3316,7 +3349,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.ModelProperties.sameAsModel"
     }
    ],
    "Protocol": {
@@ -3388,7 +3422,8 @@
      "Path": "/special-words/operations/and",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.and"
     },
     {
      "$id": "333",
@@ -3417,7 +3452,8 @@
      "Path": "/special-words/operations/as",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.as"
     },
     {
      "$id": "335",
@@ -3446,7 +3482,8 @@
      "Path": "/special-words/operations/assert",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.assert"
     },
     {
      "$id": "337",
@@ -3475,7 +3512,8 @@
      "Path": "/special-words/operations/async",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.async"
     },
     {
      "$id": "339",
@@ -3504,7 +3542,8 @@
      "Path": "/special-words/operations/await",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.await"
     },
     {
      "$id": "341",
@@ -3533,7 +3572,8 @@
      "Path": "/special-words/operations/break",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.break"
     },
     {
      "$id": "343",
@@ -3562,7 +3602,8 @@
      "Path": "/special-words/operations/class",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.class"
     },
     {
      "$id": "345",
@@ -3591,7 +3632,8 @@
      "Path": "/special-words/operations/constructor",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.constructor"
     },
     {
      "$id": "347",
@@ -3620,7 +3662,8 @@
      "Path": "/special-words/operations/continue",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.continue"
     },
     {
      "$id": "349",
@@ -3649,7 +3692,8 @@
      "Path": "/special-words/operations/def",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.def"
     },
     {
      "$id": "351",
@@ -3678,7 +3722,8 @@
      "Path": "/special-words/operations/del",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.del"
     },
     {
      "$id": "353",
@@ -3707,7 +3752,8 @@
      "Path": "/special-words/operations/elif",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.elif"
     },
     {
      "$id": "355",
@@ -3736,7 +3782,8 @@
      "Path": "/special-words/operations/else",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.else"
     },
     {
      "$id": "357",
@@ -3765,7 +3812,8 @@
      "Path": "/special-words/operations/except",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.except"
     },
     {
      "$id": "359",
@@ -3794,7 +3842,8 @@
      "Path": "/special-words/operations/exec",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.exec"
     },
     {
      "$id": "361",
@@ -3823,7 +3872,8 @@
      "Path": "/special-words/operations/finally",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.finally"
     },
     {
      "$id": "363",
@@ -3852,7 +3902,8 @@
      "Path": "/special-words/operations/for",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.for"
     },
     {
      "$id": "365",
@@ -3881,7 +3932,8 @@
      "Path": "/special-words/operations/from",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.from"
     },
     {
      "$id": "367",
@@ -3910,7 +3962,8 @@
      "Path": "/special-words/operations/global",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.global"
     },
     {
      "$id": "369",
@@ -3939,7 +3992,8 @@
      "Path": "/special-words/operations/if",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.if"
     },
     {
      "$id": "371",
@@ -3968,7 +4022,8 @@
      "Path": "/special-words/operations/import",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.import"
     },
     {
      "$id": "373",
@@ -3997,7 +4052,8 @@
      "Path": "/special-words/operations/in",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.in"
     },
     {
      "$id": "375",
@@ -4026,7 +4082,8 @@
      "Path": "/special-words/operations/is",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.is"
     },
     {
      "$id": "377",
@@ -4055,7 +4112,8 @@
      "Path": "/special-words/operations/lambda",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.lambda"
     },
     {
      "$id": "379",
@@ -4084,7 +4142,8 @@
      "Path": "/special-words/operations/not",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.not"
     },
     {
      "$id": "381",
@@ -4113,7 +4172,8 @@
      "Path": "/special-words/operations/or",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.or"
     },
     {
      "$id": "383",
@@ -4142,7 +4202,8 @@
      "Path": "/special-words/operations/pass",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.pass"
     },
     {
      "$id": "385",
@@ -4171,7 +4232,8 @@
      "Path": "/special-words/operations/raise",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.raise"
     },
     {
      "$id": "387",
@@ -4200,7 +4262,8 @@
      "Path": "/special-words/operations/return",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.return"
     },
     {
      "$id": "389",
@@ -4229,7 +4292,8 @@
      "Path": "/special-words/operations/try",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.try"
     },
     {
      "$id": "391",
@@ -4258,7 +4322,8 @@
      "Path": "/special-words/operations/while",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.while"
     },
     {
      "$id": "393",
@@ -4287,7 +4352,8 @@
      "Path": "/special-words/operations/with",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.with"
     },
     {
      "$id": "395",
@@ -4316,7 +4382,8 @@
      "Path": "/special-words/operations/yield",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.yield"
     }
    ],
    "Protocol": {
@@ -4406,7 +4473,8 @@
      "Path": "/special-words/parameters/and",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAnd"
     },
     {
      "$id": "407",
@@ -4453,7 +4521,8 @@
      "Path": "/special-words/parameters/as",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAs"
     },
     {
      "$id": "411",
@@ -4500,7 +4569,8 @@
      "Path": "/special-words/parameters/assert",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAssert"
     },
     {
      "$id": "415",
@@ -4547,7 +4617,8 @@
      "Path": "/special-words/parameters/async",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAsync"
     },
     {
      "$id": "419",
@@ -4594,7 +4665,8 @@
      "Path": "/special-words/parameters/await",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAwait"
     },
     {
      "$id": "423",
@@ -4641,7 +4713,8 @@
      "Path": "/special-words/parameters/break",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withBreak"
     },
     {
      "$id": "427",
@@ -4688,7 +4761,8 @@
      "Path": "/special-words/parameters/class",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withClass"
     },
     {
      "$id": "431",
@@ -4735,7 +4809,8 @@
      "Path": "/special-words/parameters/constructor",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withConstructor"
     },
     {
      "$id": "435",
@@ -4782,7 +4857,8 @@
      "Path": "/special-words/parameters/continue",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withContinue"
     },
     {
      "$id": "439",
@@ -4829,7 +4905,8 @@
      "Path": "/special-words/parameters/def",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withDef"
     },
     {
      "$id": "443",
@@ -4876,7 +4953,8 @@
      "Path": "/special-words/parameters/del",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withDel"
     },
     {
      "$id": "447",
@@ -4923,7 +5001,8 @@
      "Path": "/special-words/parameters/elif",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withElif"
     },
     {
      "$id": "451",
@@ -4970,7 +5049,8 @@
      "Path": "/special-words/parameters/else",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withElse"
     },
     {
      "$id": "455",
@@ -5017,7 +5097,8 @@
      "Path": "/special-words/parameters/except",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withExcept"
     },
     {
      "$id": "459",
@@ -5064,7 +5145,8 @@
      "Path": "/special-words/parameters/exec",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withExec"
     },
     {
      "$id": "463",
@@ -5111,7 +5193,8 @@
      "Path": "/special-words/parameters/finally",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withFinally"
     },
     {
      "$id": "467",
@@ -5158,7 +5241,8 @@
      "Path": "/special-words/parameters/for",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withFor"
     },
     {
      "$id": "471",
@@ -5205,7 +5289,8 @@
      "Path": "/special-words/parameters/from",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withFrom"
     },
     {
      "$id": "475",
@@ -5252,7 +5337,8 @@
      "Path": "/special-words/parameters/global",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withGlobal"
     },
     {
      "$id": "479",
@@ -5299,7 +5385,8 @@
      "Path": "/special-words/parameters/if",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withIf"
     },
     {
      "$id": "483",
@@ -5346,7 +5433,8 @@
      "Path": "/special-words/parameters/import",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withImport"
     },
     {
      "$id": "487",
@@ -5393,7 +5481,8 @@
      "Path": "/special-words/parameters/in",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withIn"
     },
     {
      "$id": "491",
@@ -5440,7 +5529,8 @@
      "Path": "/special-words/parameters/is",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withIs"
     },
     {
      "$id": "495",
@@ -5487,7 +5577,8 @@
      "Path": "/special-words/parameters/lambda",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withLambda"
     },
     {
      "$id": "499",
@@ -5534,7 +5625,8 @@
      "Path": "/special-words/parameters/not",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withNot"
     },
     {
      "$id": "503",
@@ -5581,7 +5673,8 @@
      "Path": "/special-words/parameters/or",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withOr"
     },
     {
      "$id": "507",
@@ -5628,7 +5721,8 @@
      "Path": "/special-words/parameters/pass",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withPass"
     },
     {
      "$id": "511",
@@ -5675,7 +5769,8 @@
      "Path": "/special-words/parameters/raise",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withRaise"
     },
     {
      "$id": "515",
@@ -5722,7 +5817,8 @@
      "Path": "/special-words/parameters/return",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withReturn"
     },
     {
      "$id": "519",
@@ -5769,7 +5865,8 @@
      "Path": "/special-words/parameters/try",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withTry"
     },
     {
      "$id": "523",
@@ -5816,7 +5913,8 @@
      "Path": "/special-words/parameters/while",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withWhile"
     },
     {
      "$id": "527",
@@ -5863,7 +5961,8 @@
      "Path": "/special-words/parameters/with",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withWith"
     },
     {
      "$id": "531",
@@ -5910,7 +6009,8 @@
      "Path": "/special-words/parameters/yield",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withYield"
     },
     {
      "$id": "535",
@@ -5957,7 +6057,8 @@
      "Path": "/special-words/parameters/cancellationToken",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withCancellationToken"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/array/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/array/tspCodeModel.json
@@ -185,7 +185,8 @@
      "Path": "/type/array/int32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int32Value.get"
     },
     {
      "$id": "25",
@@ -265,7 +266,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int32Value.put"
     }
    ],
    "Protocol": {
@@ -375,7 +377,8 @@
      "Path": "/type/array/int64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int64Value.get"
     },
     {
      "$id": "46",
@@ -455,7 +458,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int64Value.put"
     }
    ],
    "Protocol": {
@@ -565,7 +569,8 @@
      "Path": "/type/array/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.BooleanValue.get"
     },
     {
      "$id": "67",
@@ -645,7 +650,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.BooleanValue.put"
     }
    ],
    "Protocol": {
@@ -755,7 +761,8 @@
      "Path": "/type/array/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.StringValue.get"
     },
     {
      "$id": "88",
@@ -835,7 +842,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.StringValue.put"
     }
    ],
    "Protocol": {
@@ -945,7 +953,8 @@
      "Path": "/type/array/float32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Float32Value.get"
     },
     {
      "$id": "109",
@@ -1025,7 +1034,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Float32Value.put"
     }
    ],
    "Protocol": {
@@ -1142,7 +1152,8 @@
      "Path": "/type/array/datetime",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DatetimeValue.get"
     },
     {
      "$id": "131",
@@ -1229,7 +1240,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DatetimeValue.put"
     }
    ],
    "Protocol": {
@@ -1346,7 +1358,8 @@
      "Path": "/type/array/duration",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DurationValue.get"
     },
     {
      "$id": "154",
@@ -1433,7 +1446,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DurationValue.put"
     }
    ],
    "Protocol": {
@@ -1543,7 +1557,8 @@
      "Path": "/type/array/unknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.UnknownValue.get"
     },
     {
      "$id": "176",
@@ -1623,7 +1638,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.UnknownValue.put"
     }
    ],
    "Protocol": {
@@ -1730,7 +1746,8 @@
      "Path": "/type/array/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.ModelValue.get"
     },
     {
      "$id": "196",
@@ -1807,7 +1824,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.ModelValue.put"
     }
    ],
    "Protocol": {
@@ -1921,7 +1939,8 @@
      "Path": "/type/array/nullable-float",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableFloatValue.get"
     },
     {
      "$id": "217",
@@ -2005,7 +2024,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableFloatValue.put"
     }
    ],
    "Protocol": {
@@ -2119,7 +2139,8 @@
      "Path": "/type/array/nullable-int32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableInt32Value.get"
     },
     {
      "$id": "240",
@@ -2203,7 +2224,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableInt32Value.put"
     }
    ],
    "Protocol": {
@@ -2317,7 +2339,8 @@
      "Path": "/type/array/nullable-boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableBooleanValue.get"
     },
     {
      "$id": "263",
@@ -2401,7 +2424,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableBooleanValue.put"
     }
    ],
    "Protocol": {
@@ -2515,7 +2539,8 @@
      "Path": "/type/array/nullable-string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableStringValue.get"
     },
     {
      "$id": "286",
@@ -2599,7 +2624,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableStringValue.put"
     }
    ],
    "Protocol": {
@@ -2710,7 +2736,8 @@
      "Path": "/type/array/nullable-model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableModelValue.get"
     },
     {
      "$id": "308",
@@ -2791,7 +2818,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableModelValue.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/dictionary/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/dictionary/tspCodeModel.json
@@ -193,7 +193,8 @@
      "Path": "/type/dictionary/int32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int32Value.get"
     },
     {
      "$id": "27",
@@ -277,7 +278,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int32Value.put"
     }
    ],
    "Protocol": {
@@ -391,7 +393,8 @@
      "Path": "/type/dictionary/int64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int64Value.get"
     },
     {
      "$id": "50",
@@ -475,7 +478,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int64Value.put"
     }
    ],
    "Protocol": {
@@ -589,7 +593,8 @@
      "Path": "/type/dictionary/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.BooleanValue.get"
     },
     {
      "$id": "73",
@@ -673,7 +678,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.BooleanValue.put"
     }
    ],
    "Protocol": {
@@ -787,7 +793,8 @@
      "Path": "/type/dictionary/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.StringValue.get"
     },
     {
      "$id": "96",
@@ -871,7 +878,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.StringValue.put"
     }
    ],
    "Protocol": {
@@ -985,7 +993,8 @@
      "Path": "/type/dictionary/float32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Float32Value.get"
     },
     {
      "$id": "119",
@@ -1069,7 +1078,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Float32Value.put"
     }
    ],
    "Protocol": {
@@ -1190,7 +1200,8 @@
      "Path": "/type/dictionary/datetime",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DatetimeValue.get"
     },
     {
      "$id": "143",
@@ -1281,7 +1292,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DatetimeValue.put"
     }
    ],
    "Protocol": {
@@ -1402,7 +1414,8 @@
      "Path": "/type/dictionary/duration",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DurationValue.get"
     },
     {
      "$id": "168",
@@ -1493,7 +1506,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DurationValue.put"
     }
    ],
    "Protocol": {
@@ -1607,7 +1621,8 @@
      "Path": "/type/dictionary/unknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.UnknownValue.get"
     },
     {
      "$id": "192",
@@ -1691,7 +1706,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.UnknownValue.put"
     }
    ],
    "Protocol": {
@@ -1802,7 +1818,8 @@
      "Path": "/type/dictionary/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.ModelValue.get"
     },
     {
      "$id": "214",
@@ -1883,7 +1900,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.ModelValue.put"
     }
    ],
    "Protocol": {
@@ -1994,7 +2012,8 @@
      "Path": "/type/dictionary/model/recursive",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.RecursiveModelValue.get"
     },
     {
      "$id": "235",
@@ -2075,7 +2094,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.RecursiveModelValue.put"
     }
    ],
    "Protocol": {
@@ -2193,7 +2213,8 @@
      "Path": "/type/dictionary/nullable-float",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.NullableFloatValue.get"
     },
     {
      "$id": "258",
@@ -2281,7 +2302,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.NullableFloatValue.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/enum/extensible/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/enum/extensible/tspCodeModel.json
@@ -192,7 +192,8 @@
      "Path": "/type/enum/extensible/string/known-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.getKnownValue"
     },
     {
      "$id": "27",
@@ -250,7 +251,8 @@
      "Path": "/type/enum/extensible/string/unknown-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.getUnknownValue"
     },
     {
      "$id": "32",
@@ -321,7 +323,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.putKnownValue"
     },
     {
      "$id": "38",
@@ -392,7 +395,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.putUnknownValue"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/enum/fixed/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/enum/fixed/tspCodeModel.json
@@ -193,7 +193,8 @@
      "Path": "/type/enum/fixed/string/known-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Fixed.String.getKnownValue"
     },
     {
      "$id": "27",
@@ -266,7 +267,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Fixed.String.putKnownValue"
     },
     {
      "$id": "33",
@@ -339,7 +341,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Fixed.String.putUnknownValue"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/empty/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/empty/tspCodeModel.json
@@ -134,7 +134,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Empty.putEmpty"
     },
     {
      "$id": "16",
@@ -192,7 +193,8 @@
      "Path": "/type/model/empty/alone",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Empty.getEmpty"
     },
     {
      "$id": "21",
@@ -292,7 +294,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Empty.postRoundTripEmpty"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/flatten/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/flatten/tspCodeModel.json
@@ -374,7 +374,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Flatten.putFlattenModel"
     },
     {
      "$id": "44",
@@ -474,7 +475,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Flatten.putNestedFlattenModel"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/inheritance/enum-discriminator/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/enum-discriminator/tspCodeModel.json
@@ -300,7 +300,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/extensible-enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getExtensibleModel"
     },
     {
      "$id": "36",
@@ -373,7 +374,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.putExtensibleModel"
     },
     {
      "$id": "42",
@@ -432,7 +434,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/extensible-enum/missingdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getExtensibleModelMissingDiscriminator"
     },
     {
      "$id": "47",
@@ -491,7 +494,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/extensible-enum/wrongdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getExtensibleModelWrongDiscriminator"
     },
     {
      "$id": "52",
@@ -550,7 +554,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/fixed-enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getFixedModel"
     },
     {
      "$id": "57",
@@ -623,7 +628,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.putFixedModel"
     },
     {
      "$id": "63",
@@ -682,7 +688,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/fixed-enum/missingdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getFixedModelMissingDiscriminator"
     },
     {
      "$id": "68",
@@ -741,7 +748,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/fixed-enum/wrongdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getFixedModelWrongDiscriminator"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/inheritance/not-discriminated/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/not-discriminated/tspCodeModel.json
@@ -185,7 +185,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.NotDiscriminated.postValid"
     },
     {
      "$id": "22",
@@ -243,7 +244,8 @@
      "Path": "/type/model/inheritance/not-discriminated/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.NotDiscriminated.getValid"
     },
     {
      "$id": "27",
@@ -343,7 +345,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.NotDiscriminated.putValid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/inheritance/recursive/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/recursive/tspCodeModel.json
@@ -161,7 +161,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.Recursive.put"
     },
     {
      "$id": "19",
@@ -219,7 +220,8 @@
      "Path": "/type/model/inheritance/recursive",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.Recursive.get"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/inheritance/single-discriminator/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/inheritance/single-discriminator/tspCodeModel.json
@@ -418,7 +418,8 @@
      "Path": "/type/model/inheritance/single-discriminator/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getModel"
     },
     {
      "$id": "50",
@@ -489,7 +490,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.putModel"
     },
     {
      "$id": "56",
@@ -547,7 +549,8 @@
      "Path": "/type/model/inheritance/single-discriminator/recursivemodel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getRecursiveModel"
     },
     {
      "$id": "61",
@@ -618,7 +621,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.putRecursiveModel"
     },
     {
      "$id": "67",
@@ -676,7 +680,8 @@
      "Path": "/type/model/inheritance/single-discriminator/missingdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getMissingDiscriminator"
     },
     {
      "$id": "72",
@@ -734,7 +739,8 @@
      "Path": "/type/model/inheritance/single-discriminator/wrongdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getWrongDiscriminator"
     },
     {
      "$id": "77",
@@ -792,7 +798,8 @@
      "Path": "/type/model/inheritance/single-discriminator/legacy-model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getLegacyModel"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/model/usage/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/model/usage/tspCodeModel.json
@@ -179,7 +179,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Usage.input"
     },
     {
      "$id": "22",
@@ -237,7 +238,8 @@
      "Path": "/type/model/usage/output",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Usage.output"
     },
     {
      "$id": "27",
@@ -337,7 +339,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Usage.inputAndOutput"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/property/additional-properties/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/property/additional-properties/tspCodeModel.json
@@ -1575,7 +1575,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordUnknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknown.get"
     },
     {
      "$id": "194",
@@ -1648,7 +1649,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknown.put"
     }
    ],
    "Protocol": {
@@ -1749,7 +1751,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordUnknownDerived",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDerived.get"
     },
     {
      "$id": "211",
@@ -1822,7 +1825,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDerived.put"
     }
    ],
    "Protocol": {
@@ -1923,7 +1927,8 @@
      "Path": "/type/property/additionalProperties/extendsUnknownDiscriminated",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDiscriminated.get"
     },
     {
      "$id": "228",
@@ -1996,7 +2001,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDiscriminated.put"
     }
    ],
    "Protocol": {
@@ -2097,7 +2103,8 @@
      "Path": "/type/property/additionalProperties/isRecordUnknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknown.get"
     },
     {
      "$id": "245",
@@ -2170,7 +2177,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknown.put"
     }
    ],
    "Protocol": {
@@ -2271,7 +2279,8 @@
      "Path": "/type/property/additionalProperties/isRecordUnknownDerived",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDerived.get"
     },
     {
      "$id": "262",
@@ -2344,7 +2353,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDerived.put"
     }
    ],
    "Protocol": {
@@ -2445,7 +2455,8 @@
      "Path": "/type/property/additionalProperties/isUnknownDiscriminated",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDiscriminated.get"
     },
     {
      "$id": "279",
@@ -2518,7 +2529,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDiscriminated.put"
     }
    ],
    "Protocol": {
@@ -2619,7 +2631,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsString.get"
     },
     {
      "$id": "296",
@@ -2692,7 +2705,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsString.put"
     }
    ],
    "Protocol": {
@@ -2793,7 +2807,8 @@
      "Path": "/type/property/additionalProperties/isRecordstring",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsString.get"
     },
     {
      "$id": "313",
@@ -2866,7 +2881,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsString.put"
     }
    ],
    "Protocol": {
@@ -2967,7 +2983,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadString.get"
     },
     {
      "$id": "330",
@@ -3040,7 +3057,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadString.put"
     }
    ],
    "Protocol": {
@@ -3141,7 +3159,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsFloat.get"
     },
     {
      "$id": "347",
@@ -3214,7 +3233,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsFloat.put"
     }
    ],
    "Protocol": {
@@ -3315,7 +3335,8 @@
      "Path": "/type/property/additionalProperties/isRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsFloat.get"
     },
     {
      "$id": "364",
@@ -3388,7 +3409,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsFloat.put"
     }
    ],
    "Protocol": {
@@ -3489,7 +3511,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadFloat.get"
     },
     {
      "$id": "381",
@@ -3562,7 +3585,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadFloat.put"
     }
    ],
    "Protocol": {
@@ -3663,7 +3687,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModel.get"
     },
     {
      "$id": "398",
@@ -3736,7 +3761,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModel.put"
     }
    ],
    "Protocol": {
@@ -3837,7 +3863,8 @@
      "Path": "/type/property/additionalProperties/isRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModel.get"
     },
     {
      "$id": "415",
@@ -3910,7 +3937,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModel.put"
     }
    ],
    "Protocol": {
@@ -4011,7 +4039,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModel.get"
     },
     {
      "$id": "432",
@@ -4084,7 +4113,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModel.put"
     }
    ],
    "Protocol": {
@@ -4185,7 +4215,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModelArray.get"
     },
     {
      "$id": "449",
@@ -4258,7 +4289,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModelArray.put"
     }
    ],
    "Protocol": {
@@ -4359,7 +4391,8 @@
      "Path": "/type/property/additionalProperties/isRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModelArray.get"
     },
     {
      "$id": "466",
@@ -4432,7 +4465,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModelArray.put"
     }
    ],
    "Protocol": {
@@ -4533,7 +4567,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModelArray.get"
     },
     {
      "$id": "483",
@@ -4606,7 +4641,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModelArray.put"
     }
    ],
    "Protocol": {
@@ -4707,7 +4743,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentString.get"
     },
     {
      "$id": "500",
@@ -4780,7 +4817,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentString.put"
     }
    ],
    "Protocol": {
@@ -4881,7 +4919,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentFloat.get"
     },
     {
      "$id": "517",
@@ -4954,7 +4993,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentFloat.put"
     }
    ],
    "Protocol": {
@@ -5055,7 +5095,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModel.get"
     },
     {
      "$id": "534",
@@ -5128,7 +5169,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModel.put"
     }
    ],
    "Protocol": {
@@ -5229,7 +5271,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModelArray.get"
     },
     {
      "$id": "551",
@@ -5302,7 +5345,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModelArray.put"
     }
    ],
    "Protocol": {
@@ -5403,7 +5447,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadString.get"
     },
     {
      "$id": "568",
@@ -5476,7 +5521,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadString.put"
     }
    ],
    "Protocol": {
@@ -5577,7 +5623,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadFloat.get"
     },
     {
      "$id": "585",
@@ -5650,7 +5697,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadFloat.put"
     }
    ],
    "Protocol": {
@@ -5751,7 +5799,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModel.get"
     },
     {
      "$id": "602",
@@ -5824,7 +5873,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModel.put"
     }
    ],
    "Protocol": {
@@ -5925,7 +5975,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModelArray.get"
     },
     {
      "$id": "619",
@@ -5998,7 +6049,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModelArray.put"
     }
    ],
    "Protocol": {
@@ -6099,7 +6151,8 @@
      "Path": "/type/property/additionalProperties/multipleSpreadRecord",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.MultipleSpread.get"
     },
     {
      "$id": "636",
@@ -6172,7 +6225,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.MultipleSpread.put"
     }
    ],
    "Protocol": {
@@ -6273,7 +6327,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordUnion",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordUnion.get"
     },
     {
      "$id": "653",
@@ -6346,7 +6401,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordUnion.put"
     }
    ],
    "Protocol": {
@@ -6447,7 +6503,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordDiscriminatedUnion",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordDiscriminatedUnion.get"
     },
     {
      "$id": "670",
@@ -6520,7 +6577,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordDiscriminatedUnion.put"
     }
    ],
    "Protocol": {
@@ -6621,7 +6679,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordNonDiscriminatedUnion",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion.get"
     },
     {
      "$id": "687",
@@ -6694,7 +6753,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion.put"
     }
    ],
    "Protocol": {
@@ -6795,7 +6855,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordNonDiscriminatedUnion2",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion2.get"
     },
     {
      "$id": "704",
@@ -6868,7 +6929,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion2.put"
     }
    ],
    "Protocol": {
@@ -6969,7 +7031,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordNonDiscriminatedUnion3",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion3.get"
     },
     {
      "$id": "721",
@@ -7042,7 +7105,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion3.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/property/nullable/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/property/nullable/tspCodeModel.json
@@ -484,7 +484,8 @@
      "Path": "/type/property/nullable/string/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.getNonNull"
     },
     {
      "$id": "67",
@@ -543,7 +544,8 @@
      "Path": "/type/property/nullable/string/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.getNull"
     },
     {
      "$id": "72",
@@ -615,7 +617,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.patchNonNull"
     },
     {
      "$id": "78",
@@ -687,7 +690,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.patchNull"
     }
    ],
    "Protocol": {
@@ -788,7 +792,8 @@
      "Path": "/type/property/nullable/bytes/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.getNonNull"
     },
     {
      "$id": "95",
@@ -847,7 +852,8 @@
      "Path": "/type/property/nullable/bytes/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.getNull"
     },
     {
      "$id": "100",
@@ -919,7 +925,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.patchNonNull"
     },
     {
      "$id": "106",
@@ -991,7 +998,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.patchNull"
     }
    ],
    "Protocol": {
@@ -1092,7 +1100,8 @@
      "Path": "/type/property/nullable/datetime/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.getNonNull"
     },
     {
      "$id": "123",
@@ -1151,7 +1160,8 @@
      "Path": "/type/property/nullable/datetime/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.getNull"
     },
     {
      "$id": "128",
@@ -1223,7 +1233,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.patchNonNull"
     },
     {
      "$id": "134",
@@ -1295,7 +1306,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.patchNull"
     }
    ],
    "Protocol": {
@@ -1396,7 +1408,8 @@
      "Path": "/type/property/nullable/duration/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.getNonNull"
     },
     {
      "$id": "151",
@@ -1455,7 +1468,8 @@
      "Path": "/type/property/nullable/duration/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.getNull"
     },
     {
      "$id": "156",
@@ -1527,7 +1541,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.patchNonNull"
     },
     {
      "$id": "162",
@@ -1599,7 +1614,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.patchNull"
     }
    ],
    "Protocol": {
@@ -1700,7 +1716,8 @@
      "Path": "/type/property/nullable/collections/bytes/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.getNonNull"
     },
     {
      "$id": "179",
@@ -1759,7 +1776,8 @@
      "Path": "/type/property/nullable/collections/bytes/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.getNull"
     },
     {
      "$id": "184",
@@ -1831,7 +1849,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.patchNonNull"
     },
     {
      "$id": "190",
@@ -1903,7 +1922,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.patchNull"
     }
    ],
    "Protocol": {
@@ -2004,7 +2024,8 @@
      "Path": "/type/property/nullable/collections/model/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.getNonNull"
     },
     {
      "$id": "207",
@@ -2063,7 +2084,8 @@
      "Path": "/type/property/nullable/collections/model/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.getNull"
     },
     {
      "$id": "212",
@@ -2135,7 +2157,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.patchNonNull"
     },
     {
      "$id": "218",
@@ -2207,7 +2230,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.patchNull"
     }
    ],
    "Protocol": {
@@ -2308,7 +2332,8 @@
      "Path": "/type/property/nullable/collections/string/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.getNonNull"
     },
     {
      "$id": "235",
@@ -2367,7 +2392,8 @@
      "Path": "/type/property/nullable/collections/string/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.getNull"
     },
     {
      "$id": "240",
@@ -2439,7 +2465,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.patchNonNull"
     },
     {
      "$id": "246",
@@ -2511,7 +2538,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.patchNull"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/property/optionality/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/property/optionality/tspCodeModel.json
@@ -708,7 +708,8 @@
      "Path": "/type/property/optional/string/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.getAll"
     },
     {
      "$id": "90",
@@ -767,7 +768,8 @@
      "Path": "/type/property/optional/string/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.getDefault"
     },
     {
      "$id": "95",
@@ -839,7 +841,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.putAll"
     },
     {
      "$id": "101",
@@ -911,7 +914,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.putDefault"
     }
    ],
    "Protocol": {
@@ -1012,7 +1016,8 @@
      "Path": "/type/property/optional/bytes/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.getAll"
     },
     {
      "$id": "118",
@@ -1071,7 +1076,8 @@
      "Path": "/type/property/optional/bytes/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.getDefault"
     },
     {
      "$id": "123",
@@ -1143,7 +1149,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.putAll"
     },
     {
      "$id": "129",
@@ -1215,7 +1222,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.putDefault"
     }
    ],
    "Protocol": {
@@ -1316,7 +1324,8 @@
      "Path": "/type/property/optional/datetime/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.getAll"
     },
     {
      "$id": "146",
@@ -1375,7 +1384,8 @@
      "Path": "/type/property/optional/datetime/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.getDefault"
     },
     {
      "$id": "151",
@@ -1447,7 +1457,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.putAll"
     },
     {
      "$id": "157",
@@ -1519,7 +1530,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.putDefault"
     }
    ],
    "Protocol": {
@@ -1620,7 +1632,8 @@
      "Path": "/type/property/optional/duration/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.getAll"
     },
     {
      "$id": "174",
@@ -1679,7 +1692,8 @@
      "Path": "/type/property/optional/duration/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.getDefault"
     },
     {
      "$id": "179",
@@ -1751,7 +1765,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.putAll"
     },
     {
      "$id": "185",
@@ -1823,7 +1838,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.putDefault"
     }
    ],
    "Protocol": {
@@ -1924,7 +1940,8 @@
      "Path": "/type/property/optional/plainDate/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.getAll"
     },
     {
      "$id": "202",
@@ -1983,7 +2000,8 @@
      "Path": "/type/property/optional/plainDate/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.getDefault"
     },
     {
      "$id": "207",
@@ -2055,7 +2073,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.putAll"
     },
     {
      "$id": "213",
@@ -2127,7 +2146,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.putDefault"
     }
    ],
    "Protocol": {
@@ -2228,7 +2248,8 @@
      "Path": "/type/property/optional/plainTime/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.getAll"
     },
     {
      "$id": "230",
@@ -2287,7 +2308,8 @@
      "Path": "/type/property/optional/plainTime/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.getDefault"
     },
     {
      "$id": "235",
@@ -2359,7 +2381,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.putAll"
     },
     {
      "$id": "241",
@@ -2431,7 +2454,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.putDefault"
     }
    ],
    "Protocol": {
@@ -2532,7 +2556,8 @@
      "Path": "/type/property/optional/collections/bytes/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.getAll"
     },
     {
      "$id": "258",
@@ -2591,7 +2616,8 @@
      "Path": "/type/property/optional/collections/bytes/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.getDefault"
     },
     {
      "$id": "263",
@@ -2663,7 +2689,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.putAll"
     },
     {
      "$id": "269",
@@ -2735,7 +2762,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.putDefault"
     }
    ],
    "Protocol": {
@@ -2836,7 +2864,8 @@
      "Path": "/type/property/optional/collections/model/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.getAll"
     },
     {
      "$id": "286",
@@ -2895,7 +2924,8 @@
      "Path": "/type/property/optional/collections/model/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.getDefault"
     },
     {
      "$id": "291",
@@ -2967,7 +2997,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.putAll"
     },
     {
      "$id": "297",
@@ -3039,7 +3070,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.putDefault"
     }
    ],
    "Protocol": {
@@ -3140,7 +3172,8 @@
      "Path": "/type/property/optional/string/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.getAll"
     },
     {
      "$id": "314",
@@ -3199,7 +3232,8 @@
      "Path": "/type/property/optional/string/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.getDefault"
     },
     {
      "$id": "319",
@@ -3271,7 +3305,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.putAll"
     },
     {
      "$id": "325",
@@ -3343,7 +3378,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -3444,7 +3480,8 @@
      "Path": "/type/property/optional/int/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.getAll"
     },
     {
      "$id": "342",
@@ -3503,7 +3540,8 @@
      "Path": "/type/property/optional/int/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.getDefault"
     },
     {
      "$id": "347",
@@ -3575,7 +3613,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.putAll"
     },
     {
      "$id": "353",
@@ -3647,7 +3686,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -3748,7 +3788,8 @@
      "Path": "/type/property/optional/float/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.getAll"
     },
     {
      "$id": "370",
@@ -3807,7 +3848,8 @@
      "Path": "/type/property/optional/float/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.getDefault"
     },
     {
      "$id": "375",
@@ -3879,7 +3921,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.putAll"
     },
     {
      "$id": "381",
@@ -3951,7 +3994,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4052,7 +4096,8 @@
      "Path": "/type/property/optional/boolean/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.getAll"
     },
     {
      "$id": "398",
@@ -4111,7 +4156,8 @@
      "Path": "/type/property/optional/boolean/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.getDefault"
     },
     {
      "$id": "403",
@@ -4183,7 +4229,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.putAll"
     },
     {
      "$id": "409",
@@ -4255,7 +4302,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4356,7 +4404,8 @@
      "Path": "/type/property/optional/union/string/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.getAll"
     },
     {
      "$id": "426",
@@ -4415,7 +4464,8 @@
      "Path": "/type/property/optional/union/string/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.getDefault"
     },
     {
      "$id": "431",
@@ -4487,7 +4537,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.putAll"
     },
     {
      "$id": "437",
@@ -4559,7 +4610,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4660,7 +4712,8 @@
      "Path": "/type/property/optional/union/int/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.getAll"
     },
     {
      "$id": "454",
@@ -4719,7 +4772,8 @@
      "Path": "/type/property/optional/union/int/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.getDefault"
     },
     {
      "$id": "459",
@@ -4791,7 +4845,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.putAll"
     },
     {
      "$id": "465",
@@ -4863,7 +4918,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4964,7 +5020,8 @@
      "Path": "/type/property/optional/union/float/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.getAll"
     },
     {
      "$id": "482",
@@ -5023,7 +5080,8 @@
      "Path": "/type/property/optional/union/float/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.getDefault"
     },
     {
      "$id": "487",
@@ -5095,7 +5153,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.putAll"
     },
     {
      "$id": "493",
@@ -5167,7 +5226,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -5269,7 +5329,8 @@
      "Path": "/type/property/optional/requiredAndOptional/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.getAll"
     },
     {
      "$id": "510",
@@ -5328,7 +5389,8 @@
      "Path": "/type/property/optional/requiredAndOptional/requiredOnly",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.getRequiredOnly"
     },
     {
      "$id": "515",
@@ -5400,7 +5462,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.putAll"
     },
     {
      "$id": "521",
@@ -5472,7 +5535,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.putRequiredOnly"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/property/value-types/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/property/value-types/tspCodeModel.json
@@ -1102,7 +1102,8 @@
      "Path": "/type/property/value-types/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Boolean.get"
     },
     {
      "$id": "139",
@@ -1175,7 +1176,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Boolean.put"
     }
    ],
    "Protocol": {
@@ -1276,7 +1278,8 @@
      "Path": "/type/property/value-types/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.String.get"
     },
     {
      "$id": "156",
@@ -1349,7 +1352,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.String.put"
     }
    ],
    "Protocol": {
@@ -1450,7 +1454,8 @@
      "Path": "/type/property/value-types/bytes",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Bytes.get"
     },
     {
      "$id": "173",
@@ -1523,7 +1528,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Bytes.put"
     }
    ],
    "Protocol": {
@@ -1624,7 +1630,8 @@
      "Path": "/type/property/value-types/int",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Int.get"
     },
     {
      "$id": "190",
@@ -1697,7 +1704,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Int.put"
     }
    ],
    "Protocol": {
@@ -1798,7 +1806,8 @@
      "Path": "/type/property/value-types/float",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Float.get"
     },
     {
      "$id": "207",
@@ -1871,7 +1880,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Float.put"
     }
    ],
    "Protocol": {
@@ -1972,7 +1982,8 @@
      "Path": "/type/property/value-types/decimal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal.get"
     },
     {
      "$id": "224",
@@ -2045,7 +2056,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal.put"
     }
    ],
    "Protocol": {
@@ -2146,7 +2158,8 @@
      "Path": "/type/property/value-types/decimal128",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal128.get"
     },
     {
      "$id": "241",
@@ -2219,7 +2232,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal128.put"
     }
    ],
    "Protocol": {
@@ -2320,7 +2334,8 @@
      "Path": "/type/property/value-types/datetime",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Datetime.get"
     },
     {
      "$id": "258",
@@ -2393,7 +2408,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Datetime.put"
     }
    ],
    "Protocol": {
@@ -2494,7 +2510,8 @@
      "Path": "/type/property/value-types/duration",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Duration.get"
     },
     {
      "$id": "275",
@@ -2567,7 +2584,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Duration.put"
     }
    ],
    "Protocol": {
@@ -2668,7 +2686,8 @@
      "Path": "/type/property/value-types/enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Enum.get"
     },
     {
      "$id": "292",
@@ -2741,7 +2760,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Enum.put"
     }
    ],
    "Protocol": {
@@ -2842,7 +2862,8 @@
      "Path": "/type/property/value-types/extensible-enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.ExtensibleEnum.get"
     },
     {
      "$id": "309",
@@ -2915,7 +2936,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.ExtensibleEnum.put"
     }
    ],
    "Protocol": {
@@ -3016,7 +3038,8 @@
      "Path": "/type/property/value-types/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Model.get"
     },
     {
      "$id": "326",
@@ -3089,7 +3112,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Model.put"
     }
    ],
    "Protocol": {
@@ -3190,7 +3214,8 @@
      "Path": "/type/property/value-types/collections/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsString.get"
     },
     {
      "$id": "343",
@@ -3263,7 +3288,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsString.put"
     }
    ],
    "Protocol": {
@@ -3364,7 +3390,8 @@
      "Path": "/type/property/value-types/collections/int",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsInt.get"
     },
     {
      "$id": "360",
@@ -3437,7 +3464,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsInt.put"
     }
    ],
    "Protocol": {
@@ -3538,7 +3566,8 @@
      "Path": "/type/property/value-types/collections/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsModel.get"
     },
     {
      "$id": "377",
@@ -3611,7 +3640,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsModel.put"
     }
    ],
    "Protocol": {
@@ -3712,7 +3742,8 @@
      "Path": "/type/property/value-types/dictionary/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.DictionaryString.get"
     },
     {
      "$id": "394",
@@ -3785,7 +3816,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.DictionaryString.put"
     }
    ],
    "Protocol": {
@@ -3886,7 +3918,8 @@
      "Path": "/type/property/value-types/never",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Never.get"
     },
     {
      "$id": "411",
@@ -3959,7 +3992,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Never.put"
     }
    ],
    "Protocol": {
@@ -4060,7 +4094,8 @@
      "Path": "/type/property/value-types/unknown/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownString.get"
     },
     {
      "$id": "428",
@@ -4133,7 +4168,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownString.put"
     }
    ],
    "Protocol": {
@@ -4234,7 +4270,8 @@
      "Path": "/type/property/value-types/unknown/int",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownInt.get"
     },
     {
      "$id": "445",
@@ -4307,7 +4344,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownInt.put"
     }
    ],
    "Protocol": {
@@ -4408,7 +4446,8 @@
      "Path": "/type/property/value-types/unknown/dict",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownDict.get"
     },
     {
      "$id": "462",
@@ -4481,7 +4520,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownDict.put"
     }
    ],
    "Protocol": {
@@ -4582,7 +4622,8 @@
      "Path": "/type/property/value-types/unknown/array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownArray.get"
     },
     {
      "$id": "479",
@@ -4655,7 +4696,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownArray.put"
     }
    ],
    "Protocol": {
@@ -4756,7 +4798,8 @@
      "Path": "/type/property/value-types/string/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.StringLiteral.get"
     },
     {
      "$id": "496",
@@ -4829,7 +4872,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.StringLiteral.put"
     }
    ],
    "Protocol": {
@@ -4930,7 +4974,8 @@
      "Path": "/type/property/value-types/int/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.IntLiteral.get"
     },
     {
      "$id": "513",
@@ -5003,7 +5048,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.IntLiteral.put"
     }
    ],
    "Protocol": {
@@ -5104,7 +5150,8 @@
      "Path": "/type/property/value-types/float/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.FloatLiteral.get"
     },
     {
      "$id": "530",
@@ -5177,7 +5224,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.FloatLiteral.put"
     }
    ],
    "Protocol": {
@@ -5278,7 +5326,8 @@
      "Path": "/type/property/value-types/boolean/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.BooleanLiteral.get"
     },
     {
      "$id": "547",
@@ -5351,7 +5400,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.BooleanLiteral.put"
     }
    ],
    "Protocol": {
@@ -5452,7 +5502,8 @@
      "Path": "/type/property/value-types/union/string/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionStringLiteral.get"
     },
     {
      "$id": "564",
@@ -5525,7 +5576,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionStringLiteral.put"
     }
    ],
    "Protocol": {
@@ -5626,7 +5678,8 @@
      "Path": "/type/property/value-types/union/int/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionIntLiteral.get"
     },
     {
      "$id": "581",
@@ -5699,7 +5752,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionIntLiteral.put"
     }
    ],
    "Protocol": {
@@ -5800,7 +5854,8 @@
      "Path": "/type/property/value-types/union/float/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionFloatLiteral.get"
     },
     {
      "$id": "598",
@@ -5873,7 +5928,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionFloatLiteral.put"
     }
    ],
    "Protocol": {
@@ -5974,7 +6030,8 @@
      "Path": "/type/property/value-types/union-enum-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionEnumValue.get"
     },
     {
      "$id": "615",
@@ -6047,7 +6104,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionEnumValue.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/scalar/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/scalar/tspCodeModel.json
@@ -136,7 +136,8 @@
      "Path": "/type/scalar/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.String.get"
     },
     {
      "$id": "19",
@@ -212,7 +213,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.String.put"
     }
    ],
    "Protocol": {
@@ -316,7 +318,8 @@
      "Path": "/type/scalar/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Boolean.get"
     },
     {
      "$id": "38",
@@ -392,7 +395,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Boolean.put"
     }
    ],
    "Protocol": {
@@ -496,7 +500,8 @@
      "Path": "/type/scalar/unknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Unknown.get"
     },
     {
      "$id": "57",
@@ -572,7 +577,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Unknown.put"
     }
    ],
    "Protocol": {
@@ -676,7 +682,8 @@
      "Path": "/type/scalar/decimal/response_body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalType.responseBody"
     },
     {
      "$id": "76",
@@ -750,7 +757,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalType.requestBody"
     },
     {
      "$id": "83",
@@ -797,7 +805,8 @@
      "Path": "/type/scalar/decimal/request_parameter",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalType.requestParameter"
     }
    ],
    "Protocol": {
@@ -901,7 +910,8 @@
      "Path": "/type/scalar/decimal128/response_body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Type.responseBody"
     },
     {
      "$id": "99",
@@ -975,7 +985,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Type.requestBody"
     },
     {
      "$id": "106",
@@ -1022,7 +1033,8 @@
      "Path": "/type/scalar/decimal128/request_parameter",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Type.requestParameter"
     }
    ],
    "Protocol": {
@@ -1132,7 +1144,8 @@
      "Path": "/type/scalar/decimal/prepare_verify",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalVerify.prepareVerify"
     },
     {
      "$id": "123",
@@ -1206,7 +1219,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalVerify.verify"
     }
    ],
    "Protocol": {
@@ -1316,7 +1330,8 @@
      "Path": "/type/scalar/decimal128/prepare_verify",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Verify.prepareVerify"
     },
     {
      "$id": "143",
@@ -1390,7 +1405,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Verify.verify"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/type/union/tspCodeModel.json
+++ b/test/CadlRanchProjects/type/union/tspCodeModel.json
@@ -1380,7 +1380,8 @@
      "Path": "/type/union/strings-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringsOnly.get"
     },
     {
      "$id": "186",
@@ -1451,7 +1452,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringsOnly.send"
     }
    ],
    "Protocol": {
@@ -1552,7 +1554,8 @@
      "Path": "/type/union/string-extensible",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensible.get"
     },
     {
      "$id": "203",
@@ -1623,7 +1626,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensible.send"
     }
    ],
    "Protocol": {
@@ -1724,7 +1728,8 @@
      "Path": "/type/union/string-extensible-named",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensibleNamed.get"
     },
     {
      "$id": "220",
@@ -1795,7 +1800,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensibleNamed.send"
     }
    ],
    "Protocol": {
@@ -1896,7 +1902,8 @@
      "Path": "/type/union/ints-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.IntsOnly.get"
     },
     {
      "$id": "237",
@@ -1967,7 +1974,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.IntsOnly.send"
     }
    ],
    "Protocol": {
@@ -2068,7 +2076,8 @@
      "Path": "/type/union/floats-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.FloatsOnly.get"
     },
     {
      "$id": "254",
@@ -2139,7 +2148,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.FloatsOnly.send"
     }
    ],
    "Protocol": {
@@ -2240,7 +2250,8 @@
      "Path": "/type/union/models-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.ModelsOnly.get"
     },
     {
      "$id": "271",
@@ -2311,7 +2322,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.ModelsOnly.send"
     }
    ],
    "Protocol": {
@@ -2412,7 +2424,8 @@
      "Path": "/type/union/enums-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.EnumsOnly.get"
     },
     {
      "$id": "288",
@@ -2483,7 +2496,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.EnumsOnly.send"
     }
    ],
    "Protocol": {
@@ -2584,7 +2598,8 @@
      "Path": "/type/union/string-and-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringAndArray.get"
     },
     {
      "$id": "305",
@@ -2655,7 +2670,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringAndArray.send"
     }
    ],
    "Protocol": {
@@ -2756,7 +2772,8 @@
      "Path": "/type/union/mixed-literals",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedLiterals.get"
     },
     {
      "$id": "322",
@@ -2827,7 +2844,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedLiterals.send"
     }
    ],
    "Protocol": {
@@ -2928,7 +2946,8 @@
      "Path": "/type/union/mixed-types",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedTypes.get"
     },
     {
      "$id": "339",
@@ -2999,7 +3018,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedTypes.send"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/versioning/added/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/added/tspCodeModel.json
@@ -371,7 +371,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.Added.v1"
     },
     {
      "$id": "45",
@@ -474,7 +475,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.Added.v2"
     }
    ],
    "Protocol": {
@@ -627,7 +629,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.Added.InterfaceV2.v2InInterface"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/versioning/madeOptional/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/madeOptional/tspCodeModel.json
@@ -233,7 +233,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.MadeOptional.test"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/versioning/removed/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/removed/tspCodeModel.json
@@ -260,7 +260,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.Removed.v2"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/versioning/renamedFrom/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/renamedFrom/tspCodeModel.json
@@ -284,7 +284,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.RenamedFrom.newOp"
     }
    ],
    "Protocol": {
@@ -437,7 +438,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.RenamedFrom.NewInterface.newOpInNewInterface"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/versioning/returnTypeChangedFrom/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/returnTypeChangedFrom/tspCodeModel.json
@@ -183,7 +183,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.ReturnTypeChangedFrom.test"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjects/versioning/typeChangedFrom/tspCodeModel.json
+++ b/test/CadlRanchProjects/versioning/typeChangedFrom/tspCodeModel.json
@@ -233,7 +233,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Versioning.TypeChangedFrom.test"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/authentication/api-key/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/authentication/api-key/tspCodeModel.json
@@ -89,7 +89,8 @@
      "Path": "/authentication/api-key/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.ApiKey.valid"
     },
     {
      "$id": "12",
@@ -142,7 +143,8 @@
      "Path": "/authentication/api-key/invalid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.ApiKey.invalid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/authentication/http/custom/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/authentication/http/custom/tspCodeModel.json
@@ -89,7 +89,8 @@
      "Path": "/authentication/http/custom/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.Http.Custom.valid"
     },
     {
      "$id": "12",
@@ -142,7 +143,8 @@
      "Path": "/authentication/http/custom/invalid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Authentication.Http.Custom.invalid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/client/naming/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/client/naming/tspCodeModel.json
@@ -228,7 +228,8 @@
      "Path": "/client/naming/operation",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.operation"
     },
     {
      "$id": "31",
@@ -275,7 +276,8 @@
      "Path": "/client/naming/parameter",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.parameter"
     },
     {
      "$id": "35",
@@ -346,7 +348,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Property.client"
     },
     {
      "$id": "41",
@@ -417,7 +420,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Property.language"
     },
     {
      "$id": "47",
@@ -488,7 +492,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Property.compatibleWithEncodedName"
     },
     {
      "$id": "53",
@@ -535,7 +540,8 @@
      "Path": "/client/naming/header",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Header.request"
     },
     {
      "$id": "57",
@@ -576,7 +582,8 @@
      "Path": "/client/naming/header",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Header.response"
     }
    ],
    "Protocol": {
@@ -688,7 +695,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Model.client"
     },
     {
      "$id": "73",
@@ -759,7 +767,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.Model.language"
     }
    ],
    "Protocol": {
@@ -872,7 +881,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.UnionEnum.unionEnumName"
     },
     {
      "$id": "91",
@@ -943,7 +953,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Client.Naming.UnionEnum.unionEnumMemberName"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/parameters/body-optionality/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/parameters/body-optionality/tspCodeModel.json
@@ -153,7 +153,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.requiredExplicit"
     },
     {
      "$id": "19",
@@ -224,7 +225,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.requiredImplicit"
     }
    ],
    "Protocol": {
@@ -336,7 +338,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.OptionalExplicit.set"
     },
     {
      "$id": "37",
@@ -407,7 +410,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.BodyOptionality.OptionalExplicit.omit"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/parameters/spread/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/parameters/spread/tspCodeModel.json
@@ -400,7 +400,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadAsRequestBody"
     },
     {
      "$id": "53",
@@ -471,7 +472,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequestOnlyWithBody"
     },
     {
      "$id": "59",
@@ -536,7 +538,8 @@
      "Path": "/parameters/spread/model/composite-request-without-body/{name}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequestWithoutBody"
     },
     {
      "$id": "65",
@@ -643,7 +646,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequest"
     },
     {
      "$id": "75",
@@ -750,7 +754,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Model.spreadCompositeRequestMix"
     }
    ],
    "Protocol": {
@@ -863,7 +868,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadAsRequestBody"
     },
     {
      "$id": "97",
@@ -970,7 +976,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadParameterWithInnerModel"
     },
     {
      "$id": "107",
@@ -1077,7 +1084,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadAsRequestParameter"
     },
     {
      "$id": "117",
@@ -1184,7 +1192,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadWithMultipleParameters"
     },
     {
      "$id": "127",
@@ -1292,7 +1301,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Parameters.Spread.Alias.spreadParameterWithInnerAlias"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/payload/content-negotiation/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/payload/content-negotiation/tspCodeModel.json
@@ -179,7 +179,8 @@
      "Path": "/content-negotiation/same-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.SameBody.getAvatarAsPng"
     },
     {
      "$id": "25",
@@ -258,7 +259,8 @@
      "Path": "/content-negotiation/same-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.SameBody.getAvatarAsJpeg"
     }
    ],
    "Protocol": {
@@ -379,7 +381,8 @@
      "Path": "/content-negotiation/different-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.DifferentBody.getAvatarAsPng"
     },
     {
      "$id": "49",
@@ -454,7 +457,8 @@
      "Path": "/content-negotiation/different-body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.ContentNegotiation.DifferentBody.getAvatarAsJson"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/payload/multipart/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/payload/multipart/tspCodeModel.json
@@ -478,7 +478,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.basic"
     },
     {
      "$id": "61",
@@ -549,7 +550,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.complex"
     },
     {
      "$id": "67",
@@ -620,7 +622,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.jsonPart"
     },
     {
      "$id": "73",
@@ -691,7 +694,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.binaryArrayParts"
     },
     {
      "$id": "79",
@@ -762,7 +766,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.jsonArrayParts"
     },
     {
      "$id": "85",
@@ -833,7 +838,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.multiBinaryParts"
     },
     {
      "$id": "91",
@@ -904,7 +910,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.checkFileNameAndContentType"
     },
     {
      "$id": "97",
@@ -975,7 +982,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Payload.MultiPart.FormData.anonymousModel"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/serialization/encoded-name/json/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/serialization/encoded-name/json/tspCodeModel.json
@@ -170,7 +170,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Serialization.EncodedName.Json.Property.send"
     },
     {
      "$id": "22",
@@ -228,7 +229,8 @@
      "Path": "/serialization/encoded-name/json/property",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Serialization.EncodedName.Json.Property.get"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/server/endpoint/not-defined/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/server/endpoint/not-defined/tspCodeModel.json
@@ -54,7 +54,8 @@
      "Path": "/server/endpoint/not-defined/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Server.Endpoint.NotDefined.valid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/special-words/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/special-words/tspCodeModel.json
@@ -930,7 +930,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAnd"
     },
     {
      "$id": "121",
@@ -1001,7 +1002,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAs"
     },
     {
      "$id": "127",
@@ -1072,7 +1074,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAssert"
     },
     {
      "$id": "133",
@@ -1143,7 +1146,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAsync"
     },
     {
      "$id": "139",
@@ -1214,7 +1218,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withAwait"
     },
     {
      "$id": "145",
@@ -1285,7 +1290,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withBreak"
     },
     {
      "$id": "151",
@@ -1356,7 +1362,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withClass"
     },
     {
      "$id": "157",
@@ -1427,7 +1434,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withConstructor"
     },
     {
      "$id": "163",
@@ -1498,7 +1506,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withContinue"
     },
     {
      "$id": "169",
@@ -1569,7 +1578,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withDef"
     },
     {
      "$id": "175",
@@ -1640,7 +1650,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withDel"
     },
     {
      "$id": "181",
@@ -1711,7 +1722,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withElif"
     },
     {
      "$id": "187",
@@ -1782,7 +1794,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withElse"
     },
     {
      "$id": "193",
@@ -1853,7 +1866,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withExcept"
     },
     {
      "$id": "199",
@@ -1924,7 +1938,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withExec"
     },
     {
      "$id": "205",
@@ -1995,7 +2010,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withFinally"
     },
     {
      "$id": "211",
@@ -2066,7 +2082,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withFor"
     },
     {
      "$id": "217",
@@ -2137,7 +2154,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withFrom"
     },
     {
      "$id": "223",
@@ -2208,7 +2226,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withGlobal"
     },
     {
      "$id": "229",
@@ -2279,7 +2298,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withIf"
     },
     {
      "$id": "235",
@@ -2350,7 +2370,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withImport"
     },
     {
      "$id": "241",
@@ -2421,7 +2442,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withIn"
     },
     {
      "$id": "247",
@@ -2492,7 +2514,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withIs"
     },
     {
      "$id": "253",
@@ -2563,7 +2586,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withLambda"
     },
     {
      "$id": "259",
@@ -2634,7 +2658,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withNot"
     },
     {
      "$id": "265",
@@ -2705,7 +2730,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withOr"
     },
     {
      "$id": "271",
@@ -2776,7 +2802,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withPass"
     },
     {
      "$id": "277",
@@ -2847,7 +2874,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withRaise"
     },
     {
      "$id": "283",
@@ -2918,7 +2946,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withReturn"
     },
     {
      "$id": "289",
@@ -2989,7 +3018,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withTry"
     },
     {
      "$id": "295",
@@ -3060,7 +3090,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withWhile"
     },
     {
      "$id": "301",
@@ -3131,7 +3162,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withWith"
     },
     {
      "$id": "307",
@@ -3202,7 +3234,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Models.withYield"
     }
    ],
    "Protocol": {
@@ -3316,7 +3349,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.ModelProperties.sameAsModel"
     }
    ],
    "Protocol": {
@@ -3388,7 +3422,8 @@
      "Path": "/special-words/operations/and",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.and"
     },
     {
      "$id": "333",
@@ -3417,7 +3452,8 @@
      "Path": "/special-words/operations/as",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.as"
     },
     {
      "$id": "335",
@@ -3446,7 +3482,8 @@
      "Path": "/special-words/operations/assert",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.assert"
     },
     {
      "$id": "337",
@@ -3475,7 +3512,8 @@
      "Path": "/special-words/operations/async",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.async"
     },
     {
      "$id": "339",
@@ -3504,7 +3542,8 @@
      "Path": "/special-words/operations/await",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.await"
     },
     {
      "$id": "341",
@@ -3533,7 +3572,8 @@
      "Path": "/special-words/operations/break",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.break"
     },
     {
      "$id": "343",
@@ -3562,7 +3602,8 @@
      "Path": "/special-words/operations/class",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.class"
     },
     {
      "$id": "345",
@@ -3591,7 +3632,8 @@
      "Path": "/special-words/operations/constructor",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.constructor"
     },
     {
      "$id": "347",
@@ -3620,7 +3662,8 @@
      "Path": "/special-words/operations/continue",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.continue"
     },
     {
      "$id": "349",
@@ -3649,7 +3692,8 @@
      "Path": "/special-words/operations/def",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.def"
     },
     {
      "$id": "351",
@@ -3678,7 +3722,8 @@
      "Path": "/special-words/operations/del",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.del"
     },
     {
      "$id": "353",
@@ -3707,7 +3752,8 @@
      "Path": "/special-words/operations/elif",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.elif"
     },
     {
      "$id": "355",
@@ -3736,7 +3782,8 @@
      "Path": "/special-words/operations/else",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.else"
     },
     {
      "$id": "357",
@@ -3765,7 +3812,8 @@
      "Path": "/special-words/operations/except",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.except"
     },
     {
      "$id": "359",
@@ -3794,7 +3842,8 @@
      "Path": "/special-words/operations/exec",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.exec"
     },
     {
      "$id": "361",
@@ -3823,7 +3872,8 @@
      "Path": "/special-words/operations/finally",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.finally"
     },
     {
      "$id": "363",
@@ -3852,7 +3902,8 @@
      "Path": "/special-words/operations/for",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.for"
     },
     {
      "$id": "365",
@@ -3881,7 +3932,8 @@
      "Path": "/special-words/operations/from",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.from"
     },
     {
      "$id": "367",
@@ -3910,7 +3962,8 @@
      "Path": "/special-words/operations/global",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.global"
     },
     {
      "$id": "369",
@@ -3939,7 +3992,8 @@
      "Path": "/special-words/operations/if",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.if"
     },
     {
      "$id": "371",
@@ -3968,7 +4022,8 @@
      "Path": "/special-words/operations/import",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.import"
     },
     {
      "$id": "373",
@@ -3997,7 +4052,8 @@
      "Path": "/special-words/operations/in",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.in"
     },
     {
      "$id": "375",
@@ -4026,7 +4082,8 @@
      "Path": "/special-words/operations/is",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.is"
     },
     {
      "$id": "377",
@@ -4055,7 +4112,8 @@
      "Path": "/special-words/operations/lambda",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.lambda"
     },
     {
      "$id": "379",
@@ -4084,7 +4142,8 @@
      "Path": "/special-words/operations/not",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.not"
     },
     {
      "$id": "381",
@@ -4113,7 +4172,8 @@
      "Path": "/special-words/operations/or",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.or"
     },
     {
      "$id": "383",
@@ -4142,7 +4202,8 @@
      "Path": "/special-words/operations/pass",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.pass"
     },
     {
      "$id": "385",
@@ -4171,7 +4232,8 @@
      "Path": "/special-words/operations/raise",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.raise"
     },
     {
      "$id": "387",
@@ -4200,7 +4262,8 @@
      "Path": "/special-words/operations/return",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.return"
     },
     {
      "$id": "389",
@@ -4229,7 +4292,8 @@
      "Path": "/special-words/operations/try",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.try"
     },
     {
      "$id": "391",
@@ -4258,7 +4322,8 @@
      "Path": "/special-words/operations/while",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.while"
     },
     {
      "$id": "393",
@@ -4287,7 +4352,8 @@
      "Path": "/special-words/operations/with",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.with"
     },
     {
      "$id": "395",
@@ -4316,7 +4382,8 @@
      "Path": "/special-words/operations/yield",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Operations.yield"
     }
    ],
    "Protocol": {
@@ -4406,7 +4473,8 @@
      "Path": "/special-words/parameters/and",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAnd"
     },
     {
      "$id": "407",
@@ -4453,7 +4521,8 @@
      "Path": "/special-words/parameters/as",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAs"
     },
     {
      "$id": "411",
@@ -4500,7 +4569,8 @@
      "Path": "/special-words/parameters/assert",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAssert"
     },
     {
      "$id": "415",
@@ -4547,7 +4617,8 @@
      "Path": "/special-words/parameters/async",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAsync"
     },
     {
      "$id": "419",
@@ -4594,7 +4665,8 @@
      "Path": "/special-words/parameters/await",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withAwait"
     },
     {
      "$id": "423",
@@ -4641,7 +4713,8 @@
      "Path": "/special-words/parameters/break",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withBreak"
     },
     {
      "$id": "427",
@@ -4688,7 +4761,8 @@
      "Path": "/special-words/parameters/class",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withClass"
     },
     {
      "$id": "431",
@@ -4735,7 +4809,8 @@
      "Path": "/special-words/parameters/constructor",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withConstructor"
     },
     {
      "$id": "435",
@@ -4782,7 +4857,8 @@
      "Path": "/special-words/parameters/continue",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withContinue"
     },
     {
      "$id": "439",
@@ -4829,7 +4905,8 @@
      "Path": "/special-words/parameters/def",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withDef"
     },
     {
      "$id": "443",
@@ -4876,7 +4953,8 @@
      "Path": "/special-words/parameters/del",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withDel"
     },
     {
      "$id": "447",
@@ -4923,7 +5001,8 @@
      "Path": "/special-words/parameters/elif",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withElif"
     },
     {
      "$id": "451",
@@ -4970,7 +5049,8 @@
      "Path": "/special-words/parameters/else",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withElse"
     },
     {
      "$id": "455",
@@ -5017,7 +5097,8 @@
      "Path": "/special-words/parameters/except",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withExcept"
     },
     {
      "$id": "459",
@@ -5064,7 +5145,8 @@
      "Path": "/special-words/parameters/exec",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withExec"
     },
     {
      "$id": "463",
@@ -5111,7 +5193,8 @@
      "Path": "/special-words/parameters/finally",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withFinally"
     },
     {
      "$id": "467",
@@ -5158,7 +5241,8 @@
      "Path": "/special-words/parameters/for",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withFor"
     },
     {
      "$id": "471",
@@ -5205,7 +5289,8 @@
      "Path": "/special-words/parameters/from",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withFrom"
     },
     {
      "$id": "475",
@@ -5252,7 +5337,8 @@
      "Path": "/special-words/parameters/global",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withGlobal"
     },
     {
      "$id": "479",
@@ -5299,7 +5385,8 @@
      "Path": "/special-words/parameters/if",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withIf"
     },
     {
      "$id": "483",
@@ -5346,7 +5433,8 @@
      "Path": "/special-words/parameters/import",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withImport"
     },
     {
      "$id": "487",
@@ -5393,7 +5481,8 @@
      "Path": "/special-words/parameters/in",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withIn"
     },
     {
      "$id": "491",
@@ -5440,7 +5529,8 @@
      "Path": "/special-words/parameters/is",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withIs"
     },
     {
      "$id": "495",
@@ -5487,7 +5577,8 @@
      "Path": "/special-words/parameters/lambda",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withLambda"
     },
     {
      "$id": "499",
@@ -5534,7 +5625,8 @@
      "Path": "/special-words/parameters/not",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withNot"
     },
     {
      "$id": "503",
@@ -5581,7 +5673,8 @@
      "Path": "/special-words/parameters/or",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withOr"
     },
     {
      "$id": "507",
@@ -5628,7 +5721,8 @@
      "Path": "/special-words/parameters/pass",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withPass"
     },
     {
      "$id": "511",
@@ -5675,7 +5769,8 @@
      "Path": "/special-words/parameters/raise",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withRaise"
     },
     {
      "$id": "515",
@@ -5722,7 +5817,8 @@
      "Path": "/special-words/parameters/return",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withReturn"
     },
     {
      "$id": "519",
@@ -5769,7 +5865,8 @@
      "Path": "/special-words/parameters/try",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withTry"
     },
     {
      "$id": "523",
@@ -5816,7 +5913,8 @@
      "Path": "/special-words/parameters/while",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withWhile"
     },
     {
      "$id": "527",
@@ -5863,7 +5961,8 @@
      "Path": "/special-words/parameters/with",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withWith"
     },
     {
      "$id": "531",
@@ -5910,7 +6009,8 @@
      "Path": "/special-words/parameters/yield",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withYield"
     },
     {
      "$id": "535",
@@ -5957,7 +6057,8 @@
      "Path": "/special-words/parameters/cancellationToken",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "SpecialWords.Parameters.withCancellationToken"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/array/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/array/tspCodeModel.json
@@ -185,7 +185,8 @@
      "Path": "/type/array/int32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int32Value.get"
     },
     {
      "$id": "25",
@@ -265,7 +266,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int32Value.put"
     }
    ],
    "Protocol": {
@@ -375,7 +377,8 @@
      "Path": "/type/array/int64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int64Value.get"
     },
     {
      "$id": "46",
@@ -455,7 +458,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Int64Value.put"
     }
    ],
    "Protocol": {
@@ -565,7 +569,8 @@
      "Path": "/type/array/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.BooleanValue.get"
     },
     {
      "$id": "67",
@@ -645,7 +650,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.BooleanValue.put"
     }
    ],
    "Protocol": {
@@ -755,7 +761,8 @@
      "Path": "/type/array/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.StringValue.get"
     },
     {
      "$id": "88",
@@ -835,7 +842,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.StringValue.put"
     }
    ],
    "Protocol": {
@@ -945,7 +953,8 @@
      "Path": "/type/array/float32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Float32Value.get"
     },
     {
      "$id": "109",
@@ -1025,7 +1034,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.Float32Value.put"
     }
    ],
    "Protocol": {
@@ -1142,7 +1152,8 @@
      "Path": "/type/array/datetime",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DatetimeValue.get"
     },
     {
      "$id": "131",
@@ -1229,7 +1240,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DatetimeValue.put"
     }
    ],
    "Protocol": {
@@ -1346,7 +1358,8 @@
      "Path": "/type/array/duration",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DurationValue.get"
     },
     {
      "$id": "154",
@@ -1433,7 +1446,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.DurationValue.put"
     }
    ],
    "Protocol": {
@@ -1543,7 +1557,8 @@
      "Path": "/type/array/unknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.UnknownValue.get"
     },
     {
      "$id": "176",
@@ -1623,7 +1638,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.UnknownValue.put"
     }
    ],
    "Protocol": {
@@ -1730,7 +1746,8 @@
      "Path": "/type/array/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.ModelValue.get"
     },
     {
      "$id": "196",
@@ -1807,7 +1824,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.ModelValue.put"
     }
    ],
    "Protocol": {
@@ -1921,7 +1939,8 @@
      "Path": "/type/array/nullable-float",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableFloatValue.get"
     },
     {
      "$id": "217",
@@ -2005,7 +2024,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableFloatValue.put"
     }
    ],
    "Protocol": {
@@ -2119,7 +2139,8 @@
      "Path": "/type/array/nullable-int32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableInt32Value.get"
     },
     {
      "$id": "240",
@@ -2203,7 +2224,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableInt32Value.put"
     }
    ],
    "Protocol": {
@@ -2317,7 +2339,8 @@
      "Path": "/type/array/nullable-boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableBooleanValue.get"
     },
     {
      "$id": "263",
@@ -2401,7 +2424,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableBooleanValue.put"
     }
    ],
    "Protocol": {
@@ -2515,7 +2539,8 @@
      "Path": "/type/array/nullable-string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableStringValue.get"
     },
     {
      "$id": "286",
@@ -2599,7 +2624,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableStringValue.put"
     }
    ],
    "Protocol": {
@@ -2710,7 +2736,8 @@
      "Path": "/type/array/nullable-model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableModelValue.get"
     },
     {
      "$id": "308",
@@ -2791,7 +2818,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Array.NullableModelValue.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/dictionary/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/dictionary/tspCodeModel.json
@@ -193,7 +193,8 @@
      "Path": "/type/dictionary/int32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int32Value.get"
     },
     {
      "$id": "27",
@@ -277,7 +278,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int32Value.put"
     }
    ],
    "Protocol": {
@@ -391,7 +393,8 @@
      "Path": "/type/dictionary/int64",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int64Value.get"
     },
     {
      "$id": "50",
@@ -475,7 +478,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Int64Value.put"
     }
    ],
    "Protocol": {
@@ -589,7 +593,8 @@
      "Path": "/type/dictionary/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.BooleanValue.get"
     },
     {
      "$id": "73",
@@ -673,7 +678,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.BooleanValue.put"
     }
    ],
    "Protocol": {
@@ -787,7 +793,8 @@
      "Path": "/type/dictionary/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.StringValue.get"
     },
     {
      "$id": "96",
@@ -871,7 +878,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.StringValue.put"
     }
    ],
    "Protocol": {
@@ -985,7 +993,8 @@
      "Path": "/type/dictionary/float32",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Float32Value.get"
     },
     {
      "$id": "119",
@@ -1069,7 +1078,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.Float32Value.put"
     }
    ],
    "Protocol": {
@@ -1190,7 +1200,8 @@
      "Path": "/type/dictionary/datetime",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DatetimeValue.get"
     },
     {
      "$id": "143",
@@ -1281,7 +1292,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DatetimeValue.put"
     }
    ],
    "Protocol": {
@@ -1402,7 +1414,8 @@
      "Path": "/type/dictionary/duration",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DurationValue.get"
     },
     {
      "$id": "168",
@@ -1493,7 +1506,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.DurationValue.put"
     }
    ],
    "Protocol": {
@@ -1607,7 +1621,8 @@
      "Path": "/type/dictionary/unknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.UnknownValue.get"
     },
     {
      "$id": "192",
@@ -1691,7 +1706,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.UnknownValue.put"
     }
    ],
    "Protocol": {
@@ -1802,7 +1818,8 @@
      "Path": "/type/dictionary/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.ModelValue.get"
     },
     {
      "$id": "214",
@@ -1883,7 +1900,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.ModelValue.put"
     }
    ],
    "Protocol": {
@@ -1994,7 +2012,8 @@
      "Path": "/type/dictionary/model/recursive",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.RecursiveModelValue.get"
     },
     {
      "$id": "235",
@@ -2075,7 +2094,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.RecursiveModelValue.put"
     }
    ],
    "Protocol": {
@@ -2193,7 +2213,8 @@
      "Path": "/type/dictionary/nullable-float",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.NullableFloatValue.get"
     },
     {
      "$id": "258",
@@ -2281,7 +2302,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Dictionary.NullableFloatValue.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/enum/extensible/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/enum/extensible/tspCodeModel.json
@@ -192,7 +192,8 @@
      "Path": "/type/enum/extensible/string/known-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.getKnownValue"
     },
     {
      "$id": "27",
@@ -250,7 +251,8 @@
      "Path": "/type/enum/extensible/string/unknown-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.getUnknownValue"
     },
     {
      "$id": "32",
@@ -321,7 +323,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.putKnownValue"
     },
     {
      "$id": "38",
@@ -392,7 +395,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Extensible.String.putUnknownValue"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/enum/fixed/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/enum/fixed/tspCodeModel.json
@@ -193,7 +193,8 @@
      "Path": "/type/enum/fixed/string/known-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Fixed.String.getKnownValue"
     },
     {
      "$id": "27",
@@ -266,7 +267,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Fixed.String.putKnownValue"
     },
     {
      "$id": "33",
@@ -339,7 +341,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Enum.Fixed.String.putUnknownValue"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/model/empty/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/model/empty/tspCodeModel.json
@@ -134,7 +134,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Empty.putEmpty"
     },
     {
      "$id": "16",
@@ -192,7 +193,8 @@
      "Path": "/type/model/empty/alone",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Empty.getEmpty"
     },
     {
      "$id": "21",
@@ -292,7 +294,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Empty.postRoundTripEmpty"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/enum-discriminator/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/enum-discriminator/tspCodeModel.json
@@ -300,7 +300,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/extensible-enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getExtensibleModel"
     },
     {
      "$id": "36",
@@ -373,7 +374,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.putExtensibleModel"
     },
     {
      "$id": "42",
@@ -432,7 +434,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/extensible-enum/missingdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getExtensibleModelMissingDiscriminator"
     },
     {
      "$id": "47",
@@ -491,7 +494,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/extensible-enum/wrongdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getExtensibleModelWrongDiscriminator"
     },
     {
      "$id": "52",
@@ -550,7 +554,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/fixed-enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getFixedModel"
     },
     {
      "$id": "57",
@@ -623,7 +628,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.putFixedModel"
     },
     {
      "$id": "63",
@@ -682,7 +688,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/fixed-enum/missingdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getFixedModelMissingDiscriminator"
     },
     {
      "$id": "68",
@@ -741,7 +748,8 @@
      "Path": "/type/model/inheritance/enum-discriminator/fixed-enum/wrongdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.EnumDiscriminator.getFixedModelWrongDiscriminator"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/not-discriminated/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/not-discriminated/tspCodeModel.json
@@ -185,7 +185,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.NotDiscriminated.postValid"
     },
     {
      "$id": "22",
@@ -243,7 +244,8 @@
      "Path": "/type/model/inheritance/not-discriminated/valid",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.NotDiscriminated.getValid"
     },
     {
      "$id": "27",
@@ -343,7 +345,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.NotDiscriminated.putValid"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/recursive/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/recursive/tspCodeModel.json
@@ -161,7 +161,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.Recursive.put"
     },
     {
      "$id": "19",
@@ -219,7 +220,8 @@
      "Path": "/type/model/inheritance/recursive",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.Recursive.get"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/model/inheritance/single-discriminator/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/model/inheritance/single-discriminator/tspCodeModel.json
@@ -418,7 +418,8 @@
      "Path": "/type/model/inheritance/single-discriminator/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getModel"
     },
     {
      "$id": "50",
@@ -489,7 +490,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.putModel"
     },
     {
      "$id": "56",
@@ -547,7 +549,8 @@
      "Path": "/type/model/inheritance/single-discriminator/recursivemodel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getRecursiveModel"
     },
     {
      "$id": "61",
@@ -618,7 +621,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.putRecursiveModel"
     },
     {
      "$id": "67",
@@ -676,7 +680,8 @@
      "Path": "/type/model/inheritance/single-discriminator/missingdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getMissingDiscriminator"
     },
     {
      "$id": "72",
@@ -734,7 +739,8 @@
      "Path": "/type/model/inheritance/single-discriminator/wrongdiscriminator",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getWrongDiscriminator"
     },
     {
      "$id": "77",
@@ -792,7 +798,8 @@
      "Path": "/type/model/inheritance/single-discriminator/legacy-model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Inheritance.SingleDiscriminator.getLegacyModel"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/model/usage/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/model/usage/tspCodeModel.json
@@ -179,7 +179,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Usage.input"
     },
     {
      "$id": "22",
@@ -237,7 +238,8 @@
      "Path": "/type/model/usage/output",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Usage.output"
     },
     {
      "$id": "27",
@@ -337,7 +339,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Model.Usage.inputAndOutput"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/property/additional-properties/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/property/additional-properties/tspCodeModel.json
@@ -1575,7 +1575,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordUnknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknown.get"
     },
     {
      "$id": "194",
@@ -1648,7 +1649,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknown.put"
     }
    ],
    "Protocol": {
@@ -1749,7 +1751,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordUnknownDerived",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDerived.get"
     },
     {
      "$id": "211",
@@ -1822,7 +1825,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDerived.put"
     }
    ],
    "Protocol": {
@@ -1923,7 +1927,8 @@
      "Path": "/type/property/additionalProperties/extendsUnknownDiscriminated",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDiscriminated.get"
     },
     {
      "$id": "228",
@@ -1996,7 +2001,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsUnknownDiscriminated.put"
     }
    ],
    "Protocol": {
@@ -2097,7 +2103,8 @@
      "Path": "/type/property/additionalProperties/isRecordUnknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknown.get"
     },
     {
      "$id": "245",
@@ -2170,7 +2177,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknown.put"
     }
    ],
    "Protocol": {
@@ -2271,7 +2279,8 @@
      "Path": "/type/property/additionalProperties/isRecordUnknownDerived",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDerived.get"
     },
     {
      "$id": "262",
@@ -2344,7 +2353,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDerived.put"
     }
    ],
    "Protocol": {
@@ -2445,7 +2455,8 @@
      "Path": "/type/property/additionalProperties/isUnknownDiscriminated",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDiscriminated.get"
     },
     {
      "$id": "279",
@@ -2518,7 +2529,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsUnknownDiscriminated.put"
     }
    ],
    "Protocol": {
@@ -2619,7 +2631,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsString.get"
     },
     {
      "$id": "296",
@@ -2692,7 +2705,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsString.put"
     }
    ],
    "Protocol": {
@@ -2793,7 +2807,8 @@
      "Path": "/type/property/additionalProperties/isRecordstring",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsString.get"
     },
     {
      "$id": "313",
@@ -2866,7 +2881,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsString.put"
     }
    ],
    "Protocol": {
@@ -2967,7 +2983,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadString.get"
     },
     {
      "$id": "330",
@@ -3040,7 +3057,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadString.put"
     }
    ],
    "Protocol": {
@@ -3141,7 +3159,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsFloat.get"
     },
     {
      "$id": "347",
@@ -3214,7 +3233,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsFloat.put"
     }
    ],
    "Protocol": {
@@ -3315,7 +3335,8 @@
      "Path": "/type/property/additionalProperties/isRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsFloat.get"
     },
     {
      "$id": "364",
@@ -3388,7 +3409,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsFloat.put"
     }
    ],
    "Protocol": {
@@ -3489,7 +3511,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadFloat.get"
     },
     {
      "$id": "381",
@@ -3562,7 +3585,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadFloat.put"
     }
    ],
    "Protocol": {
@@ -3663,7 +3687,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModel.get"
     },
     {
      "$id": "398",
@@ -3736,7 +3761,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModel.put"
     }
    ],
    "Protocol": {
@@ -3837,7 +3863,8 @@
      "Path": "/type/property/additionalProperties/isRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModel.get"
     },
     {
      "$id": "415",
@@ -3910,7 +3937,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModel.put"
     }
    ],
    "Protocol": {
@@ -4011,7 +4039,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModel.get"
     },
     {
      "$id": "432",
@@ -4084,7 +4113,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModel.put"
     }
    ],
    "Protocol": {
@@ -4185,7 +4215,8 @@
      "Path": "/type/property/additionalProperties/extendsRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModelArray.get"
     },
     {
      "$id": "449",
@@ -4258,7 +4289,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsModelArray.put"
     }
    ],
    "Protocol": {
@@ -4359,7 +4391,8 @@
      "Path": "/type/property/additionalProperties/isRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModelArray.get"
     },
     {
      "$id": "466",
@@ -4432,7 +4465,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.IsModelArray.put"
     }
    ],
    "Protocol": {
@@ -4533,7 +4567,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModelArray.get"
     },
     {
      "$id": "483",
@@ -4606,7 +4641,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadModelArray.put"
     }
    ],
    "Protocol": {
@@ -4707,7 +4743,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentString.get"
     },
     {
      "$id": "500",
@@ -4780,7 +4817,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentString.put"
     }
    ],
    "Protocol": {
@@ -4881,7 +4919,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentFloat.get"
     },
     {
      "$id": "517",
@@ -4954,7 +4993,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentFloat.put"
     }
    ],
    "Protocol": {
@@ -5055,7 +5095,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModel.get"
     },
     {
      "$id": "534",
@@ -5128,7 +5169,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModel.put"
     }
    ],
    "Protocol": {
@@ -5229,7 +5271,8 @@
      "Path": "/type/property/additionalProperties/spreadDifferentRecordModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModelArray.get"
     },
     {
      "$id": "551",
@@ -5302,7 +5345,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadDifferentModelArray.put"
     }
    ],
    "Protocol": {
@@ -5403,7 +5447,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadString.get"
     },
     {
      "$id": "568",
@@ -5476,7 +5521,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadString.put"
     }
    ],
    "Protocol": {
@@ -5577,7 +5623,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadFloat",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadFloat.get"
     },
     {
      "$id": "585",
@@ -5650,7 +5697,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadFloat.put"
     }
    ],
    "Protocol": {
@@ -5751,7 +5799,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModel.get"
     },
     {
      "$id": "602",
@@ -5824,7 +5873,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModel.put"
     }
    ],
    "Protocol": {
@@ -5925,7 +5975,8 @@
      "Path": "/type/property/additionalProperties/extendsDifferentSpreadModelArray",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModelArray.get"
     },
     {
      "$id": "619",
@@ -5998,7 +6049,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.ExtendsDifferentSpreadModelArray.put"
     }
    ],
    "Protocol": {
@@ -6099,7 +6151,8 @@
      "Path": "/type/property/additionalProperties/multipleSpreadRecord",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.MultipleSpread.get"
     },
     {
      "$id": "636",
@@ -6172,7 +6225,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.MultipleSpread.put"
     }
    ],
    "Protocol": {
@@ -6273,7 +6327,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordUnion",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordUnion.get"
     },
     {
      "$id": "653",
@@ -6346,7 +6401,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordUnion.put"
     }
    ],
    "Protocol": {
@@ -6447,7 +6503,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordDiscriminatedUnion",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordDiscriminatedUnion.get"
     },
     {
      "$id": "670",
@@ -6520,7 +6577,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordDiscriminatedUnion.put"
     }
    ],
    "Protocol": {
@@ -6621,7 +6679,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordNonDiscriminatedUnion",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion.get"
     },
     {
      "$id": "687",
@@ -6694,7 +6753,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion.put"
     }
    ],
    "Protocol": {
@@ -6795,7 +6855,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordNonDiscriminatedUnion2",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion2.get"
     },
     {
      "$id": "704",
@@ -6868,7 +6929,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion2.put"
     }
    ],
    "Protocol": {
@@ -6969,7 +7031,8 @@
      "Path": "/type/property/additionalProperties/spreadRecordNonDiscriminatedUnion3",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion3.get"
     },
     {
      "$id": "721",
@@ -7042,7 +7105,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.AdditionalProperties.SpreadRecordNonDiscriminatedUnion3.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/property/nullable/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/property/nullable/tspCodeModel.json
@@ -484,7 +484,8 @@
      "Path": "/type/property/nullable/string/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.getNonNull"
     },
     {
      "$id": "67",
@@ -543,7 +544,8 @@
      "Path": "/type/property/nullable/string/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.getNull"
     },
     {
      "$id": "72",
@@ -615,7 +617,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.patchNonNull"
     },
     {
      "$id": "78",
@@ -687,7 +690,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.String.patchNull"
     }
    ],
    "Protocol": {
@@ -788,7 +792,8 @@
      "Path": "/type/property/nullable/bytes/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.getNonNull"
     },
     {
      "$id": "95",
@@ -847,7 +852,8 @@
      "Path": "/type/property/nullable/bytes/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.getNull"
     },
     {
      "$id": "100",
@@ -919,7 +925,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.patchNonNull"
     },
     {
      "$id": "106",
@@ -991,7 +998,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Bytes.patchNull"
     }
    ],
    "Protocol": {
@@ -1092,7 +1100,8 @@
      "Path": "/type/property/nullable/datetime/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.getNonNull"
     },
     {
      "$id": "123",
@@ -1151,7 +1160,8 @@
      "Path": "/type/property/nullable/datetime/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.getNull"
     },
     {
      "$id": "128",
@@ -1223,7 +1233,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.patchNonNull"
     },
     {
      "$id": "134",
@@ -1295,7 +1306,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Datetime.patchNull"
     }
    ],
    "Protocol": {
@@ -1396,7 +1408,8 @@
      "Path": "/type/property/nullable/duration/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.getNonNull"
     },
     {
      "$id": "151",
@@ -1455,7 +1468,8 @@
      "Path": "/type/property/nullable/duration/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.getNull"
     },
     {
      "$id": "156",
@@ -1527,7 +1541,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.patchNonNull"
     },
     {
      "$id": "162",
@@ -1599,7 +1614,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.Duration.patchNull"
     }
    ],
    "Protocol": {
@@ -1700,7 +1716,8 @@
      "Path": "/type/property/nullable/collections/bytes/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.getNonNull"
     },
     {
      "$id": "179",
@@ -1759,7 +1776,8 @@
      "Path": "/type/property/nullable/collections/bytes/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.getNull"
     },
     {
      "$id": "184",
@@ -1831,7 +1849,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.patchNonNull"
     },
     {
      "$id": "190",
@@ -1903,7 +1922,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsByte.patchNull"
     }
    ],
    "Protocol": {
@@ -2004,7 +2024,8 @@
      "Path": "/type/property/nullable/collections/model/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.getNonNull"
     },
     {
      "$id": "207",
@@ -2063,7 +2084,8 @@
      "Path": "/type/property/nullable/collections/model/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.getNull"
     },
     {
      "$id": "212",
@@ -2135,7 +2157,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.patchNonNull"
     },
     {
      "$id": "218",
@@ -2207,7 +2230,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsModel.patchNull"
     }
    ],
    "Protocol": {
@@ -2308,7 +2332,8 @@
      "Path": "/type/property/nullable/collections/string/non-null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.getNonNull"
     },
     {
      "$id": "235",
@@ -2367,7 +2392,8 @@
      "Path": "/type/property/nullable/collections/string/null",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.getNull"
     },
     {
      "$id": "240",
@@ -2439,7 +2465,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.patchNonNull"
     },
     {
      "$id": "246",
@@ -2511,7 +2538,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "Type.Property.Nullable.CollectionsString.patchNull"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/property/optionality/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/property/optionality/tspCodeModel.json
@@ -708,7 +708,8 @@
      "Path": "/type/property/optional/string/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.getAll"
     },
     {
      "$id": "90",
@@ -767,7 +768,8 @@
      "Path": "/type/property/optional/string/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.getDefault"
     },
     {
      "$id": "95",
@@ -839,7 +841,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.putAll"
     },
     {
      "$id": "101",
@@ -911,7 +914,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.String.putDefault"
     }
    ],
    "Protocol": {
@@ -1012,7 +1016,8 @@
      "Path": "/type/property/optional/bytes/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.getAll"
     },
     {
      "$id": "118",
@@ -1071,7 +1076,8 @@
      "Path": "/type/property/optional/bytes/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.getDefault"
     },
     {
      "$id": "123",
@@ -1143,7 +1149,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.putAll"
     },
     {
      "$id": "129",
@@ -1215,7 +1222,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Bytes.putDefault"
     }
    ],
    "Protocol": {
@@ -1316,7 +1324,8 @@
      "Path": "/type/property/optional/datetime/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.getAll"
     },
     {
      "$id": "146",
@@ -1375,7 +1384,8 @@
      "Path": "/type/property/optional/datetime/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.getDefault"
     },
     {
      "$id": "151",
@@ -1447,7 +1457,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.putAll"
     },
     {
      "$id": "157",
@@ -1519,7 +1530,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Datetime.putDefault"
     }
    ],
    "Protocol": {
@@ -1620,7 +1632,8 @@
      "Path": "/type/property/optional/duration/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.getAll"
     },
     {
      "$id": "174",
@@ -1679,7 +1692,8 @@
      "Path": "/type/property/optional/duration/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.getDefault"
     },
     {
      "$id": "179",
@@ -1751,7 +1765,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.putAll"
     },
     {
      "$id": "185",
@@ -1823,7 +1838,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.Duration.putDefault"
     }
    ],
    "Protocol": {
@@ -1924,7 +1940,8 @@
      "Path": "/type/property/optional/plainDate/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.getAll"
     },
     {
      "$id": "202",
@@ -1983,7 +2000,8 @@
      "Path": "/type/property/optional/plainDate/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.getDefault"
     },
     {
      "$id": "207",
@@ -2055,7 +2073,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.putAll"
     },
     {
      "$id": "213",
@@ -2127,7 +2146,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainDate.putDefault"
     }
    ],
    "Protocol": {
@@ -2228,7 +2248,8 @@
      "Path": "/type/property/optional/plainTime/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.getAll"
     },
     {
      "$id": "230",
@@ -2287,7 +2308,8 @@
      "Path": "/type/property/optional/plainTime/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.getDefault"
     },
     {
      "$id": "235",
@@ -2359,7 +2381,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.putAll"
     },
     {
      "$id": "241",
@@ -2431,7 +2454,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.PlainTime.putDefault"
     }
    ],
    "Protocol": {
@@ -2532,7 +2556,8 @@
      "Path": "/type/property/optional/collections/bytes/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.getAll"
     },
     {
      "$id": "258",
@@ -2591,7 +2616,8 @@
      "Path": "/type/property/optional/collections/bytes/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.getDefault"
     },
     {
      "$id": "263",
@@ -2663,7 +2689,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.putAll"
     },
     {
      "$id": "269",
@@ -2735,7 +2762,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsByte.putDefault"
     }
    ],
    "Protocol": {
@@ -2836,7 +2864,8 @@
      "Path": "/type/property/optional/collections/model/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.getAll"
     },
     {
      "$id": "286",
@@ -2895,7 +2924,8 @@
      "Path": "/type/property/optional/collections/model/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.getDefault"
     },
     {
      "$id": "291",
@@ -2967,7 +2997,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.putAll"
     },
     {
      "$id": "297",
@@ -3039,7 +3070,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.CollectionsModel.putDefault"
     }
    ],
    "Protocol": {
@@ -3140,7 +3172,8 @@
      "Path": "/type/property/optional/string/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.getAll"
     },
     {
      "$id": "314",
@@ -3199,7 +3232,8 @@
      "Path": "/type/property/optional/string/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.getDefault"
     },
     {
      "$id": "319",
@@ -3271,7 +3305,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.putAll"
     },
     {
      "$id": "325",
@@ -3343,7 +3378,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.StringLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -3444,7 +3480,8 @@
      "Path": "/type/property/optional/int/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.getAll"
     },
     {
      "$id": "342",
@@ -3503,7 +3540,8 @@
      "Path": "/type/property/optional/int/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.getDefault"
     },
     {
      "$id": "347",
@@ -3575,7 +3613,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.putAll"
     },
     {
      "$id": "353",
@@ -3647,7 +3686,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.IntLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -3748,7 +3788,8 @@
      "Path": "/type/property/optional/float/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.getAll"
     },
     {
      "$id": "370",
@@ -3807,7 +3848,8 @@
      "Path": "/type/property/optional/float/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.getDefault"
     },
     {
      "$id": "375",
@@ -3879,7 +3921,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.putAll"
     },
     {
      "$id": "381",
@@ -3951,7 +3994,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.FloatLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4052,7 +4096,8 @@
      "Path": "/type/property/optional/boolean/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.getAll"
     },
     {
      "$id": "398",
@@ -4111,7 +4156,8 @@
      "Path": "/type/property/optional/boolean/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.getDefault"
     },
     {
      "$id": "403",
@@ -4183,7 +4229,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.putAll"
     },
     {
      "$id": "409",
@@ -4255,7 +4302,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.BooleanLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4356,7 +4404,8 @@
      "Path": "/type/property/optional/union/string/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.getAll"
     },
     {
      "$id": "426",
@@ -4415,7 +4464,8 @@
      "Path": "/type/property/optional/union/string/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.getDefault"
     },
     {
      "$id": "431",
@@ -4487,7 +4537,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.putAll"
     },
     {
      "$id": "437",
@@ -4559,7 +4610,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionStringLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4660,7 +4712,8 @@
      "Path": "/type/property/optional/union/int/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.getAll"
     },
     {
      "$id": "454",
@@ -4719,7 +4772,8 @@
      "Path": "/type/property/optional/union/int/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.getDefault"
     },
     {
      "$id": "459",
@@ -4791,7 +4845,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.putAll"
     },
     {
      "$id": "465",
@@ -4863,7 +4918,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionIntLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -4964,7 +5020,8 @@
      "Path": "/type/property/optional/union/float/literal/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.getAll"
     },
     {
      "$id": "482",
@@ -5023,7 +5080,8 @@
      "Path": "/type/property/optional/union/float/literal/default",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.getDefault"
     },
     {
      "$id": "487",
@@ -5095,7 +5153,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.putAll"
     },
     {
      "$id": "493",
@@ -5167,7 +5226,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.UnionFloatLiteral.putDefault"
     }
    ],
    "Protocol": {
@@ -5269,7 +5329,8 @@
      "Path": "/type/property/optional/requiredAndOptional/all",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.getAll"
     },
     {
      "$id": "510",
@@ -5328,7 +5389,8 @@
      "Path": "/type/property/optional/requiredAndOptional/requiredOnly",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.getRequiredOnly"
     },
     {
      "$id": "515",
@@ -5400,7 +5462,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.putAll"
     },
     {
      "$id": "521",
@@ -5472,7 +5535,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.Optional.RequiredAndOptional.putRequiredOnly"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/property/value-types/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/property/value-types/tspCodeModel.json
@@ -1102,7 +1102,8 @@
      "Path": "/type/property/value-types/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Boolean.get"
     },
     {
      "$id": "139",
@@ -1175,7 +1176,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Boolean.put"
     }
    ],
    "Protocol": {
@@ -1276,7 +1278,8 @@
      "Path": "/type/property/value-types/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.String.get"
     },
     {
      "$id": "156",
@@ -1349,7 +1352,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.String.put"
     }
    ],
    "Protocol": {
@@ -1450,7 +1454,8 @@
      "Path": "/type/property/value-types/bytes",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Bytes.get"
     },
     {
      "$id": "173",
@@ -1523,7 +1528,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Bytes.put"
     }
    ],
    "Protocol": {
@@ -1624,7 +1630,8 @@
      "Path": "/type/property/value-types/int",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Int.get"
     },
     {
      "$id": "190",
@@ -1697,7 +1704,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Int.put"
     }
    ],
    "Protocol": {
@@ -1798,7 +1806,8 @@
      "Path": "/type/property/value-types/float",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Float.get"
     },
     {
      "$id": "207",
@@ -1871,7 +1880,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Float.put"
     }
    ],
    "Protocol": {
@@ -1972,7 +1982,8 @@
      "Path": "/type/property/value-types/decimal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal.get"
     },
     {
      "$id": "224",
@@ -2045,7 +2056,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal.put"
     }
    ],
    "Protocol": {
@@ -2146,7 +2158,8 @@
      "Path": "/type/property/value-types/decimal128",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal128.get"
     },
     {
      "$id": "241",
@@ -2219,7 +2232,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Decimal128.put"
     }
    ],
    "Protocol": {
@@ -2320,7 +2334,8 @@
      "Path": "/type/property/value-types/datetime",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Datetime.get"
     },
     {
      "$id": "258",
@@ -2393,7 +2408,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Datetime.put"
     }
    ],
    "Protocol": {
@@ -2494,7 +2510,8 @@
      "Path": "/type/property/value-types/duration",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Duration.get"
     },
     {
      "$id": "275",
@@ -2567,7 +2584,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Duration.put"
     }
    ],
    "Protocol": {
@@ -2668,7 +2686,8 @@
      "Path": "/type/property/value-types/enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Enum.get"
     },
     {
      "$id": "292",
@@ -2741,7 +2760,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Enum.put"
     }
    ],
    "Protocol": {
@@ -2842,7 +2862,8 @@
      "Path": "/type/property/value-types/extensible-enum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.ExtensibleEnum.get"
     },
     {
      "$id": "309",
@@ -2915,7 +2936,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.ExtensibleEnum.put"
     }
    ],
    "Protocol": {
@@ -3016,7 +3038,8 @@
      "Path": "/type/property/value-types/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Model.get"
     },
     {
      "$id": "326",
@@ -3089,7 +3112,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Model.put"
     }
    ],
    "Protocol": {
@@ -3190,7 +3214,8 @@
      "Path": "/type/property/value-types/collections/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsString.get"
     },
     {
      "$id": "343",
@@ -3263,7 +3288,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsString.put"
     }
    ],
    "Protocol": {
@@ -3364,7 +3390,8 @@
      "Path": "/type/property/value-types/collections/int",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsInt.get"
     },
     {
      "$id": "360",
@@ -3437,7 +3464,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsInt.put"
     }
    ],
    "Protocol": {
@@ -3538,7 +3566,8 @@
      "Path": "/type/property/value-types/collections/model",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsModel.get"
     },
     {
      "$id": "377",
@@ -3611,7 +3640,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.CollectionsModel.put"
     }
    ],
    "Protocol": {
@@ -3712,7 +3742,8 @@
      "Path": "/type/property/value-types/dictionary/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.DictionaryString.get"
     },
     {
      "$id": "394",
@@ -3785,7 +3816,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.DictionaryString.put"
     }
    ],
    "Protocol": {
@@ -3886,7 +3918,8 @@
      "Path": "/type/property/value-types/never",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Never.get"
     },
     {
      "$id": "411",
@@ -3959,7 +3992,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.Never.put"
     }
    ],
    "Protocol": {
@@ -4060,7 +4094,8 @@
      "Path": "/type/property/value-types/unknown/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownString.get"
     },
     {
      "$id": "428",
@@ -4133,7 +4168,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownString.put"
     }
    ],
    "Protocol": {
@@ -4234,7 +4270,8 @@
      "Path": "/type/property/value-types/unknown/int",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownInt.get"
     },
     {
      "$id": "445",
@@ -4307,7 +4344,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownInt.put"
     }
    ],
    "Protocol": {
@@ -4408,7 +4446,8 @@
      "Path": "/type/property/value-types/unknown/dict",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownDict.get"
     },
     {
      "$id": "462",
@@ -4481,7 +4520,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownDict.put"
     }
    ],
    "Protocol": {
@@ -4582,7 +4622,8 @@
      "Path": "/type/property/value-types/unknown/array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownArray.get"
     },
     {
      "$id": "479",
@@ -4655,7 +4696,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnknownArray.put"
     }
    ],
    "Protocol": {
@@ -4756,7 +4798,8 @@
      "Path": "/type/property/value-types/string/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.StringLiteral.get"
     },
     {
      "$id": "496",
@@ -4829,7 +4872,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.StringLiteral.put"
     }
    ],
    "Protocol": {
@@ -4930,7 +4974,8 @@
      "Path": "/type/property/value-types/int/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.IntLiteral.get"
     },
     {
      "$id": "513",
@@ -5003,7 +5048,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.IntLiteral.put"
     }
    ],
    "Protocol": {
@@ -5104,7 +5150,8 @@
      "Path": "/type/property/value-types/float/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.FloatLiteral.get"
     },
     {
      "$id": "530",
@@ -5177,7 +5224,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.FloatLiteral.put"
     }
    ],
    "Protocol": {
@@ -5278,7 +5326,8 @@
      "Path": "/type/property/value-types/boolean/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.BooleanLiteral.get"
     },
     {
      "$id": "547",
@@ -5351,7 +5400,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.BooleanLiteral.put"
     }
    ],
    "Protocol": {
@@ -5452,7 +5502,8 @@
      "Path": "/type/property/value-types/union/string/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionStringLiteral.get"
     },
     {
      "$id": "564",
@@ -5525,7 +5576,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionStringLiteral.put"
     }
    ],
    "Protocol": {
@@ -5626,7 +5678,8 @@
      "Path": "/type/property/value-types/union/int/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionIntLiteral.get"
     },
     {
      "$id": "581",
@@ -5699,7 +5752,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionIntLiteral.put"
     }
    ],
    "Protocol": {
@@ -5800,7 +5854,8 @@
      "Path": "/type/property/value-types/union/float/literal",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionFloatLiteral.get"
     },
     {
      "$id": "598",
@@ -5873,7 +5928,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionFloatLiteral.put"
     }
    ],
    "Protocol": {
@@ -5974,7 +6030,8 @@
      "Path": "/type/property/value-types/union-enum-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionEnumValue.get"
     },
     {
      "$id": "615",
@@ -6047,7 +6104,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Property.ValueTypes.UnionEnumValue.put"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/scalar/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/scalar/tspCodeModel.json
@@ -136,7 +136,8 @@
      "Path": "/type/scalar/string",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.String.get"
     },
     {
      "$id": "19",
@@ -212,7 +213,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.String.put"
     }
    ],
    "Protocol": {
@@ -316,7 +318,8 @@
      "Path": "/type/scalar/boolean",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Boolean.get"
     },
     {
      "$id": "38",
@@ -392,7 +395,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Boolean.put"
     }
    ],
    "Protocol": {
@@ -496,7 +500,8 @@
      "Path": "/type/scalar/unknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Unknown.get"
     },
     {
      "$id": "57",
@@ -572,7 +577,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Unknown.put"
     }
    ],
    "Protocol": {
@@ -676,7 +682,8 @@
      "Path": "/type/scalar/decimal/response_body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalType.responseBody"
     },
     {
      "$id": "76",
@@ -750,7 +757,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalType.requestBody"
     },
     {
      "$id": "83",
@@ -797,7 +805,8 @@
      "Path": "/type/scalar/decimal/request_parameter",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalType.requestParameter"
     }
    ],
    "Protocol": {
@@ -901,7 +910,8 @@
      "Path": "/type/scalar/decimal128/response_body",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Type.responseBody"
     },
     {
      "$id": "99",
@@ -975,7 +985,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Type.requestBody"
     },
     {
      "$id": "106",
@@ -1022,7 +1033,8 @@
      "Path": "/type/scalar/decimal128/request_parameter",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Type.requestParameter"
     }
    ],
    "Protocol": {
@@ -1132,7 +1144,8 @@
      "Path": "/type/scalar/decimal/prepare_verify",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalVerify.prepareVerify"
     },
     {
      "$id": "123",
@@ -1206,7 +1219,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.DecimalVerify.verify"
     }
    ],
    "Protocol": {
@@ -1316,7 +1330,8 @@
      "Path": "/type/scalar/decimal128/prepare_verify",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Verify.prepareVerify"
     },
     {
      "$id": "143",
@@ -1390,7 +1405,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Scalar.Decimal128Verify.verify"
     }
    ],
    "Protocol": {

--- a/test/CadlRanchProjectsNonAzure/type/union/tspCodeModel.json
+++ b/test/CadlRanchProjectsNonAzure/type/union/tspCodeModel.json
@@ -1380,7 +1380,8 @@
      "Path": "/type/union/strings-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringsOnly.get"
     },
     {
      "$id": "186",
@@ -1451,7 +1452,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringsOnly.send"
     }
    ],
    "Protocol": {
@@ -1552,7 +1554,8 @@
      "Path": "/type/union/string-extensible",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensible.get"
     },
     {
      "$id": "203",
@@ -1623,7 +1626,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensible.send"
     }
    ],
    "Protocol": {
@@ -1724,7 +1728,8 @@
      "Path": "/type/union/string-extensible-named",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensibleNamed.get"
     },
     {
      "$id": "220",
@@ -1795,7 +1800,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringExtensibleNamed.send"
     }
    ],
    "Protocol": {
@@ -1896,7 +1902,8 @@
      "Path": "/type/union/ints-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.IntsOnly.get"
     },
     {
      "$id": "237",
@@ -1967,7 +1974,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.IntsOnly.send"
     }
    ],
    "Protocol": {
@@ -2068,7 +2076,8 @@
      "Path": "/type/union/floats-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.FloatsOnly.get"
     },
     {
      "$id": "254",
@@ -2139,7 +2148,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.FloatsOnly.send"
     }
    ],
    "Protocol": {
@@ -2240,7 +2250,8 @@
      "Path": "/type/union/models-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.ModelsOnly.get"
     },
     {
      "$id": "271",
@@ -2311,7 +2322,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.ModelsOnly.send"
     }
    ],
    "Protocol": {
@@ -2412,7 +2424,8 @@
      "Path": "/type/union/enums-only",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.EnumsOnly.get"
     },
     {
      "$id": "288",
@@ -2483,7 +2496,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.EnumsOnly.send"
     }
    ],
    "Protocol": {
@@ -2584,7 +2598,8 @@
      "Path": "/type/union/string-and-array",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringAndArray.get"
     },
     {
      "$id": "305",
@@ -2655,7 +2670,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.StringAndArray.send"
     }
    ],
    "Protocol": {
@@ -2756,7 +2772,8 @@
      "Path": "/type/union/mixed-literals",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedLiterals.get"
     },
     {
      "$id": "322",
@@ -2827,7 +2844,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedLiterals.send"
     }
    ],
    "Protocol": {
@@ -2928,7 +2946,8 @@
      "Path": "/type/union/mixed-types",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedTypes.get"
     },
     {
      "$id": "339",
@@ -2999,7 +3018,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Type.Union.MixedTypes.send"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/Authoring-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/Authoring-TypeSpec/tspCodeModel.json
@@ -1454,7 +1454,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.createOrUpdate"
     },
     {
      "$id": "189",
@@ -1560,7 +1561,8 @@
      "Path": "/authoring/analyze-text/projects/{projectName}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.get"
     },
     {
      "$id": "200",
@@ -1696,7 +1698,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.delete"
     },
     {
      "$id": "216",
@@ -1789,7 +1792,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.list"
     },
     {
      "$id": "226",
@@ -1937,7 +1941,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.export"
     },
     {
      "$id": "244",
@@ -2067,7 +2072,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.importx"
     },
     {
      "$id": "260",
@@ -2239,7 +2245,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Projects.train"
     }
    ],
    "Protocol": {
@@ -2395,7 +2402,8 @@
      "Path": "/authoring/analyze-text/projects/{projectName}/deployments/{deploymentName}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Deployments.getDeployment"
     },
     {
      "$id": "297",
@@ -2629,7 +2637,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Deployments.deployProject"
     },
     {
      "$id": "323",
@@ -2783,7 +2792,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Deployments.deleteDeployment"
     },
     {
      "$id": "341",
@@ -2894,7 +2904,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Deployments.list"
     },
     {
      "$id": "353",
@@ -3067,7 +3078,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Deployments.swapDeployments"
     }
    ],
    "Protocol": {
@@ -3241,7 +3253,8 @@
      "Path": "/authoring/analyze-text/projects/{projectName}/deployments/{deploymentName}/jobs/{jobId}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Jobs.getDeploymentStatus"
     },
     {
      "$id": "392",
@@ -3383,7 +3396,8 @@
      "Path": "/authoring/analyze-text/projects/{projectName}/deployments/{deploymentName}/swap/jobs/{jobId}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Jobs.getSwapDeploymentsStatus"
     }
    ],
    "Protocol": {
@@ -3561,7 +3575,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Global.getSupportedLanguages"
     },
     {
      "$id": "427",
@@ -3707,7 +3722,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "AuthoringTypeSpec.Global.listTrainingConfigVersions"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/ClientAndOperationGroup-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/ClientAndOperationGroup-TypeSpec/tspCodeModel.json
@@ -85,7 +85,8 @@
      "Path": "/top",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ClientAndOperationGroup.zero"
     },
     {
      "$id": "11",
@@ -146,7 +147,8 @@
      "Path": "/Alpha",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ClientAndOperationGroup.Alpha.one"
     }
    ],
    "Protocol": {
@@ -238,7 +240,8 @@
      "Path": "/Beta",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ClientAndOperationGroup.Beta.two"
     },
     {
      "$id": "27",
@@ -299,7 +302,8 @@
      "Path": "/SubBeta",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ClientAndOperationGroup.Beta.SubBeta.three"
     }
    ],
    "Protocol": {
@@ -392,7 +396,8 @@
      "Path": "/Gamma",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ClientAndOperationGroup.Gamma.four"
     },
     {
      "$id": "43",
@@ -453,7 +458,8 @@
      "Path": "/Gamma",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ClientAndOperationGroup.Gamma.five"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/ConvenienceUpdate-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/ConvenienceUpdate-TypeSpec/tspCodeModel.json
@@ -109,7 +109,8 @@
      "Path": "/updateConvenience",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.updateConvenience"
     },
     {
      "$id": "13",
@@ -199,7 +200,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceOptionalBeforeRequired"
     },
     {
      "$id": "21",
@@ -258,7 +260,8 @@
      "Path": "/noConvenience",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.noConvenience"
     },
     {
      "$id": "26",
@@ -330,7 +333,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.noConvenienceRequiredBody"
     },
     {
      "$id": "32",
@@ -402,7 +406,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.noConvenienceOptionalBody"
     },
     {
      "$id": "38",
@@ -461,7 +466,8 @@
      "Path": "/protocol",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocol"
     },
     {
      "$id": "43",
@@ -520,7 +526,8 @@
      "Path": "/convenienceWithOptional",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceWithOptional"
     },
     {
      "$id": "48",
@@ -579,7 +586,8 @@
      "Path": "/convenienceWithRequired",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceWithRequired"
     },
     {
      "$id": "53",
@@ -609,7 +617,8 @@
      "Path": "/convenienceShouldNotGenerate",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceShouldNotGenerate"
     },
     {
      "$id": "55",
@@ -639,7 +648,8 @@
      "Path": "/protocolShouldNotGenerateConvenience",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocolShouldNotGenerateConvenience"
     },
     {
      "$id": "57",
@@ -716,7 +726,8 @@
      "Path": "/protocolOptionalQuery",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocolOptionalQuery"
     },
     {
      "$id": "64",
@@ -793,7 +804,8 @@
      "Path": "/protocolRequiredQuery",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocolRequiredQuery"
     },
     {
      "$id": "71",
@@ -865,7 +877,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocolOptionalModel"
     },
     {
      "$id": "77",
@@ -937,7 +950,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocolRequiredModel"
     },
     {
      "$id": "83",
@@ -1014,7 +1028,8 @@
      "Path": "/convenienceOptionalQueryWithOptional",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceOptionalQueryWithOptional"
     },
     {
      "$id": "90",
@@ -1091,7 +1106,8 @@
      "Path": "/convenienceRequiredQueryWithOptional",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceRequiredQueryWithOptional"
     },
     {
      "$id": "97",
@@ -1168,7 +1184,8 @@
      "Path": "/convenienceOptionalQueryWithRequired",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceOptionalQueryWithRequired"
     },
     {
      "$id": "104",
@@ -1245,7 +1262,8 @@
      "Path": "/convenienceRequiredQueryWithRequired",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceRequiredQueryWithRequired"
     },
     {
      "$id": "111",
@@ -1317,7 +1335,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceOptionalModelWithOptional"
     },
     {
      "$id": "117",
@@ -1389,7 +1408,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceRequiredModelWithOptional"
     },
     {
      "$id": "123",
@@ -1461,7 +1481,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.convenienceOptionalModelWithRequired"
     },
     {
      "$id": "129",
@@ -1551,7 +1572,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ConvenienceInCadl.protocolOptionalBeforeRequired"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/Customizations-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/Customizations-TypeSpec/tspCodeModel.json
@@ -1018,7 +1018,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizationsInTsp.roundTrip"
     },
     {
      "$id": "137",
@@ -1119,7 +1120,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizationsInTsp.foo"
     },
     {
      "$id": "146",
@@ -1220,7 +1222,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizationsInTsp.bar"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/FirstTest-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/FirstTest-TypeSpec/tspCodeModel.json
@@ -2220,7 +2220,8 @@
      "Path": "/top/{action}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.topAction"
     },
     {
      "$id": "301",
@@ -2279,7 +2280,8 @@
      "Path": "/top2",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.topAction2"
     },
     {
      "$id": "306",
@@ -2380,7 +2382,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.patchAction"
     },
     {
      "$id": "315",
@@ -2481,7 +2484,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.anonymousBody"
     },
     {
      "$id": "324",
@@ -2582,7 +2586,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.friendlyModel"
     },
     {
      "$id": "333",
@@ -2636,7 +2641,8 @@
      "Path": "/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.addTimeHeader"
     },
     {
      "$id": "338",
@@ -2732,7 +2738,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.stringFormat"
     },
     {
      "$id": "347",
@@ -2833,7 +2840,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.projectedNameModel"
     },
     {
      "$id": "356",
@@ -2892,7 +2900,8 @@
      "Path": "/retunsAnonymousModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.returnsAnonymousModel"
     },
     {
      "$id": "361",
@@ -2940,7 +2949,8 @@
      "Path": "/headAsBoolean/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.headAsBoolean"
     },
     {
      "$id": "365",
@@ -3015,7 +3025,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.stringBody"
     },
     {
      "$id": "372",
@@ -3090,7 +3101,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.boolBody"
     },
     {
      "$id": "379",
@@ -3172,7 +3184,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.dateTimeBody"
     },
     {
      "$id": "387",
@@ -3234,7 +3247,8 @@
      "Path": "/returnString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.returnString"
     },
     {
      "$id": "393",
@@ -3295,7 +3309,8 @@
      "Path": "/returnUnknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.returnUnknown"
     },
     {
      "$id": "399",
@@ -3367,7 +3382,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.recursiveExtension"
     },
     {
      "$id": "405",
@@ -3439,7 +3455,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.threeLevelRecursive"
     },
     {
      "$id": "411",
@@ -3511,7 +3528,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.recursiveModels"
     },
     {
      "$id": "417",
@@ -3583,7 +3601,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.ContainSelfModels"
     },
     {
      "$id": "423",
@@ -3628,7 +3647,8 @@
      "Path": "/enumParameter/{p1}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.enumParameter"
     },
     {
      "$id": "426",
@@ -3700,7 +3720,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.bodyIsModelWithProjectedEnum"
     },
     {
      "$id": "432",
@@ -3785,7 +3806,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.optionalDictionary"
     },
     {
      "$id": "441",
@@ -3905,7 +3927,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.azureLocationOp"
     }
    ],
    "Protocol": {
@@ -4081,7 +4104,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Hello.Demo.sayHi"
     }
    ],
    "Protocol": {
@@ -4249,7 +4273,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Hello.Demo2.helloAgain"
     },
     {
      "$id": "489",
@@ -4386,7 +4411,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Hello.Demo2.noContentType"
     },
     {
      "$id": "502",
@@ -4445,7 +4471,8 @@
      "Path": "/demoHi",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Hello.Demo2.helloDemoAgain"
     },
     {
      "$id": "507",
@@ -4546,7 +4573,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Hello.Demo2.createLiteral"
     },
     {
      "$id": "516",
@@ -4674,7 +4702,8 @@
      "Path": "/helloLiteral/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Hello.Demo2.helloLiteral"
     }
    ],
    "Protocol": {
@@ -4778,7 +4807,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.EnumTest.createUnknownValue"
     }
    ],
    "Protocol": {
@@ -4911,7 +4941,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.ProtocolAndConvenient.internalProtocol"
     },
     {
      "$id": "553",
@@ -4941,7 +4972,8 @@
      "Path": "/stillConvenient",
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.ProtocolAndConvenient.stillConvenient"
     }
    ],
    "Protocol": {
@@ -5050,7 +5082,8 @@
      "Path": "/entity/doSomething/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Entity.doSomething"
     }
    ],
    "Protocol": {
@@ -5177,7 +5210,8 @@
      "Path": "/glossary/doSomething/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "FirstTestTypeSpec.Glossary.doSomething"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/LatestVersion-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/LatestVersion-TypeSpec/tspCodeModel.json
@@ -684,7 +684,8 @@
       "ResultPath": "result"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Latest.VersioningOp.export"
     },
     {
      "$id": "87",
@@ -821,7 +822,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Latest.VersioningOp.list"
     },
     {
      "$id": "102",
@@ -1037,7 +1039,8 @@
       }
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Latest.VersioningOp.createLongRunning"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/MediaTypes-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/MediaTypes-TypeSpec/tspCodeModel.json
@@ -174,7 +174,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "MultipleMediaTypes.oneBinaryBodyTwoContentTypes"
     },
     {
      "$id": "22",
@@ -241,7 +242,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "MultipleMediaTypes.oneStringBodyThreeContentTypes"
     },
     {
      "$id": "27",
@@ -311,7 +313,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "MultipleMediaTypes.oneModelBodyOneContentType"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/MgmtTypeSpec/PrivateEndpointConnection.tsp
+++ b/test/TestProjects/MgmtTypeSpec/PrivateEndpointConnection.tsp
@@ -1,6 +1,9 @@
+import "@azure-tools/typespec-client-generator-core";
+
 using TypeSpec.Http;
 using TypeSpec.Rest;
 using Azure.ResourceManager;
+using Azure.ClientGenerator.Core;
 
 namespace MgmtTypeSpec;
 
@@ -12,5 +15,6 @@ model PrivateLinkResource is ProxyResource<PrivateLinkResourceProperties> {
 @armResourceOperations(PrivateLinkResource)
 interface PrivateLinks {
   /** list private links on the given resource */
+  @clientName("GetAllPrivateLinkResources")
   listByMongoCluster is ArmResourceListByParent<PrivateLinkResource>;
 }

--- a/test/TestProjects/MgmtTypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
+++ b/test/TestProjects/MgmtTypeSpec/src/Generated/Extensions/MgmtTypeSpecExtensions.cs
@@ -32,7 +32,7 @@ namespace MgmtTypeSpec
         /// </item>
         /// <item>
         /// <term>Operation Id</term>
-        /// <description>PrivateLinkResource_ListByMongoCluster</description>
+        /// <description>PrivateLinkResource_GetAllPrivateLinkResources</description>
         /// </item>
         /// <item>
         /// <term>Default Api Version</term>
@@ -41,18 +41,18 @@ namespace MgmtTypeSpec
         /// </list>
         /// <item>
         /// <term>Mocking</term>
-        /// <description>To mock this method, please mock <see cref="MockableMgmtTypeSpecResourceGroupResource.GetPrivateLinksByMongoCluster(CancellationToken)"/> instead.</description>
+        /// <description>To mock this method, please mock <see cref="MockableMgmtTypeSpecResourceGroupResource.GetAllPrivateLinkResources(CancellationToken)"/> instead.</description>
         /// </item>
         /// </summary>
         /// <param name="resourceGroupResource"> The <see cref="ResourceGroupResource" /> instance the method will execute against. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceGroupResource"/> is null. </exception>
         /// <returns> An async collection of <see cref="MgmtTypeSpecPrivateLinkResourceData"/> that may take multiple service requests to iterate over. </returns>
-        public static AsyncPageable<MgmtTypeSpecPrivateLinkResourceData> GetPrivateLinksByMongoClusterAsync(this ResourceGroupResource resourceGroupResource, CancellationToken cancellationToken = default)
+        public static AsyncPageable<MgmtTypeSpecPrivateLinkResourceData> GetAllPrivateLinkResourcesAsync(this ResourceGroupResource resourceGroupResource, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(resourceGroupResource, nameof(resourceGroupResource));
 
-            return GetMockableMgmtTypeSpecResourceGroupResource(resourceGroupResource).GetPrivateLinksByMongoClusterAsync(cancellationToken);
+            return GetMockableMgmtTypeSpecResourceGroupResource(resourceGroupResource).GetAllPrivateLinkResourcesAsync(cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace MgmtTypeSpec
         /// </item>
         /// <item>
         /// <term>Operation Id</term>
-        /// <description>PrivateLinkResource_ListByMongoCluster</description>
+        /// <description>PrivateLinkResource_GetAllPrivateLinkResources</description>
         /// </item>
         /// <item>
         /// <term>Default Api Version</term>
@@ -73,18 +73,18 @@ namespace MgmtTypeSpec
         /// </list>
         /// <item>
         /// <term>Mocking</term>
-        /// <description>To mock this method, please mock <see cref="MockableMgmtTypeSpecResourceGroupResource.GetPrivateLinksByMongoCluster(CancellationToken)"/> instead.</description>
+        /// <description>To mock this method, please mock <see cref="MockableMgmtTypeSpecResourceGroupResource.GetAllPrivateLinkResources(CancellationToken)"/> instead.</description>
         /// </item>
         /// </summary>
         /// <param name="resourceGroupResource"> The <see cref="ResourceGroupResource" /> instance the method will execute against. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="resourceGroupResource"/> is null. </exception>
         /// <returns> A collection of <see cref="MgmtTypeSpecPrivateLinkResourceData"/> that may take multiple service requests to iterate over. </returns>
-        public static Pageable<MgmtTypeSpecPrivateLinkResourceData> GetPrivateLinksByMongoCluster(this ResourceGroupResource resourceGroupResource, CancellationToken cancellationToken = default)
+        public static Pageable<MgmtTypeSpecPrivateLinkResourceData> GetAllPrivateLinkResources(this ResourceGroupResource resourceGroupResource, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(resourceGroupResource, nameof(resourceGroupResource));
 
-            return GetMockableMgmtTypeSpecResourceGroupResource(resourceGroupResource).GetPrivateLinksByMongoCluster(cancellationToken);
+            return GetMockableMgmtTypeSpecResourceGroupResource(resourceGroupResource).GetAllPrivateLinkResources(cancellationToken);
         }
     }
 }

--- a/test/TestProjects/MgmtTypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecResourceGroupResource.cs
+++ b/test/TestProjects/MgmtTypeSpec/src/Generated/Extensions/MockableMgmtTypeSpecResourceGroupResource.cs
@@ -51,7 +51,7 @@ namespace MgmtTypeSpec.Mocking
         /// </item>
         /// <item>
         /// <term>Operation Id</term>
-        /// <description>PrivateLinkResource_ListByMongoCluster</description>
+        /// <description>PrivateLinkResource_GetAllPrivateLinkResources</description>
         /// </item>
         /// <item>
         /// <term>Default Api Version</term>
@@ -61,11 +61,11 @@ namespace MgmtTypeSpec.Mocking
         /// </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> An async collection of <see cref="MgmtTypeSpecPrivateLinkResourceData"/> that may take multiple service requests to iterate over. </returns>
-        public virtual AsyncPageable<MgmtTypeSpecPrivateLinkResourceData> GetPrivateLinksByMongoClusterAsync(CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<MgmtTypeSpecPrivateLinkResourceData> GetAllPrivateLinkResourcesAsync(CancellationToken cancellationToken = default)
         {
-            HttpMessage FirstPageRequest(int? pageSizeHint) => PrivateLinksRestClient.CreateListByMongoClusterRequest(Id.SubscriptionId, Id.ResourceGroupName);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => PrivateLinksRestClient.CreateListByMongoClusterNextPageRequest(nextLink, Id.SubscriptionId, Id.ResourceGroupName);
-            return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => MgmtTypeSpecPrivateLinkResourceData.DeserializeMgmtTypeSpecPrivateLinkResourceData(e), PrivateLinksClientDiagnostics, Pipeline, "MockableMgmtTypeSpecResourceGroupResource.GetPrivateLinksByMongoCluster", "value", "nextLink", cancellationToken);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => PrivateLinksRestClient.CreateGetAllPrivateLinkResourcesRequest(Id.SubscriptionId, Id.ResourceGroupName);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => PrivateLinksRestClient.CreateGetAllPrivateLinkResourcesNextPageRequest(nextLink, Id.SubscriptionId, Id.ResourceGroupName);
+            return GeneratorPageableHelpers.CreateAsyncPageable(FirstPageRequest, NextPageRequest, e => MgmtTypeSpecPrivateLinkResourceData.DeserializeMgmtTypeSpecPrivateLinkResourceData(e), PrivateLinksClientDiagnostics, Pipeline, "MockableMgmtTypeSpecResourceGroupResource.GetAllPrivateLinkResources", "value", "nextLink", cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace MgmtTypeSpec.Mocking
         /// </item>
         /// <item>
         /// <term>Operation Id</term>
-        /// <description>PrivateLinkResource_ListByMongoCluster</description>
+        /// <description>PrivateLinkResource_GetAllPrivateLinkResources</description>
         /// </item>
         /// <item>
         /// <term>Default Api Version</term>
@@ -87,11 +87,11 @@ namespace MgmtTypeSpec.Mocking
         /// </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns> A collection of <see cref="MgmtTypeSpecPrivateLinkResourceData"/> that may take multiple service requests to iterate over. </returns>
-        public virtual Pageable<MgmtTypeSpecPrivateLinkResourceData> GetPrivateLinksByMongoCluster(CancellationToken cancellationToken = default)
+        public virtual Pageable<MgmtTypeSpecPrivateLinkResourceData> GetAllPrivateLinkResources(CancellationToken cancellationToken = default)
         {
-            HttpMessage FirstPageRequest(int? pageSizeHint) => PrivateLinksRestClient.CreateListByMongoClusterRequest(Id.SubscriptionId, Id.ResourceGroupName);
-            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => PrivateLinksRestClient.CreateListByMongoClusterNextPageRequest(nextLink, Id.SubscriptionId, Id.ResourceGroupName);
-            return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => MgmtTypeSpecPrivateLinkResourceData.DeserializeMgmtTypeSpecPrivateLinkResourceData(e), PrivateLinksClientDiagnostics, Pipeline, "MockableMgmtTypeSpecResourceGroupResource.GetPrivateLinksByMongoCluster", "value", "nextLink", cancellationToken);
+            HttpMessage FirstPageRequest(int? pageSizeHint) => PrivateLinksRestClient.CreateGetAllPrivateLinkResourcesRequest(Id.SubscriptionId, Id.ResourceGroupName);
+            HttpMessage NextPageRequest(int? pageSizeHint, string nextLink) => PrivateLinksRestClient.CreateGetAllPrivateLinkResourcesNextPageRequest(nextLink, Id.SubscriptionId, Id.ResourceGroupName);
+            return GeneratorPageableHelpers.CreatePageable(FirstPageRequest, NextPageRequest, e => MgmtTypeSpecPrivateLinkResourceData.DeserializeMgmtTypeSpecPrivateLinkResourceData(e), PrivateLinksClientDiagnostics, Pipeline, "MockableMgmtTypeSpecResourceGroupResource.GetAllPrivateLinkResources", "value", "nextLink", cancellationToken);
         }
     }
 }

--- a/test/TestProjects/MgmtTypeSpec/src/Generated/RestOperations/PrivateLinksRestOperations.cs
+++ b/test/TestProjects/MgmtTypeSpec/src/Generated/RestOperations/PrivateLinksRestOperations.cs
@@ -37,7 +37,7 @@ namespace MgmtTypeSpec
             _userAgent = new TelemetryDetails(GetType().Assembly, applicationId);
         }
 
-        internal RequestUriBuilder CreateListByMongoClusterRequestUri(string subscriptionId, string resourceGroupName)
+        internal RequestUriBuilder CreateGetAllPrivateLinkResourcesRequestUri(string subscriptionId, string resourceGroupName)
         {
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
@@ -50,7 +50,7 @@ namespace MgmtTypeSpec
             return uri;
         }
 
-        internal HttpMessage CreateListByMongoClusterRequest(string subscriptionId, string resourceGroupName)
+        internal HttpMessage CreateGetAllPrivateLinkResourcesRequest(string subscriptionId, string resourceGroupName)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -75,12 +75,12 @@ namespace MgmtTypeSpec
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is an empty string, and was expected to be non-empty. </exception>
-        public async Task<Response<MgmtTypeSpecPrivateLinkResourceListResult>> ListByMongoClusterAsync(string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
+        public async Task<Response<MgmtTypeSpecPrivateLinkResourceListResult>> GetAllPrivateLinkResourcesAsync(string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(subscriptionId, nameof(subscriptionId));
             Argument.AssertNotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
 
-            using var message = CreateListByMongoClusterRequest(subscriptionId, resourceGroupName);
+            using var message = CreateGetAllPrivateLinkResourcesRequest(subscriptionId, resourceGroupName);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -102,12 +102,12 @@ namespace MgmtTypeSpec
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is an empty string, and was expected to be non-empty. </exception>
-        public Response<MgmtTypeSpecPrivateLinkResourceListResult> ListByMongoCluster(string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
+        public Response<MgmtTypeSpecPrivateLinkResourceListResult> GetAllPrivateLinkResources(string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(subscriptionId, nameof(subscriptionId));
             Argument.AssertNotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
 
-            using var message = CreateListByMongoClusterRequest(subscriptionId, resourceGroupName);
+            using var message = CreateGetAllPrivateLinkResourcesRequest(subscriptionId, resourceGroupName);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {
@@ -123,7 +123,7 @@ namespace MgmtTypeSpec
             }
         }
 
-        internal RequestUriBuilder CreateListByMongoClusterNextPageRequestUri(string nextLink, string subscriptionId, string resourceGroupName)
+        internal RequestUriBuilder CreateGetAllPrivateLinkResourcesNextPageRequestUri(string nextLink, string subscriptionId, string resourceGroupName)
         {
             var uri = new RawRequestUriBuilder();
             uri.Reset(_endpoint);
@@ -131,7 +131,7 @@ namespace MgmtTypeSpec
             return uri;
         }
 
-        internal HttpMessage CreateListByMongoClusterNextPageRequest(string nextLink, string subscriptionId, string resourceGroupName)
+        internal HttpMessage CreateGetAllPrivateLinkResourcesNextPageRequest(string nextLink, string subscriptionId, string resourceGroupName)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -152,13 +152,13 @@ namespace MgmtTypeSpec
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="nextLink"/>, <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is an empty string, and was expected to be non-empty. </exception>
-        public async Task<Response<MgmtTypeSpecPrivateLinkResourceListResult>> ListByMongoClusterNextPageAsync(string nextLink, string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
+        public async Task<Response<MgmtTypeSpecPrivateLinkResourceListResult>> GetAllPrivateLinkResourcesNextPageAsync(string nextLink, string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(nextLink, nameof(nextLink));
             Argument.AssertNotNullOrEmpty(subscriptionId, nameof(subscriptionId));
             Argument.AssertNotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
 
-            using var message = CreateListByMongoClusterNextPageRequest(nextLink, subscriptionId, resourceGroupName);
+            using var message = CreateGetAllPrivateLinkResourcesNextPageRequest(nextLink, subscriptionId, resourceGroupName);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             switch (message.Response.Status)
             {
@@ -181,13 +181,13 @@ namespace MgmtTypeSpec
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="nextLink"/>, <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="subscriptionId"/> or <paramref name="resourceGroupName"/> is an empty string, and was expected to be non-empty. </exception>
-        public Response<MgmtTypeSpecPrivateLinkResourceListResult> ListByMongoClusterNextPage(string nextLink, string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
+        public Response<MgmtTypeSpecPrivateLinkResourceListResult> GetAllPrivateLinkResourcesNextPage(string nextLink, string subscriptionId, string resourceGroupName, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(nextLink, nameof(nextLink));
             Argument.AssertNotNullOrEmpty(subscriptionId, nameof(subscriptionId));
             Argument.AssertNotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
 
-            using var message = CreateListByMongoClusterNextPageRequest(nextLink, subscriptionId, resourceGroupName);
+            using var message = CreateGetAllPrivateLinkResourcesNextPageRequest(nextLink, subscriptionId, resourceGroupName);
             _pipeline.Send(message, cancellationToken);
             switch (message.Response.Status)
             {

--- a/test/TestProjects/MgmtTypeSpec/tspCodeModel.json
+++ b/test/TestProjects/MgmtTypeSpec/tspCodeModel.json
@@ -747,7 +747,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "MgmtTypeSpec.PrivateLinks.listByMongoCluster"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/MgmtTypeSpec/tspCodeModel.json
+++ b/test/TestProjects/MgmtTypeSpec/tspCodeModel.json
@@ -587,7 +587,7 @@
    "Operations": [
     {
      "$id": "76",
-     "Name": "listByMongoCluster",
+     "Name": "GetAllPrivateLinkResources",
      "ResourceName": "PrivateLinkResource",
      "Description": "list private links on the given resource",
      "Accessibility": "public",

--- a/test/TestProjects/MixAPIVersion-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/MixAPIVersion-TypeSpec/tspCodeModel.json
@@ -371,7 +371,8 @@
      "Path": "/pets/Pet/{name}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "MixApiVersion.Pets.delete"
     },
     {
      "$id": "48",
@@ -464,7 +465,8 @@
      "Path": "/pets/{petId}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "MixApiVersion.Pets.read"
     },
     {
      "$id": "56",
@@ -587,7 +589,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "MixApiVersion.Pets.create"
     }
    ],
    "Protocol": {
@@ -713,7 +716,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "MixApiVersion.ListPetToysResponse.listPet"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/ModelReaderWriterValidation-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/ModelReaderWriterValidation-TypeSpec/tspCodeModel.json
@@ -1730,7 +1730,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op1"
     },
     {
      "$id": "227",
@@ -1830,7 +1831,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op2"
     },
     {
      "$id": "236",
@@ -1930,7 +1932,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op3"
     },
     {
      "$id": "245",
@@ -2030,7 +2033,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op4"
     },
     {
      "$id": "254",
@@ -2088,7 +2092,8 @@
      "Path": "/api/ResourceProvider",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op5"
     },
     {
      "$id": "259",
@@ -2188,7 +2193,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op6"
     },
     {
      "$id": "268",
@@ -2288,7 +2294,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op7"
     },
     {
      "$id": "277",
@@ -2388,7 +2395,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelReaderWriterValidationTypeSpec.op8"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/Models-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/Models-TypeSpec/tspCodeModel.json
@@ -3357,7 +3357,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.putBaseModelWithDiscriminatorDefinedOnBase"
     },
     {
      "$id": "455",
@@ -3415,7 +3416,8 @@
      "Path": "/pet",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.getOutputDiscriminatorModel"
     },
     {
      "$id": "460",
@@ -3516,7 +3518,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.inputToRoundTrip"
     },
     {
      "$id": "469",
@@ -3617,7 +3620,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.inputToRoundTripPrimitive"
     },
     {
      "$id": "478",
@@ -3718,7 +3722,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.inputToRoundTripOptional"
     },
     {
      "$id": "487",
@@ -3820,7 +3825,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.inputToRoundTripReadOnly"
     },
     {
      "$id": "496",
@@ -3921,7 +3927,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.roundTripToOutput"
     },
     {
      "$id": "505",
@@ -3993,7 +4000,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.InputRecursive"
     },
     {
      "$id": "511",
@@ -4094,7 +4102,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.roundTripRecursive"
     },
     {
      "$id": "520",
@@ -4153,7 +4162,8 @@
      "Path": "/selfReference",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.selfReference"
     },
     {
      "$id": "525",
@@ -4227,7 +4237,8 @@
      "Path": "/fixedFloatEnum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.fixedFloatEnum"
     },
     {
      "$id": "531",
@@ -4301,7 +4312,8 @@
      "Path": "/extenisbleIntEnum",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.extenisbleIntEnum"
     },
     {
      "$id": "537",
@@ -4402,7 +4414,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.roundTripToOutputWithNoUseBase"
     },
     {
      "$id": "546",
@@ -4460,7 +4473,8 @@
      "Path": "/internalInput",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.getInternalInput"
     },
     {
      "$id": "551",
@@ -4560,7 +4574,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.putInternalInput"
     },
     {
      "$id": "560",
@@ -4648,7 +4663,8 @@
      "Path": "/items:analyzeConversation",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.analyzeConversation"
     },
     {
      "$id": "569",
@@ -4719,7 +4735,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ModelsTypeSpec.genericType"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/NoDocs-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/NoDocs-TypeSpec/tspCodeModel.json
@@ -2056,7 +2056,8 @@
      "Path": "/top",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.topAction"
     },
     {
      "$id": "278",
@@ -2157,7 +2158,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.patchAction"
     },
     {
      "$id": "287",
@@ -2258,7 +2260,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.anonymousBody"
     },
     {
      "$id": "296",
@@ -2359,7 +2362,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.friendlyModel"
     },
     {
      "$id": "305",
@@ -2413,7 +2417,8 @@
      "Path": "/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.addTimeHeader"
     },
     {
      "$id": "310",
@@ -2514,7 +2519,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.projectedNameModel"
     },
     {
      "$id": "319",
@@ -2573,7 +2579,8 @@
      "Path": "/retunsAnonymousModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.returnsAnonymousModel"
     },
     {
      "$id": "324",
@@ -2621,7 +2628,8 @@
      "Path": "/headAsBoolean/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.headAsBoolean"
     },
     {
      "$id": "328",
@@ -2696,7 +2704,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.stringBody"
     },
     {
      "$id": "335",
@@ -2771,7 +2780,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.boolBody"
     },
     {
      "$id": "342",
@@ -2853,7 +2863,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.dateTimeBody"
     },
     {
      "$id": "350",
@@ -2915,7 +2926,8 @@
      "Path": "/returnString",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.returnString"
     },
     {
      "$id": "356",
@@ -2976,7 +2988,8 @@
      "Path": "/returnUnknown",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.returnUnknown"
     },
     {
      "$id": "362",
@@ -3048,7 +3061,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.recursiveExtension"
     },
     {
      "$id": "368",
@@ -3120,7 +3134,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.threeLevelRecursive"
     },
     {
      "$id": "374",
@@ -3192,7 +3207,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.recursiveModels"
     },
     {
      "$id": "380",
@@ -3264,7 +3280,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.ContainSelfModels"
     },
     {
      "$id": "386",
@@ -3309,7 +3326,8 @@
      "Path": "/enumParameter/{p1}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.enumParameter"
     },
     {
      "$id": "389",
@@ -3381,7 +3399,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.bodyIsModelWithProjectedEnum"
     },
     {
      "$id": "395",
@@ -3466,7 +3485,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.optionalDictionary"
     },
     {
      "$id": "404",
@@ -3586,7 +3606,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.azureLocationOp"
     }
    ],
    "Protocol": {
@@ -3762,7 +3783,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Hello.Demo.sayHi"
     }
    ],
    "Protocol": {
@@ -3930,7 +3952,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Hello.Demo2.helloAgain"
     },
     {
      "$id": "452",
@@ -4067,7 +4090,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Hello.Demo2.noContentType"
     },
     {
      "$id": "465",
@@ -4126,7 +4150,8 @@
      "Path": "/demoHi",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Hello.Demo2.helloDemoAgain"
     },
     {
      "$id": "470",
@@ -4227,7 +4252,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Hello.Demo2.createLiteral"
     },
     {
      "$id": "479",
@@ -4355,7 +4381,8 @@
      "Path": "/helloLiteral/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Hello.Demo2.helloLiteral"
     }
    ],
    "Protocol": {
@@ -4459,7 +4486,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.EnumTest.createUnknownValue"
     }
    ],
    "Protocol": {
@@ -4592,7 +4620,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.ProtocolAndConvenient.internalProtocol"
     },
     {
      "$id": "516",
@@ -4622,7 +4651,8 @@
      "Path": "/stillConvenient",
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.ProtocolAndConvenient.stillConvenient"
     }
    ],
    "Protocol": {
@@ -4731,7 +4761,8 @@
      "Path": "/entity/doSomething/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Entity.doSomething"
     }
    ],
    "Protocol": {
@@ -4858,7 +4889,8 @@
      "Path": "/glossary/doSomething/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsTypeSpec.Glossary.doSomething"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/OldestVersion-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/OldestVersion-TypeSpec/tspCodeModel.json
@@ -686,7 +686,8 @@
       "ResultPath": "result"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Oldest.VersioningOp.export"
     },
     {
      "$id": "87",
@@ -822,7 +823,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Oldest.VersioningOp.list"
     },
     {
      "$id": "102",
@@ -986,7 +988,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Oldest.VersioningOp.create"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/Pagination-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/Pagination-TypeSpec/tspCodeModel.json
@@ -793,7 +793,8 @@
       "NextLinkName": "customNextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Pagination.ListPaginationLedgerEntries"
     }
    ],
    "Protocol": {
@@ -1029,7 +1030,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Pagination.AdditionalParameter.ListMetricDimensionValues"
     }
    ],
    "Protocol": {
@@ -1154,7 +1156,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Pagination.UseFoundationsResourceList.list"
     }
    ],
    "Protocol": {
@@ -1280,7 +1283,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Pagination.TwoTypesItem.listTextBlocklists"
     },
     {
      "$id": "155",
@@ -1450,7 +1454,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Pagination.TwoTypesItem.listTextBlocklistItems"
     }
    ],
    "Protocol": {
@@ -1646,7 +1651,8 @@
       "NextLinkName": "odata.nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "Pagination.Pools.listPools"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/Parameters-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/Parameters-TypeSpec/tspCodeModel.json
@@ -224,7 +224,8 @@
      "Path": "/parameterOrders",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ParametersCadl.ParameterOrders.Operation"
     },
     {
      "$id": "28",
@@ -318,7 +319,8 @@
      "Path": "/parameterOrders",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "ParametersCadl.ParameterOrders.Operation2"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/SpecificVersion-TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/SpecificVersion-TypeSpec/tspCodeModel.json
@@ -623,7 +623,8 @@
       "ResultPath": "result"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Specific.VersioningOp.export"
     },
     {
      "$id": "79",
@@ -759,7 +760,8 @@
       "NextLinkName": "nextLink"
      },
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Specific.VersioningOp.list"
     },
     {
      "$id": "94",
@@ -923,7 +925,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "TypeSpec.Versioning.Specific.VersioningOp.create"
     }
    ],
    "Protocol": {

--- a/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/tspCodeModel.json
+++ b/test/TestProjects/sdk/newprojecttypespec/Azure.NewProject.TypeSpec/tspCodeModel.json
@@ -1432,7 +1432,8 @@
      "Path": "/top/{action}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.topAction"
     },
     {
      "$id": "196",
@@ -1491,7 +1492,8 @@
      "Path": "/top2",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.topAction2"
     },
     {
      "$id": "201",
@@ -1592,7 +1594,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.patchAction"
     },
     {
      "$id": "210",
@@ -1693,7 +1696,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.anonymousBody"
     },
     {
      "$id": "219",
@@ -1794,7 +1798,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.friendlyModel"
     },
     {
      "$id": "228",
@@ -1848,7 +1853,8 @@
      "Path": "/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.addTimeHeader"
     }
    ],
    "Protocol": {
@@ -2024,7 +2030,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.Hello.Demo.sayHi"
     }
    ],
    "Protocol": {
@@ -2192,7 +2199,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.Hello.Demo2.helloAgain"
     },
     {
      "$id": "269",
@@ -2329,7 +2337,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.Hello.Demo2.noContentType"
     },
     {
      "$id": "282",
@@ -2430,7 +2439,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.Hello.Demo2.createLiteral"
     },
     {
      "$id": "291",
@@ -2558,7 +2568,8 @@
      "Path": "/helloLiteral/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.Hello.Demo2.helloLiteral"
     }
    ],
    "Protocol": {
@@ -2662,7 +2673,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.EnumTest.getUnknownValue"
     }
    ],
    "Protocol": {
@@ -2795,7 +2807,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.ProtocolAndConvenient.internalProtocol"
     },
     {
      "$id": "328",
@@ -2825,7 +2838,8 @@
      "Path": "/stillConvenient",
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NewProjectTypeSpec.ProtocolAndConvenient.stillConvenient"
     }
    ],
    "Protocol": {

--- a/test/UnbrandedProjects/Customized-TypeSpec/tspCodeModel.json
+++ b/test/UnbrandedProjects/Customized-TypeSpec/tspCodeModel.json
@@ -1175,7 +1175,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.sayHi"
     },
     {
      "$id": "157",
@@ -1311,7 +1312,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.helloAgain"
     },
     {
      "$id": "170",
@@ -1448,7 +1450,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.noContentType"
     },
     {
      "$id": "183",
@@ -1507,7 +1510,8 @@
      "Path": "/demoHi",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.helloDemo2"
     },
     {
      "$id": "188",
@@ -1608,7 +1612,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.createLiteral"
     },
     {
      "$id": "197",
@@ -1736,7 +1741,8 @@
      "Path": "/helloLiteral/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.helloLiteral"
     },
     {
      "$id": "211",
@@ -1820,7 +1826,8 @@
      "Path": "/top/{action}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.topAction"
     },
     {
      "$id": "219",
@@ -1879,7 +1886,8 @@
      "Path": "/top2",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.topAction2"
     },
     {
      "$id": "224",
@@ -1980,7 +1988,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.patchAction"
     },
     {
      "$id": "233",
@@ -2081,7 +2090,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.anonymousBody"
     },
     {
      "$id": "242",
@@ -2182,7 +2192,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.friendlyModel"
     },
     {
      "$id": "251",
@@ -2236,7 +2247,8 @@
      "Path": "/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.addTimeHeader"
     },
     {
      "$id": "256",
@@ -2337,7 +2349,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.projectedNameModel"
     },
     {
      "$id": "265",
@@ -2396,7 +2409,8 @@
      "Path": "/returnsAnonymousModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.returnsAnonymousModel"
     },
     {
      "$id": "270",
@@ -2465,7 +2479,8 @@
      "Path": "/unknown-value",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.getUnknownValue"
     },
     {
      "$id": "276",
@@ -2566,7 +2581,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.internalProtocol"
     },
     {
      "$id": "285",
@@ -2596,7 +2612,8 @@
      "Path": "/stillConvenient",
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.stillConvenient"
     },
     {
      "$id": "287",
@@ -2644,7 +2661,8 @@
      "Path": "/headAsBoolean/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "CustomizedTypeSpec.headAsBoolean"
     }
    ],
    "Protocol": {

--- a/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/tspCodeModel.json
+++ b/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/tspCodeModel.json
@@ -537,7 +537,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoDocsUnbrandedTypeSpec.sayHi"
     }
    ],
    "Protocol": {

--- a/test/UnbrandedProjects/NoTest-TypeSpec/tspCodeModel.json
+++ b/test/UnbrandedProjects/NoTest-TypeSpec/tspCodeModel.json
@@ -563,7 +563,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoTestTypeSpec.sayHi"
     },
     {
      "$id": "74",
@@ -664,7 +665,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "NoTestTypeSpec.sayHello"
     }
    ],
    "Protocol": {

--- a/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/tspCodeModel.json
+++ b/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/tspCodeModel.json
@@ -6127,7 +6127,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Audio.Transcriptions.create"
     }
    ],
    "Protocol": {
@@ -6269,7 +6270,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Audio.Translations.create"
     }
    ],
    "Protocol": {
@@ -6452,7 +6454,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Chat.Completions.create"
     }
    ],
    "Protocol": {
@@ -6636,7 +6639,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTuning.Jobs.create"
     },
     {
      "$id": "930",
@@ -6732,7 +6736,8 @@
      "Path": "/fine_tuning/jobs",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTuning.Jobs.listPaginated"
     },
     {
      "$id": "939",
@@ -6809,7 +6814,8 @@
      "Path": "/fine_tuning/jobs/{fine_tuning_job_id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTuning.Jobs.retrieve"
     },
     {
      "$id": "946",
@@ -6925,7 +6931,8 @@
      "Path": "/fine_tuning/jobs/{fine_tuning_job_id}/events",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTuning.Jobs.listEvents"
     },
     {
      "$id": "957",
@@ -7003,7 +7010,8 @@
      "Path": "/fine_tuning/jobs/{fine_tuning_job_id}/cancel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTuning.Jobs.cancel"
     }
    ],
    "Protocol": {
@@ -7145,7 +7153,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Completions.create"
     }
    ],
    "Protocol": {
@@ -7288,7 +7297,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Edits.create"
     }
    ],
    "Protocol": {
@@ -7431,7 +7441,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Embeddings.create"
     }
    ],
    "Protocol": {
@@ -7532,7 +7543,8 @@
      "Path": "/files",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Files.list"
     },
     {
      "$id": "1020",
@@ -7632,7 +7644,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Files.create"
     },
     {
      "$id": "1029",
@@ -7710,7 +7723,8 @@
      "Path": "/files/files/{file_id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Files.retrieve"
     },
     {
      "$id": "1036",
@@ -7788,7 +7802,8 @@
      "Path": "/files/files/{file_id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Files.delete"
     },
     {
      "$id": "1043",
@@ -7869,7 +7884,8 @@
      "Path": "/files/files/{file_id}/content",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Files.download"
     }
    ],
    "Protocol": {
@@ -8013,7 +8029,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTunes.create"
     },
     {
      "$id": "1066",
@@ -8073,7 +8090,8 @@
      "Path": "/fine-tunes",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTunes.list"
     },
     {
      "$id": "1071",
@@ -8152,7 +8170,8 @@
      "Path": "/fine-tunes/{fine_tune_id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTunes.retrieve"
     },
     {
      "$id": "1078",
@@ -8250,7 +8269,8 @@
      "Path": "/fine-tunes/{fine_tune_id}/events",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTunes.listEvents"
     },
     {
      "$id": "1087",
@@ -8329,7 +8349,8 @@
      "Path": "/fine-tunes/{fine_tune_id}/cancel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.FineTunes.cancel"
     }
    ],
    "Protocol": {
@@ -8430,7 +8451,8 @@
      "Path": "/models",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Models.list"
     },
     {
      "$id": "1105",
@@ -8508,7 +8530,8 @@
      "Path": "/models/{model}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Models.retrieve"
     },
     {
      "$id": "1112",
@@ -8586,7 +8609,8 @@
      "Path": "/models/{model}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Models.delete"
     }
    ],
    "Protocol": {
@@ -8729,7 +8753,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Images.create"
     },
     {
      "$id": "1134",
@@ -8829,7 +8854,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Images.createEdit"
     },
     {
      "$id": "1143",
@@ -8929,7 +8955,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Images.createVariation"
     }
    ],
    "Protocol": {
@@ -9072,7 +9099,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "OpenAI.Moderations.create"
     }
    ],
    "Protocol": {

--- a/test/UnbrandedProjects/Unbranded-TypeSpec/tspCodeModel.json
+++ b/test/UnbrandedProjects/Unbranded-TypeSpec/tspCodeModel.json
@@ -1681,7 +1681,8 @@
      "Path": "/hello",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.sayHi"
     },
     {
      "$id": "231",
@@ -1817,7 +1818,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.helloAgain"
     },
     {
      "$id": "244",
@@ -1954,7 +1956,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.noContentType"
     },
     {
      "$id": "257",
@@ -2013,7 +2016,8 @@
      "Path": "/demoHi",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.helloDemo2"
     },
     {
      "$id": "262",
@@ -2114,7 +2118,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.createLiteral"
     },
     {
      "$id": "271",
@@ -2242,7 +2247,8 @@
      "Path": "/helloLiteral/{p2}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.helloLiteral"
     },
     {
      "$id": "285",
@@ -2326,7 +2332,8 @@
      "Path": "/top/{action}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.topAction"
     },
     {
      "$id": "293",
@@ -2385,7 +2392,8 @@
      "Path": "/top2",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.topAction2"
     },
     {
      "$id": "298",
@@ -2486,7 +2494,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.patchAction"
     },
     {
      "$id": "307",
@@ -2587,7 +2596,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.anonymousBody"
     },
     {
      "$id": "316",
@@ -2688,7 +2698,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.friendlyModel"
     },
     {
      "$id": "325",
@@ -2742,7 +2753,8 @@
      "Path": "/",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.addTimeHeader"
     },
     {
      "$id": "330",
@@ -2843,7 +2855,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.projectedNameModel"
     },
     {
      "$id": "339",
@@ -2902,7 +2915,8 @@
      "Path": "/returnsAnonymousModel",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.returnsAnonymousModel"
     },
     {
      "$id": "344",
@@ -2974,7 +2988,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": false
+     "GenerateConvenienceMethod": false,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.createUnknownValue"
     },
     {
      "$id": "350",
@@ -3075,7 +3090,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.internalProtocol"
     },
     {
      "$id": "359",
@@ -3105,7 +3121,8 @@
      "Path": "/stillConvenient",
      "BufferResponse": true,
      "GenerateProtocolMethod": false,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.stillConvenient"
     },
     {
      "$id": "361",
@@ -3153,7 +3170,8 @@
      "Path": "/headAsBoolean/{id}",
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.headAsBoolean"
     },
     {
      "$id": "365",
@@ -3272,7 +3290,8 @@
      ],
      "BufferResponse": true,
      "GenerateProtocolMethod": true,
-     "GenerateConvenienceMethod": true
+     "GenerateConvenienceMethod": true,
+     "CrossLanguageDefinitionId": "UnbrandedTypeSpec.handleArray"
     }
    ],
    "Protocol": {


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/4929

# Description

This PR adds `CrossLanguageDefinitionId` to `InputOperation`, and adds a `IsChanged` property to `InputOperation`

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first