### PR TITLE
Fix cadl-ranch dashboard generator name

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -116,7 +116,7 @@ extends:
                     azureSubscription: "TypeSpec Storage"
                     scriptType: "bash"
                     scriptLocation: "inlineScript"
-                    inlineScript: npx tsp-spector upload-coverage --coverageFile ./artifacts/coverage/tsp-spector-coverage-csharp-azure.json --generatorName csharp --storageAccountName typespec --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version") --generatorMode azure --containerName coverages
+                    inlineScript: npx tsp-spector upload-coverage --coverageFile ./artifacts/coverage/tsp-spector-coverage-csharp-azure.json --generatorName @azure-tools/typespec-csharp --storageAccountName typespec --generatorVersion $(node -p -e "require('./src/TypeSpec.Extension/Emitter.Csharp/package.json').version") --generatorMode azure --containerName coverages
                     workingDirectory: $(Build.SourcesDirectory)/autorest.csharp
               - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
                 - template: new-emitter-package-files.yml


### PR DESCRIPTION
The generator name is incorrect now, which makes dashboard cannot see any reports.