### PR TITLE
add autorest emitter options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,9 +1949,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "0.1.9-alpha.20250116.6",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-0.1.9-alpha.20250116.6.tgz",
-      "integrity": "sha512-VTFIgu7YdiRY5CHEStmAk4oIMFEfsY9If7F5yuWXfIKN+PElKFZUbURfP5nzjXfEvKoRm1XyUbY/+3IqY/B8xg==",
+      "version": "0.1.9-alpha.20250131.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-0.1.9-alpha.20250131.2.tgz",
+      "integrity": "sha512-YialL75bOO4/kfp0WVVV9jrsMTySRMZycJZcenXmdZwFoeyS3dTnMF4+QYnma6t+89OjKUR/aJeDikingplD/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7758,7 +7758,7 @@
       "license": "MIT",
       "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "0.1.9-alpha.20250116.6"
+        "@typespec/http-client-csharp": "0.1.9-alpha.20250131.2"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.50.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -35,7 +35,7 @@
     ],
     "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "0.1.9-alpha.20250116.6"
+        "@typespec/http-client-csharp": "0.1.9-alpha.20250131.2"
     },
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.50.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/emitter.ts
@@ -67,12 +67,77 @@ export async function $onEmit(context: EmitContext<AzureNetEmitterOptions>) {
                     .replaceAll("\\", "/")
             );
         }
-        configurations["shared-source-folders"] = resolvedSharedFolders ?? [];
+
+        if ("head-as-boolean" in options) {
+            configurations["head-as-boolean"] = options["head-as-boolean"];
+        }
+
+        configurations["deserialize-null-collection-as-null-value"] =
+            options["deserialize-null-collection-as-null-value"];
         configurations["flavor"] =
             options["flavor"] ??
             (configurations.namespace.toLowerCase().startsWith("azure.")
                 ? "azure"
                 : undefined);
+
+        //only emit these if they are not the default values
+        if ("generate-sample-project" in options) {
+            configurations["generate-sample-project"] =
+                options["generate-sample-project"] === true
+                    ? undefined
+                    : options["generate-sample-project"];
+        }
+
+        if ("generate-test-project" in options) {
+            configurations["generate-test-project"] =
+                options["generate-test-project"] === false
+                    ? undefined
+                    : options["generate-test-project"];
+        }
+
+        configurations["use-model-reader-writer"] = true;
+
+        if ("use-model-reader-writer" in options) {
+            configurations["use-model-reader-writer"] =
+                options["use-model-reader-writer"];
+        }
+
+        if ("single-top-level-client" in options) {
+            configurations["single-top-level-client"] =
+                options["single-top-level-client"];
+        }
+
+        if ("keep-non-overloadable-protocol-signature" in options) {
+            configurations["keep-non-overloadable-protocol-signature"] =
+                options["keep-non-overloadable-protocol-signature"];
+        }
+
+        configurations["models-to-treat-empty-string-as-null"] =
+            options["models-to-treat-empty-string-as-null"];
+
+        configurations["intrinsic-types-to-treat-empty-string-as-null"] =
+            options["models-to-treat-empty-string-as-null"]
+                ? options[
+                      "additional-intrinsic-types-to-treat-empty-string-as-null"
+                  ].concat(
+                      [
+                          "Uri",
+                          "Guid",
+                          "ResourceIdentifier",
+                          "DateTimeOffset"
+                      ].filter(
+                          (item) =>
+                              options[
+                                  "additional-intrinsic-types-to-treat-empty-string-as-null"
+                              ].indexOf(item) < 0
+                      )
+                  )
+                : undefined;
+
+        configurations["methods-to-keep-client-default-value"] =
+            options["methods-to-keep-client-default-value"];
+        configurations["shared-source-folders"] = resolvedSharedFolders ?? [];
+
         configurations["enable-internal-raw-data"] =
             options["enable-internal-raw-data"];
         const examplesDir =

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/emitter.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/emitter.ts
@@ -68,10 +68,7 @@ export async function $onEmit(context: EmitContext<AzureNetEmitterOptions>) {
             );
         }
 
-        if ("head-as-boolean" in options) {
-            configurations["head-as-boolean"] = options["head-as-boolean"];
-        }
-
+        configurations["head-as-boolean"] = options["head-as-boolean"];
         configurations["deserialize-null-collection-as-null-value"] =
             options["deserialize-null-collection-as-null-value"];
         configurations["flavor"] =
@@ -81,36 +78,24 @@ export async function $onEmit(context: EmitContext<AzureNetEmitterOptions>) {
                 : undefined);
 
         //only emit these if they are not the default values
-        if ("generate-sample-project" in options) {
-            configurations["generate-sample-project"] =
-                options["generate-sample-project"] === true
-                    ? undefined
-                    : options["generate-sample-project"];
-        }
+        configurations["generate-sample-project"] =
+            options["generate-sample-project"] === true
+                ? undefined
+                : options["generate-sample-project"];
 
-        if ("generate-test-project" in options) {
-            configurations["generate-test-project"] =
-                options["generate-test-project"] === false
-                    ? undefined
-                    : options["generate-test-project"];
-        }
+        configurations["generate-test-project"] =
+            options["generate-test-project"] === false
+                ? undefined
+                : options["generate-test-project"];
 
-        configurations["use-model-reader-writer"] = true;
+        configurations["use-model-reader-writer"] =
+            options["use-model-reader-writer"];
 
-        if ("use-model-reader-writer" in options) {
-            configurations["use-model-reader-writer"] =
-                options["use-model-reader-writer"];
-        }
+        configurations["single-top-level-client"] =
+            options["single-top-level-client"];
 
-        if ("single-top-level-client" in options) {
-            configurations["single-top-level-client"] =
-                options["single-top-level-client"];
-        }
-
-        if ("keep-non-overloadable-protocol-signature" in options) {
-            configurations["keep-non-overloadable-protocol-signature"] =
-                options["keep-non-overloadable-protocol-signature"];
-        }
+        configurations["keep-non-overloadable-protocol-signature"] =
+            options["keep-non-overloadable-protocol-signature"];
 
         configurations["models-to-treat-empty-string-as-null"] =
             options["models-to-treat-empty-string-as-null"];

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
@@ -93,7 +93,12 @@ const defaultAzureEmitterOptions = {
     "deserialize-null-collection-as-null-value": undefined,
     flavor: undefined,
     "generate-test-project": false,
-    "existing-project-folder": undefined
+    "existing-project-folder": undefined,
+    "head-as-boolean": undefined,
+    "generate-sample-project": true,
+    "use-model-reader-writer": true,
+    "single-top-level-client": undefined,
+    "keep-non-overloadable-protocol-signature": undefined
 };
 
 export function resolveAzureEmitterOptions(
@@ -128,6 +133,24 @@ export function resolveAzureEmitterOptions(
         flavor: context.options.flavor ?? defaultAzureEmitterOptions.flavor,
         "existing-project-folder":
             context.options["existing-project-folder"] ??
-            defaultAzureEmitterOptions["existing-project-folder"]
+            defaultAzureEmitterOptions["existing-project-folder"],
+        "head-as-boolean":
+            context.options["head-as-boolean"] ??
+            defaultAzureEmitterOptions["head-as-boolean"],
+        "generate-sample-project":
+            context.options["generate-sample-project"] ??
+            defaultAzureEmitterOptions["generate-sample-project"],
+        "generate-test-project":
+            context.options["generate-test-project"] ??
+            defaultAzureEmitterOptions["generate-test-project"],
+        "use-model-reader-writer":
+            context.options["use-model-reader-writer"] ??
+            defaultAzureEmitterOptions["use-model-reader-writer"],
+        "single-top-level-client":
+            context.options["single-top-level-client"] ??
+            defaultAzureEmitterOptions["single-top-level-client"],
+        "keep-non-overloadable-protocol-signature":
+            context.options["keep-non-overloadable-protocol-signature"] ??
+            defaultAzureEmitterOptions["keep-non-overloadable-protocol-signature"]
     };
 }

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
@@ -151,6 +151,8 @@ export function resolveAzureEmitterOptions(
             defaultAzureEmitterOptions["single-top-level-client"],
         "keep-non-overloadable-protocol-signature":
             context.options["keep-non-overloadable-protocol-signature"] ??
-            defaultAzureEmitterOptions["keep-non-overloadable-protocol-signature"]
+            defaultAzureEmitterOptions[
+                "keep-non-overloadable-protocol-signature"
+            ]
     };
 }

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
@@ -10,6 +10,19 @@ import { dllFilePath } from "@autorest/csharp";
 export interface AzureNetEmitterOptions extends NetEmitterOptions {
     csharpGeneratorPath?: string;
     "enable-internal-raw-data"?: boolean;
+    "single-top-level-client"?: boolean;
+    "existing-project-folder"?: string;
+    "keep-non-overloadable-protocol-signature"?: boolean;
+    "models-to-treat-empty-string-as-null"?: string[];
+    "additional-intrinsic-types-to-treat-empty-string-as-null"?: string[];
+    "methods-to-keep-client-default-value"?: string[];
+    "deserialize-null-collection-as-null-value"?: boolean;
+    "package-dir"?: string;
+    "head-as-boolean"?: boolean;
+    flavor?: string;
+    "generate-sample-project"?: boolean;
+    "generate-test-project"?: boolean;
+    "use-model-reader-writer"?: boolean;
 }
 
 export const AzureNetEmitterOptionsSchema: JSONSchemaType<AzureNetEmitterOptions> =
@@ -26,7 +39,46 @@ export const AzureNetEmitterOptionsSchema: JSONSchemaType<AzureNetEmitterOptions
             "enable-internal-raw-data": {
                 type: "boolean",
                 default: false
-            }
+            },
+            "single-top-level-client": { type: "boolean", nullable: true },
+            "existing-project-folder": { type: "string", nullable: true },
+            "keep-non-overloadable-protocol-signature": {
+                type: "boolean",
+                nullable: true
+            },
+            "models-to-treat-empty-string-as-null": {
+                type: "array",
+                nullable: true,
+                items: { type: "string" }
+            },
+            "additional-intrinsic-types-to-treat-empty-string-as-null": {
+                type: "array",
+                nullable: true,
+                items: { type: "string" }
+            },
+            "methods-to-keep-client-default-value": {
+                type: "array",
+                nullable: true,
+                items: { type: "string" }
+            },
+            "deserialize-null-collection-as-null-value": {
+                type: "boolean",
+                nullable: true
+            },
+            "package-dir": { type: "string", nullable: true },
+            "head-as-boolean": { type: "boolean", nullable: true },
+            flavor: { type: "string", nullable: true },
+            "generate-sample-project": {
+                type: "boolean",
+                nullable: true,
+                default: true
+            },
+            "generate-test-project": {
+                type: "boolean",
+                nullable: true,
+                default: false
+            },
+            "use-model-reader-writer": { type: "boolean", nullable: true }
         },
         required: []
     };
@@ -34,7 +86,14 @@ export const AzureNetEmitterOptionsSchema: JSONSchemaType<AzureNetEmitterOptions
 const defaultAzureEmitterOptions = {
     ...defaultOptions,
     csharpGeneratorPath: dllFilePath,
-    "enable-internal-raw-data": undefined
+    "enable-internal-raw-data": undefined,
+    "models-to-treat-empty-string-as-null": undefined,
+    "additional-intrinsic-types-to-treat-empty-string-as-null": [],
+    "methods-to-keep-client-default-value": undefined,
+    "deserialize-null-collection-as-null-value": undefined,
+    flavor: undefined,
+    "generate-test-project": false,
+    "existing-project-folder": undefined
 };
 
 export function resolveAzureEmitterOptions(
@@ -47,6 +106,28 @@ export function resolveAzureEmitterOptions(
             defaultAzureEmitterOptions.csharpGeneratorPath,
         "enable-internal-raw-data":
             context.options["enable-internal-raw-data"] ??
-            defaultAzureEmitterOptions["enable-internal-raw-data"]
+            defaultAzureEmitterOptions["enable-internal-raw-data"],
+        "models-to-treat-empty-string-as-null":
+            context.options["models-to-treat-empty-string-as-null"] ??
+            defaultAzureEmitterOptions["models-to-treat-empty-string-as-null"],
+        "additional-intrinsic-types-to-treat-empty-string-as-null":
+            context.options[
+                "additional-intrinsic-types-to-treat-empty-string-as-null"
+            ] ??
+            defaultAzureEmitterOptions[
+                "additional-intrinsic-types-to-treat-empty-string-as-null"
+            ],
+        "methods-to-keep-client-default-value":
+            context.options["methods-to-keep-client-default-value"] ??
+            defaultAzureEmitterOptions["methods-to-keep-client-default-value"],
+        "deserialize-null-collection-as-null-value":
+            context.options["deserialize-null-collection-as-null-value"] ??
+            defaultAzureEmitterOptions[
+                "deserialize-null-collection-as-null-value"
+            ],
+        flavor: context.options.flavor ?? defaultAzureEmitterOptions.flavor,
+        "existing-project-folder":
+            context.options["existing-project-folder"] ??
+            defaultAzureEmitterOptions["existing-project-folder"]
     };
 }

--- a/test/TestProjects/Authoring-TypeSpec/Configuration.json
+++ b/test/TestProjects/Authoring-TypeSpec/Configuration.json
@@ -2,9 +2,9 @@
   "output-folder": ".",
   "namespace": "AuthoringTypeSpec",
   "library-name": "AuthoringTypeSpec",
-  "keep-non-overloadable-protocol-signature": true,
   "flavor": "azure",
   "use-model-reader-writer": true,
+  "keep-non-overloadable-protocol-signature": true,
   "shared-source-folders": [
     "../../../../../artifacts/bin/AutoRest.CSharp/Debug/net8.0/Generator.Shared",
     "../../../../../artifacts/bin/AutoRest.CSharp/Debug/net8.0/Azure.Core.Shared"

--- a/test/TestProjects/NoDocs-TypeSpec/Configuration.json
+++ b/test/TestProjects/NoDocs-TypeSpec/Configuration.json
@@ -2,12 +2,12 @@
   "output-folder": ".",
   "namespace": "NoDocsTypeSpec",
   "library-name": "NoDocsTypeSpec",
+  "disable-xml-docs": true,
   "head-as-boolean": true,
   "deserialize-null-collection-as-null-value": true,
   "flavor": "azure",
   "generate-test-project": true,
   "use-model-reader-writer": true,
-  "disable-xml-docs": true,
   "shared-source-folders": [
     "../../../../../artifacts/bin/AutoRest.CSharp/Debug/net8.0/Generator.Shared",
     "../../../../../artifacts/bin/AutoRest.CSharp/Debug/net8.0/Azure.Core.Shared"

--- a/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/Configuration.json
+++ b/test/UnbrandedProjects/NoDocsUnbranded-TypeSpec/Configuration.json
@@ -2,10 +2,10 @@
   "output-folder": ".",
   "namespace": "NoDocsUnbrandedTypeSpec",
   "library-name": "NoDocsUnbrandedTypeSpec",
+  "disable-xml-docs": true,
   "head-as-boolean": true,
   "deserialize-null-collection-as-null-value": true,
   "use-model-reader-writer": true,
-  "disable-xml-docs": true,
   "shared-source-folders": [
     "../../../../../artifacts/bin/AutoRest.CSharp/Debug/net8.0/Generator.Shared",
     "../../../../../artifacts/bin/AutoRest.CSharp/Debug/net8.0/Azure.Core.Shared"


### PR DESCRIPTION
Follow up to https://github.com/microsoft/typespec/pull/5803, which removed these autorest specific options from the unbranded emitter. This PR adds those options into the autorest emitter.