### PR TITLE
fix(build): no test case will throw error

### DIFF
--- a/eng/scripts/Test-Packages.ps1
+++ b/eng/scripts/Test-Packages.ps1
@@ -37,7 +37,7 @@ try {
             Invoke-LoggedCommand "npm run prettier" -GroupOutput
             Invoke-LoggedCommand "npm run lint" -GroupOutput
             Invoke-LoggedCommand "npm run build" -GroupOutput
-            Invoke-LoggedCommand "npm run test" -GroupOutput
+            Invoke-LoggedCommand "npm run test -- --passWithNoTests" -GroupOutput
         }
         finally {
             Pop-Location


### PR DESCRIPTION
# Description

`vitest` will throw error by default if no test is found. To suppress this error, we need to add `--passWithNoTests` to the options.

An alternative is to set up a `vitest.config` file and define that option. That's probably overdone since emitter codes are no longer maintained here.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first