### PR TITLE
bump version of `System.Text.Json` to `6.0.10`

### DIFF
--- a/Packages.Data.props
+++ b/Packages.Data.props
@@ -43,7 +43,7 @@
     <PackageReference Update="CommandLineParser" Version="2.9.1" />
     <PackageReference Update="Humanizer.Core" Version="2.13.14" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageReference Update="System.Text.Json" Version="6.0.9" />
+    <PackageReference Update="System.Text.Json" Version="6.0.10" />
     <PackageReference Update="YamlDotNet" Version="11.2.1" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="NuGet.Configuration" Version="6.8.0" />


### PR DESCRIPTION
# Description

A new version of STJ has been released and the version `6.0.9` we used to use now has a security vulnerability, which makes our main branch cannot properly build on pipelines. This PR updates the version to possible latest.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first