### PR TITLE
Fix for BinaryData as InputExampleObjectValue during sample generation

### DIFF
--- a/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
@@ -107,15 +107,15 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
 
             if (type.FrameworkType == typeof(BinaryData))
             {
-                if (exampleValue is InputExampleObjectValue objectValue)
+                switch (exampleValue)
                 {
-                    return writer.AppendBinaryData(objectValue);
+                    case InputExampleObjectValue objectValue:
+                        return writer.AppendBinaryData(objectValue);
+                    case InputExampleRawValue rawValue:
+                        return writer.AppendBinaryData((InputExampleRawValue)exampleValue);
+                    default:
+                        throw new InvalidOperationException("Unhandled BinaryData example value type");
                 }
-                if (exampleValue is InputExampleRawValue rawValue)
-                {
-                    return writer.AppendBinaryData((InputExampleRawValue)exampleValue);
-                }
-                throw new InvalidOperationException("Unhandled BinaryData example value type");
             }
 
             if (type.FrameworkType == typeof(DataFactoryElement<>))
@@ -221,7 +221,7 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
             return writer.AppendRaw(")");
         }
 
-            private static CodeWriter AppendBinaryData(this CodeWriter writer, InputExampleRawValue exampleValue)
+        private static CodeWriter AppendBinaryData(this CodeWriter writer, InputExampleRawValue exampleValue)
         {
             // determine which method on BinaryData we want to use to serialize this BinaryData
             if (exampleValue.RawValue != null && exampleValue.RawValue is string strValue)

--- a/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
@@ -106,7 +106,17 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
                 return writer.AppendDictionaryValue(type, exampleValue as InputExampleObjectValue, includeCollectionInitialization);
 
             if (type.FrameworkType == typeof(BinaryData))
-                return writer.AppendBinaryData((InputExampleRawValue)exampleValue);
+            {
+                if (exampleValue is InputExampleObjectValue objectValue)
+                {
+                    return writer.AppendBinaryData(objectValue);
+                }
+                if (exampleValue is InputExampleRawValue rawValue)
+                {
+                    return writer.AppendBinaryData((InputExampleRawValue)exampleValue);
+                }
+                throw new InvalidOperationException("Unhandled BinaryData example value type");
+            }
 
             if (type.FrameworkType == typeof(DataFactoryElement<>))
                 return writer.AppendDataFactoryElementValue(type, exampleValue);
@@ -203,7 +213,15 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
             return writer;
         }
 
-        private static CodeWriter AppendBinaryData(this CodeWriter writer, InputExampleRawValue exampleValue)
+        private static CodeWriter AppendBinaryData(this CodeWriter writer, InputExampleObjectValue exampleValue)
+        {
+            var method = "FromObjectAsJson";
+            writer.Append($"{typeof(BinaryData)}.{method}(");
+            writer.AppendAnonymousObject(exampleValue);
+            return writer.AppendRaw(")");
+        }
+
+            private static CodeWriter AppendBinaryData(this CodeWriter writer, InputExampleRawValue exampleValue)
         {
             // determine which method on BinaryData we want to use to serialize this BinaryData
             if (exampleValue.RawValue != null && exampleValue.RawValue is string strValue)
@@ -280,7 +298,7 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
             // check if this is an array
             if (exampleValue is InputExampleListValue exampleListValue)
             {
-                return writer.AppendListValue(typeof(object), exampleListValue);
+                return writer.AppendListValue(typeof(List<object>), exampleListValue);
             }
             // fallback to complex object
             if (exampleValue is InputExampleObjectValue exampleObjectValue)

--- a/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
@@ -112,7 +112,7 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
                     case InputExampleObjectValue objectValue:
                         return writer.AppendBinaryData(objectValue);
                     case InputExampleRawValue rawValue:
-                        return writer.AppendBinaryData((InputExampleRawValue)exampleValue);
+                        return writer.AppendBinaryData(rawValue);
                     default:
                         throw new InvalidOperationException("Unhandled BinaryData example value type");
                 }


### PR DESCRIPTION
Fix for https://teams.microsoft.com/l/message/19:7b87fb348f224b37b6206fa9d89a105b@thread.skype/1726280284865?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1726058282966&teamName=Azure%20SDK&channelName=Language%20-%20DotNet&createdTime=1726280284865

Since we are working on the implementation of Azure plugin, I just proved locally that it fixes the sample generation for azurestackhci, I am not adding a new test case for swagger input in autorest.csharp.