### PR TITLE
feat(mgmt): auto-add rp prefix to `Severity`

### DIFF
--- a/src/AutoRest.CSharp/Common/Input/InputTypes/Transformation/InputCommonSingleWordModelTransformer.cs
+++ b/src/AutoRest.CSharp/Common/Input/InputTypes/Transformation/InputCommonSingleWordModelTransformer.cs
@@ -32,7 +32,8 @@ namespace AutoRest.CSharp.Common.Input
             "PrivateLinkServiceConnectionStateProperty",
             // internal, but could be public in the future, also make the names more consistent
             "PrivateEndpointConnectionListResult",
-            "PrivateLinkResourceListResult"
+            "PrivateLinkResourceListResult",
+            "Severity"
         };
 
         public static void Transform(InputNamespace inputNamespace)


### PR DESCRIPTION
# Description

`Severity` as introduced in common types V5: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/common-types/resource-management/v5/networksecurityperimeter.json#L173
We should auto add rp refix to it.

resolve #5039


# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first