### PR TITLE
Update publishing to use official releaseJob

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -164,6 +164,8 @@ extends:
           
       - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
         - stage: Release
+          dependsOn:
+          - Build_and_Test
           jobs:
           - deployment: Publish
             environment: none


### PR DESCRIPTION
Fixing the pipeline before publishing starts getting blocked.

`##[error]1ES PT Non-Blocking Error: Deployment jobs are not allowed in non-release workflows. Kindly use 1ES PT release workflows for deployment jobs. This is currently a non-blocking error (does not break pipeline runs), and will be turned as blocking error by the end of Jun 2025. More details: https://aka.ms/1espt/deploymentjob-enforcement`