### PR TITLE
Fix sample generation for required string property value missing

### DIFF
--- a/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
+++ b/src/AutoRest.CSharp/MgmtTest/Extensions/CodeWriterExtensions.cs
@@ -379,7 +379,7 @@ namespace AutoRest.CSharp.MgmtTest.Extensions
             _ => writer.Append($"{value:L}"),
         };
 
-        private static bool IsStringLikeType(CSharpType type) => type.IsFrameworkType && (_newInstanceInitializedTypes.Contains(type.FrameworkType) || _parsableInitializedTypes.Contains(type.FrameworkType));
+        private static bool IsStringLikeType(CSharpType type) => type.IsFrameworkType && (_newInstanceInitializedTypes.Contains(type.FrameworkType) || _parsableInitializedTypes.Contains(type.FrameworkType)) || type.Equals(typeof(string));
 
         private static readonly HashSet<Type> _primitiveTypes = new()
         {


### PR DESCRIPTION
Workaround for now to unblock service team, we will refine this properly in https://github.com/Azure/autorest.csharp/issues/5079