### PR TITLE
Add liftr package to emitter-package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,13 @@
       "resolved": "src/TypeSpec.Extension/Emitter.Csharp",
       "link": true
     },
+    "node_modules/@azure-tools/typespec-liftr-base": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.6.0.tgz",
+      "integrity": "sha512-MQV7ESlCqWrgclTSgs/dllS/jKrMrjs9C0UNExXsYhpjUtpv/BnmToWaWL4hA/5rg5JgxDp1MSAjZ5PBjGo1ig==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@azure-tools/unbranded-tests": {
       "resolved": "test/UnbrandedProjects",
       "link": true
@@ -7783,6 +7790,7 @@
         "@azure-tools/typespec-azure-resource-manager": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-client-generator-core": ">=0.49.0 <1.0.0",
+        "@azure-tools/typespec-liftr-base": ">=0.6.0 <1.0.0",
         "@typespec/compiler": ">=0.63.0 <1.0.0",
         "@typespec/http": ">=0.63.0 <1.0.0",
         "@typespec/openapi": ">=0.63.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -43,7 +43,7 @@
         "@azure-tools/typespec-azure-resource-manager": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-autorest": ">=0.49.0 <1.0.0",
-        "@azure-tools/typespec-liftr-base": "0.6.0",
+        "@azure-tools/typespec-liftr-base": ">=0.6.0 < 1.0.0",
         "@typespec/compiler": ">=0.63.0 <1.0.0",
         "@typespec/http": ">=0.63.0 <1.0.0",
         "@typespec/openapi": ">=0.63.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -57,6 +57,7 @@
         "@azure-tools/typespec-azure-resource-manager": "0.49.0",
         "@azure-tools/typespec-azure-rulesets": "0.49.0",
         "@azure-tools/typespec-autorest": "0.49.0",
+        "@azure-tools/typespec-liftr-base": "0.6.0",
         "@eslint/js": "^9.15.0",
         "@types/mocha": "~10.0.9",
         "@types/node": "~22.7.9",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -43,7 +43,7 @@
         "@azure-tools/typespec-azure-resource-manager": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-autorest": ">=0.49.0 <1.0.0",
-        "@azure-tools/typespec-liftr-base": ">=0.6.0 < 1.0.0",
+        "@azure-tools/typespec-liftr-base": ">=0.6.0 <1.0.0",
         "@typespec/compiler": ">=0.63.0 <1.0.0",
         "@typespec/http": ">=0.63.0 <1.0.0",
         "@typespec/openapi": ">=0.63.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -43,6 +43,7 @@
         "@azure-tools/typespec-azure-resource-manager": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-azure-rulesets": ">=0.49.0 <1.0.0",
         "@azure-tools/typespec-autorest": ">=0.49.0 <1.0.0",
+        "@azure-tools/typespec-liftr-base": "0.6.0",
         "@typespec/compiler": ">=0.63.0 <1.0.0",
         "@typespec/http": ">=0.63.0 <1.0.0",
         "@typespec/openapi": ">=0.63.0 <1.0.0",


### PR DESCRIPTION
@azure-tools/typespec-liftr-base is needed for liftr to compile their TypeSpec. Since it is released as a separate npm package, we need to add it globally in the emitter.

It was wrongly added in azure-sdk-for-net directly before:
https://github.com/Azure/azure-sdk-for-net/pull/47444/files#diff-bac355930627a26bbb83d1f84d110b1e3ec82614739953f538daffc255e31d73

Every time we release a new version of autorest.chsarp, [emitter-package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/emitter-package.json) in azure-sdk-for-net will be replaced.