### PR TITLE
Remove throw for baseline contract failure

### DIFF
--- a/src/AutoRest.CSharp/Common/Input/Source/SourceInputModel.cs
+++ b/src/AutoRest.CSharp/Common/Input/Source/SourceInputModel.cs
@@ -159,11 +159,6 @@ namespace AutoRest.CSharp.Input.Source
                 {
                     return await GeneratedCodeWorkspace.CreatePreviousContractFromDll(Path.Combine(nugetFolder, $"{Configuration.Namespace}.xml"), fullPath);
                 }
-                else
-                {
-                    throw new InvalidOperationException($"Can't find Baseline contract assembly ({Configuration.Namespace}@{baselineVersion}) from Nuget Global Package Folder at {fullPath}. " +
-                        $"Please make sure the baseline nuget package has been installed properly");
-                }
             }
             return null;
         }


### PR DESCRIPTION
For some reason, this is failing in most spec PR SDK automation.
We can handle this gracefully, when there is no baseline, we simply skip the breaking change handling.