### PR TITLE
Upgrade liftr version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,7 +144,9 @@
       "link": true
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.6.0",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.7.0.tgz",
+      "integrity": "sha512-r4pPk/nOVo6S651McQqLmuSNr7FIRLzt7pj2Pk0+H5EgniKm6X0uwsXk7u2N2GpEmoGnL2yVNxTTMSOtUrkXwQ==",
       "dev": true
     },
     "node_modules/@azure-tools/unbranded-tests": {
@@ -8281,7 +8283,7 @@
         "@azure-tools/typespec-azure-resource-manager": "0.51.0",
         "@azure-tools/typespec-azure-rulesets": "0.51.0",
         "@azure-tools/typespec-client-generator-core": "0.51.1",
-        "@azure-tools/typespec-liftr-base": "0.6.0",
+        "@azure-tools/typespec-liftr-base": "0.7.0",
         "@eslint/js": "^9.15.0",
         "@types/mocha": "~10.0.9",
         "@types/node": "~22.7.9",

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -57,7 +57,7 @@
         "@azure-tools/typespec-azure-resource-manager": "0.51.0",
         "@azure-tools/typespec-azure-rulesets": "0.51.0",
         "@azure-tools/typespec-autorest": "0.51.0",
-        "@azure-tools/typespec-liftr-base": "0.6.0",
+        "@azure-tools/typespec-liftr-base": "0.7.0",
         "@eslint/js": "^9.15.0",
         "@types/mocha": "~10.0.9",
         "@types/node": "~22.7.9",


### PR DESCRIPTION
As titled. To upgrade the liftr version in azuresdk-for-net to unblock customers.