### PR TITLE
Update MTG version & add missing tcgc options to emitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1517,6 +1517,25 @@
         }
       }
     },
+    "node_modules/@typespec/http-client-csharp": {
+      "version": "1.0.0-alpha.20250324.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20250324.1.tgz",
+      "integrity": "sha512-pbM9a+/En0L8RR1qZA/PiFosTUtS3DwTsnfSMJqonKlCudzWlB00EmT/UC6RCwzKCY65Vu2vywxC0PtVMee6tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-serialize-refs": "0.1.0-0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": ">=0.53.0 <1.0.0 || ~0.54.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.53.0 <1.0.0 || ~0.54.0-0",
+        "@typespec/compiler": ">=0.67.0 <1.0.0 || ~0.68.0-0",
+        "@typespec/http": ">=0.67.0 <1.0.0 || ~0.68.0-0",
+        "@typespec/openapi": ">=0.67.0 <1.0.0 || ~0.68.0-0",
+        "@typespec/rest": ">=0.67.0 <1.0.0 || ~0.68.0-0",
+        "@typespec/versioning": ">=0.67.0 <1.0.0 || ~0.68.0-0"
+      }
+    },
     "node_modules/@typespec/http-specs": {
       "version": "0.1.0-alpha.15",
       "resolved": "https://registry.npmjs.org/@typespec/http-specs/-/http-specs-0.1.0-alpha.15.tgz",
@@ -6648,7 +6667,7 @@
       "license": "MIT",
       "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20250320.1"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20250324.1"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.53.0",
@@ -6695,25 +6714,6 @@
         "@typespec/streams": ">=0.67.1 <1.0.0",
         "@typespec/versioning": ">=0.67.1 <1.0.0",
         "@typespec/xml": ">=0.67.1 <1.0.0"
-      }
-    },
-    "src/TypeSpec.Extension/Emitter.Csharp/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20250320.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20250320.1.tgz",
-      "integrity": "sha512-jDx5UEkqbOeKICjJr6XONLSXZYdA6pPvoSf8WetxOuHvJSPDoDs4QSebabqlrg/Hqzbu7ETkzOZX8IQt0+Knpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-serialize-refs": "0.1.0-0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.52.0 <1.0.0 || ~0.53.0-0",
-        "@azure-tools/typespec-client-generator-core": ">=0.52.0 <1.0.0 || ~0.53.0-0",
-        "@typespec/compiler": ">=0.66.0 <1.0.0 || ~0.67.0-0",
-        "@typespec/http": ">=0.66.0 <1.0.0 || ~0.67.0-0",
-        "@typespec/openapi": ">=0.66.0 <1.0.0 || ~0.67.0-0",
-        "@typespec/rest": ">=0.66.0 <1.0.0 || ~0.67.0-0",
-        "@typespec/versioning": ">=0.66.0 <1.0.0 || ~0.67.0-0"
       }
     },
     "test/UnbrandedProjects": {

--- a/src/TypeSpec.Extension/Emitter.Csharp/package.json
+++ b/src/TypeSpec.Extension/Emitter.Csharp/package.json
@@ -35,7 +35,7 @@
     ],
     "dependencies": {
         "@autorest/csharp": "3.0.0-beta.20240625.4",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20250320.1"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20250324.1"
     },
     "peerDependencies": {
         "@azure-tools/typespec-azure-core": ">=0.53.0 <1.0.0",

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/options.ts
@@ -26,6 +26,7 @@ export interface AzureCSharpEmitterOptions extends CSharpEmitterOptions {
     "generate-test-project"?: boolean;
     "use-model-reader-writer"?: boolean;
     "library-name"?: string;
+    "examples-dir"?: string;
 }
 
 export const AzureCSharpEmitterOptionsSchema: JSONSchemaType<AzureCSharpEmitterOptions> =
@@ -87,7 +88,8 @@ export const AzureCSharpEmitterOptionsSchema: JSONSchemaType<AzureCSharpEmitterO
             },
             "use-model-reader-writer": { type: "boolean", nullable: true },
             namespace: { type: "string", nullable: true },
-            "library-name": { type: "string", nullable: true }
+            "library-name": { type: "string", nullable: true },
+            "examples-dir": { type: "string", nullable: true }
         },
         required: []
     };
@@ -108,7 +110,8 @@ const defaultAzureEmitterOptions = {
     "use-model-reader-writer": true,
     "single-top-level-client": undefined,
     "keep-non-overloadable-protocol-signature": undefined,
-    "library-name": undefined
+    "library-name": undefined,
+    "examples-dir": undefined
 };
 
 export function resolveAzureEmitterOptions(
@@ -166,6 +169,9 @@ export function resolveAzureEmitterOptions(
                 "keep-non-overloadable-protocol-signature"
             ],
         namespace: context.options.namespace,
-        "library-name": context.options["package-name"]
+        "library-name": context.options["package-name"],
+        "examples-dir":
+            context.options["examples-dir"] ??
+            defaultAzureEmitterOptions["examples-dir"]
     };
 }


### PR DESCRIPTION
Follow up to https://github.com/microsoft/typespec/pull/6541. This PR pulls in the latest options from MTG, and explicitly adds the tcgc options that are consumed by autorest.