### PR TITLE
Fix the `CreateResourceIdentifier` issue

### DIFF
--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -43,7 +43,7 @@
     <PackageReference Update="CommandLineParser" Version="2.9.1" />
     <PackageReference Update="Humanizer.Core" Version="2.13.14" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageReference Update="System.Text.Json" Version="6.0.9" />
+    <PackageReference Update="System.Text.Json" Version="6.0.10" />
     <PackageReference Update="YamlDotNet" Version="11.2.1" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="NuGet.Configuration" Version="6.8.0" />

--- a/src/AutoRest.CSharp/Mgmt/Output/ArmClientExtension.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/ArmClientExtension.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AutoRest.CSharp.Common.Input;
 using AutoRest.CSharp.Common.Output.Expressions.Statements;
 using AutoRest.CSharp.Common.Output.Expressions.ValueExpressions;
 using AutoRest.CSharp.Common.Output.Models;
+using AutoRest.CSharp.Generation.Types;
 using AutoRest.CSharp.Generation.Writers;
-using AutoRest.CSharp.Common.Input;
-using AutoRest.CSharp.Input;
 using AutoRest.CSharp.Mgmt.AutoRest;
 using AutoRest.CSharp.Mgmt.Decorator;
 using AutoRest.CSharp.Mgmt.Models;
@@ -17,7 +17,6 @@ using AutoRest.CSharp.Output.Models;
 using AutoRest.CSharp.Output.Models.Shared;
 using Azure.Core;
 using Azure.ResourceManager;
-using AutoRest.CSharp.Common.Output.Expressions.KnownCodeBlocks;
 
 namespace AutoRest.CSharp.Mgmt.Output
 {
@@ -183,7 +182,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             var lines = new List<FormattableString>();
             string an = resource.Type.Name.StartsWithVowel() ? "an" : "a";
             lines.Add($"Gets an object representing {an} <see cref=\"{resource.Type}\" /> along with the instance operations that can be performed on it but with no data.");
-            lines.Add($"You can use <see cref=\"{resource.Type}.CreateResourceIdentifier\" /> to create {an} <see cref=\"{resource.Type}\" /> <see cref=\"{typeof(ResourceIdentifier)}\" /> from its components.");
+            lines.Add($"You can use <see cref=\"{resource.CreateResourceIdentifierReference}\" /> to create {an} <see cref=\"{resource.Type}\" /> <see cref=\"{typeof(ResourceIdentifier)}\" /> from its components.");
             var description = FormattableStringHelpers.Join(lines, Environment.NewLine);
 
             var parameters = new List<Parameter>

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtMockableArmClient.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtMockableArmClient.cs
@@ -129,7 +129,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             var lines = new List<FormattableString>();
             string an = resource.Type.Name.StartsWithVowel() ? "an" : "a";
             lines.Add($"Gets an object representing {an} {resource.Type:C} along with the instance operations that can be performed on it but with no data.");
-            lines.Add($"You can use <see cref=\"{resource.Type}.CreateResourceIdentifier\" /> to create {an} {resource.Type:C} {typeof(ResourceIdentifier):C} from its components.");
+            lines.Add($"You can use <see cref=\"{resource.CreateResourceIdentifierReference}\" /> to create {an} {resource.Type:C} {typeof(ResourceIdentifier):C} from its components.");
             var description = FormattableStringHelpers.Join(lines, Environment.NewLine);
 
             var parameters = new List<Parameter>

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using AutoRest.CSharp.Common.Input;
 using AutoRest.CSharp.Common.Output.Expressions.KnownValueExpressions;
@@ -601,7 +602,25 @@ namespace AutoRest.CSharp.Mgmt.Output
                 return $"{Type}.{CreateResourceIdentifierMethod.Signature.Name}";
             }
 
-            return $"";
+            var parameters = CreateResourceIdentifierMethod.Signature.Parameters;
+            var formatBuilder = new StringBuilder("{0}.")
+                .Append(CreateResourceIdentifierMethod.Signature.Name)
+                .Append("(");
+            var arguments = new List<object?>(parameters.Count + 1)
+            {
+                Type
+            };
+            for (int i = 0; i < parameters.Count; i++)
+            {
+                formatBuilder.Append($"{{{i + 1}}}"); // +1 because we should start from 1
+                if (i != parameters.Count - 1)
+                {
+                    formatBuilder.Append(",");
+                }
+                arguments.Add(parameters[i].Type);
+            }
+            formatBuilder.Append(")");
+            return FormattableStringFactory.Create(formatBuilder.ToString(), [.. arguments]);
         }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -23,6 +23,7 @@ using AutoRest.CSharp.Output.Models.Shared;
 using AutoRest.CSharp.Output.Models.Types;
 using Azure.Core;
 using Azure.ResourceManager;
+using Microsoft.CodeAnalysis;
 using static AutoRest.CSharp.Common.Output.Models.Snippets;
 using static AutoRest.CSharp.Mgmt.Decorator.ParameterMappingBuilder;
 using static AutoRest.CSharp.Output.Models.MethodSignatureModifiers;
@@ -585,5 +586,22 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         public Parameter ResourceParameter => new(Name: "resource", Description: $"The client parameters to use in these operations.", Type: typeof(ArmResource), DefaultValue: null, ValidationType.None, null);
         public Parameter ResourceDataParameter => new(Name: "data", Description: $"The resource that is the target of operations.", Type: ResourceData.Type, DefaultValue: null, ValidationType.None, null);
+
+        private FormattableString? _createResourceIdentifierReference;
+        public FormattableString CreateResourceIdentifierReference => _createResourceIdentifierReference ??= BuildCreateResourceIdentifierMethodReference();
+
+        private FormattableString BuildCreateResourceIdentifierMethodReference()
+        {
+            // see if there is method with same name in customization code
+            var methods = ExistingType?.GetMembers().OfType<IMethodSymbol>().Where(m => m.MethodKind is MethodKind.Ordinary);
+            var createResourceIdentifierMethod = methods?.FirstOrDefault(m => m.Name == CreateResourceIdentifierMethod.Signature.Name);
+
+            if (createResourceIdentifierMethod == null)
+            {
+                return $"{Type}.{CreateResourceIdentifierMethod.Signature.Name}";
+            }
+
+            return $"";
+        }
     }
 }

--- a/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/Resource.cs
@@ -593,7 +593,7 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         private FormattableString BuildCreateResourceIdentifierMethodReference()
         {
-            // see if there is method with same name in customization code
+            // see if there is method naming "CreateResourceIdentifier" in customization code
             var methods = ExistingType?.GetMembers().OfType<IMethodSymbol>().Where(m => m.MethodKind is MethodKind.Ordinary);
             var createResourceIdentifierMethod = methods?.FirstOrDefault(m => m.Name == CreateResourceIdentifierMethod.Signature.Name);
 
@@ -612,7 +612,7 @@ namespace AutoRest.CSharp.Mgmt.Output
             };
             for (int i = 0; i < parameters.Count; i++)
             {
-                formatBuilder.Append($"{{{i + 1}}}"); // +1 because we should start from 1
+                formatBuilder.Append($"{{{i + 1}}}"); // +1 because the first argument is set to Resource Type
                 if (i != parameters.Count - 1)
                 {
                     formatBuilder.Append(",");


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/5097

# Description

We have reference of the `CreateResourceIdentifier` method in xml doc in some of our generated classes. This could lead to compilation error if there are overloads written in customization code to mitigate breaking changes (the code will not compile because the reference `XXXResource.CreateResourceIdentifier` is ambiguous).

This PR fixes this by including the reference with its full signature when there is a method with the same name in its corresponding customization code.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first