### PR TITLE
Fix casing for a few file paths

### DIFF
--- a/test/TestProjects/ConvenienceInitial-TypeSpec/tspconfig.yaml
+++ b/test/TestProjects/ConvenienceInitial-TypeSpec/tspconfig.yaml
@@ -4,4 +4,4 @@ emit: [
 options:
   "@azure-tools/typespec-csharp":
     flavor: "azure"
-    existing-project-folder: ../ConvenienceInitial-Typespec/Generated
+    existing-project-folder: ../ConvenienceInitial-TypeSpec/Generated

--- a/test/TestProjects/ConvenienceUpdate-TypeSpec/main.tsp
+++ b/test/TestProjects/ConvenienceUpdate-TypeSpec/main.tsp
@@ -1,4 +1,4 @@
-import "../ConvenienceInitial-Typespec/main.tsp";
+import "../ConvenienceInitial-TypeSpec/main.tsp";
 
 namespace ConvenienceInCadl;
 

--- a/test/TestProjects/ConvenienceUpdate-TypeSpec/tspconfig.yaml
+++ b/test/TestProjects/ConvenienceUpdate-TypeSpec/tspconfig.yaml
@@ -4,4 +4,4 @@ emit: [
 options:
   "@azure-tools/typespec-csharp":
     flavor: "azure"
-    existing-project-folder: ../../ConvenienceInitial-Typespec/src/Generated
+    existing-project-folder: ../../ConvenienceInitial-TypeSpec/src/Generated


### PR DESCRIPTION
The import in `main.tsp` was causing failures when running eng/Generate.ps1 on linux (found while working on https://github.com/Azure/autorest.csharp/pull/5376). I also updated the .yaml references I found pointing to the same file.