### PR TITLE
fix the array type issue in customized ctors

### DIFF
--- a/src/AutoRest.CSharp/LowLevel/Output/LowLevelClient.cs
+++ b/src/AutoRest.CSharp/LowLevel/Output/LowLevelClient.cs
@@ -341,6 +341,9 @@ namespace AutoRest.CSharp.Output.Models
                 // add custom ctors into the candidates
                 foreach (var existingCtor in ExistingType.Constructors)
                 {
+                    // skip any ctor if any of its parameters have a type of non-INamedTypeSymbol, such as an array or anonymous type (like tuple)
+                    if (existingCtor.Parameters.Any(p => p.Type is not INamedTypeSymbol))
+                        continue;
                     var parameters = existingCtor.Parameters;
                     var modifiers = GetModifiers(existingCtor);
                     bool isPublic = modifiers.HasFlag(Public);

--- a/test/TestProjects/FirstTest-TypeSpec/src/Customization/TypeSpecFirstTestClient.cs
+++ b/test/TestProjects/FirstTest-TypeSpec/src/Customization/TypeSpecFirstTestClient.cs
@@ -29,5 +29,14 @@ namespace FirstTestTypeSpec
             _pipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), new HttpPipelinePolicy[] { }, new ResponseClassifier());
             _endpoint = endpoint;
         }
+
+        /// <summary>
+        /// Constructor for testing purpose. See if we could include a constructor that takes an array as parameter
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <param name="credential"></param>
+        /// <param name="authorizationScopes"></param>
+        public FirstTestTypeSpecClient(Uri endpoint, TokenCredential credential, string[] authorizationScopes)
+        {}
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.csharp/issues/5279

# Description

In `LowLevelClient`, the generator was trying to read all the constructors and find out which one is the most suitable to be used in a sample, but unfortunately, we did not handle array type properly therefore we have the crash in the reported issue.

In this PR, we just skip those ctors that contain a parameter with a type of non-INamedTypeSymbol.
It is fine because even if a ctor with array is chosen, the generator does not have a way to figure out which value to use to call the ctor. The generator itself will never generate `T[]` as a public API, therefore skipping them makes sense.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first