### PR TITLE
add main to the trigger after we renamed feature/v3 to main

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -1,11 +1,13 @@
 trigger:
   branches:
     include:
+    - main
     - feature/*
 
 pr:
   branches:
     include:
+    - main
     - feature/*
 
 extends:


### PR DESCRIPTION
# Description

The CIs are not properly starting after we renamed our default branch from `feature/v3` to `main` because we did not update the trigger accordingly (hopefully this is the root cause)

This PR adds main as a trigger to those pipelines.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first