### PR TITLE
Use --prefer-online to install package after publish

### DIFF
--- a/eng/PublishRelease.ps1
+++ b/eng/PublishRelease.ps1
@@ -42,7 +42,7 @@ try {
     $maxAttempts = 4
     while($true) {
         Write-Host "Installing @autorest/csharp@$autorestVersion and updating package.json"
-        npm install @autorest/csharp@$autorestVersion --save-exact
+        npm install @autorest/csharp@$autorestVersion --save-exact --prefer-online
         $attemptCount += 1
 
         if($LASTEXITCODE -eq 0) {


### PR DESCRIPTION
`npm install` just after publishing a package seems to break because of cached package info not containing the newly published version.

adding `--prefer-online` to the install command should cause it to ignore local cache and check the registry for the version.

see:
https://github.com/npm/cli/issues/4513#issuecomment-1839154499
https://docs.npmjs.com/cli/v10/using-npm/config#prefer-online