### PR TITLE
fix the bug that flags in our emitters become string

### DIFF
--- a/src/TypeSpec.Extension/Emitter.Csharp/src/index.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/index.ts
@@ -1,4 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-export * from "./emitter.js";
+export { $onEmit } from "./emitter.js";
+export {
+    AzureCSharpEmitterOptions,
+    AzureCSharpEmitterOptionsSchema
+} from "./options.js";
+export { $lib } from "./lib.js";

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { createTypeSpecLibrary, DiagnosticDefinition, DiagnosticMessages, paramMessage } from "@typespec/compiler";
+import {
+    createTypeSpecLibrary,
+    DiagnosticDefinition,
+    DiagnosticMessages,
+    paramMessage
+} from "@typespec/compiler";
 import { AzureCSharpEmitterOptionsSchema } from "./options.js";
 
 export type DiagnosticMessagesMap = {

--- a/src/TypeSpec.Extension/Emitter.Csharp/src/lib.ts
+++ b/src/TypeSpec.Extension/Emitter.Csharp/src/lib.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { createTypeSpecLibrary, DiagnosticDefinition, DiagnosticMessages, paramMessage } from "@typespec/compiler";
+import { AzureCSharpEmitterOptionsSchema } from "./options.js";
+
+export type DiagnosticMessagesMap = {
+    [K in keyof typeof diags]: (typeof diags)[K]["messages"];
+};
+
+const diags: { [code: string]: DiagnosticDefinition<DiagnosticMessages> } = {
+    "no-apiVersion": {
+        severity: "error",
+        messages: {
+            default: paramMessage`No APIVersion Provider for service ${"service"}`
+        }
+    },
+    "no-route": {
+        severity: "error",
+        messages: {
+            default: paramMessage`No Route for service for service ${"service"}`
+        }
+    },
+    "general-warning": {
+        severity: "warning",
+        messages: {
+            default: paramMessage`${"message"}`
+        }
+    },
+    "general-error": {
+        severity: "error",
+        messages: {
+            default: paramMessage`${"message"}`
+        }
+    },
+    "invalid-dotnet-sdk-dependency": {
+        severity: "error",
+        messages: {
+            default: paramMessage`Invalid .NET SDK installed.`,
+            missing: paramMessage`The dotnet command was not found in the PATH. Please install the .NET SDK version ${"dotnetMajorVersion"} or above. Guidance for installing the .NET SDK can be found at ${"downloadUrl"}.`,
+            invalidVersion: paramMessage`The .NET SDK found is version ${"installedVersion"}. Please install the .NET SDK ${"dotnetMajorVersion"} or above and ensure there is no global.json in the file system requesting a lower version. Guidance for installing the .NET SDK can be found at ${"downloadUrl"}.`
+        }
+    },
+    "unsupported-auth": {
+        severity: "warning",
+        messages: {
+            default: paramMessage`${"message"}`,
+            onlyUnsupportedAuthProvided: `No supported authentication methods were provided. No public client constructors will be generated. Please provide your own custom constructor for client instantiation.`
+        }
+    },
+    "client-namespace-conflict": {
+        severity: "warning",
+        messages: {
+            default: paramMessage`${"message"}`
+        }
+    },
+    "unsupported-endpoint-url": {
+        severity: "error",
+        messages: {
+            default: paramMessage`Unsupported server endpoint URL: ${"endpoint"}`
+        }
+    },
+    "unsupported-sdk-type": {
+        severity: "error",
+        messages: {
+            default: paramMessage`Unsupported SDK type: ${"sdkType"}.`
+        }
+    },
+    "unsupported-default-value-type": {
+        severity: "error",
+        messages: {
+            default: paramMessage`Unsupported default value type: ${"valueType"}.`
+        }
+    },
+    "unsupported-cookie-parameter": {
+        severity: "error",
+        messages: {
+            default: paramMessage`Cookie parameter is not supported: ${"parameterName"}, found in operation ${"path"}`
+        }
+    },
+    "unsupported-patch-convenience-method": {
+        severity: "warning",
+        messages: {
+            default: paramMessage`Convenience method is not supported for PATCH method, it will be turned off. Please set the '@convenientAPI' to false for operation ${"methodCrossLanguageDefinitionId"}.`
+        }
+    },
+    "unsupported-service-method": {
+        severity: "warning",
+        messages: {
+            default: paramMessage`Unsupported method kind: ${"methodKind"}.`
+        }
+    },
+    "unsupported-continuation-location": {
+        severity: "error",
+        messages: {
+            default: paramMessage`Unsupported continuation location for operation ${"crossLanguageDefinitionId"}.`
+        }
+    }
+};
+
+/**
+ * The TypeSpec library for the C# HTTP client generator.
+ * @beta
+ */
+export const $lib = createTypeSpecLibrary({
+    name: "@azure-tools/typespec-csharp",
+    diagnostics: diags,
+    emitter: {
+        options: AzureCSharpEmitterOptionsSchema
+    }
+});


### PR DESCRIPTION
# Description

There is a bug in this emitter that the type of the flags in options becomes `string`.
For instance, `save-inputs` should be a boolean, but in runtime, its value is `'false'`.
This change nullifies the checks like:
```
if (!options["save-inputs"])
```
because now the value of `options["save-inputs"]` is a string "false" which is neither empty nor undefined therefore this check passes. But when its type is correct (boolean), we should get a false.

This PR fixes this by adding a `$lib` which exposes the schema of options to the compiler so that the compiler could know the type of these flags are boolean and it could make the correct conversion.

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first