### PR TITLE
fix the issue that `CodeGenType` attribute cannot change namespace of resource/resource collection

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
+++ b/src/AutoRest.CSharp/Mgmt/Generation/MgmtClientBaseWriter.cs
@@ -56,7 +56,7 @@ namespace AutoRest.CSharp.Mgmt.Generation
 
         public virtual void Write()
         {
-            using (_writer.Namespace(This.Namespace))
+            using (_writer.Namespace(This.Declaration.Namespace))
             {
                 WriteClassDeclaration();
                 using (_writer.Scope())

--- a/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
+++ b/src/AutoRest.CSharp/Mgmt/Output/MgmtTypeProvider.cs
@@ -68,9 +68,7 @@ namespace AutoRest.CSharp.Mgmt.Output
 
         public virtual FormattableString BranchIdVariableName => $"Id";
 
-        public string Namespace => DefaultNamespace;
-
-        public virtual string DiagnosticNamespace => Namespace;
+        public virtual string DiagnosticNamespace => Declaration.Namespace;
 
         public abstract CSharpType? BaseType { get; }
 

--- a/test/TestProjects/MgmtCustomizations/src/Customization/PetStoreCollection.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Customization/PetStoreCollection.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using Azure.Core;
+
+namespace MgmtCustomizations.Pets
+{
+    [CodeGenType("PetStoreCollection")]
+    public partial class PetStoreCollection {}
+}

--- a/test/TestProjects/MgmtCustomizations/src/Customization/PetStoreResource.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Customization/PetStoreResource.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using Azure.Core;
+
+namespace MgmtCustomizations.Pets
+{
+    [CodeGenType("PetStoreResource")]
+    public partial class PetStoreResource {}
+}

--- a/test/TestProjects/MgmtCustomizations/src/Generated/Extensions/MgmtCustomizationsExtensions.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/Extensions/MgmtCustomizationsExtensions.cs
@@ -13,6 +13,7 @@ using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using MgmtCustomizations.Mocking;
+using MgmtCustomizations.Pets;
 
 namespace MgmtCustomizations
 {

--- a/test/TestProjects/MgmtCustomizations/src/Generated/Extensions/MockableMgmtCustomizationsArmClient.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/Extensions/MockableMgmtCustomizationsArmClient.cs
@@ -7,6 +7,7 @@
 
 using Azure.Core;
 using Azure.ResourceManager;
+using MgmtCustomizations.Pets;
 
 namespace MgmtCustomizations.Mocking
 {

--- a/test/TestProjects/MgmtCustomizations/src/Generated/Extensions/MockableMgmtCustomizationsResourceGroupResource.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/Extensions/MockableMgmtCustomizationsResourceGroupResource.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.ResourceManager;
+using MgmtCustomizations.Pets;
 
 namespace MgmtCustomizations.Mocking
 {

--- a/test/TestProjects/MgmtCustomizations/src/Generated/LongRunningOperation/PetStoreOperationSource.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/LongRunningOperation/PetStoreOperationSource.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.ResourceManager;
+using MgmtCustomizations.Pets;
 
 namespace MgmtCustomizations
 {

--- a/test/TestProjects/MgmtCustomizations/src/Generated/Models/MgmtCustomizationsContext.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/Models/MgmtCustomizationsContext.cs
@@ -9,6 +9,7 @@ using System.ClientModel.Primitives;
 using Azure;
 using Azure.ResourceManager.Models;
 using MgmtCustomizations.Models;
+using MgmtCustomizations.Pets;
 
 namespace MgmtCustomizations
 {

--- a/test/TestProjects/MgmtCustomizations/src/Generated/PetStoreCollection.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/PetStoreCollection.cs
@@ -18,7 +18,7 @@ using Azure.Core.Pipeline;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 
-namespace MgmtCustomizations
+namespace MgmtCustomizations.Pets
 {
     /// <summary>
     /// A class representing a collection of <see cref="PetStoreResource"/> and their operations.
@@ -40,7 +40,7 @@ namespace MgmtCustomizations
         /// <param name="id"> The identifier of the parent resource that is the target of operations. </param>
         internal PetStoreCollection(ArmClient client, ResourceIdentifier id) : base(client, id)
         {
-            _petStoreClientDiagnostics = new ClientDiagnostics("MgmtCustomizations", PetStoreResource.ResourceType.Namespace, Diagnostics);
+            _petStoreClientDiagnostics = new ClientDiagnostics("MgmtCustomizations.Pets", PetStoreResource.ResourceType.Namespace, Diagnostics);
             TryGetApiVersion(PetStoreResource.ResourceType, out string petStoreApiVersion);
             _petStoreRestClient = new PetStoresRestOperations(Pipeline, Diagnostics.ApplicationId, Endpoint, petStoreApiVersion);
 #if DEBUG

--- a/test/TestProjects/MgmtCustomizations/src/Generated/PetStoreResource.Serialization.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/PetStoreResource.Serialization.cs
@@ -9,7 +9,7 @@ using System;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
-namespace MgmtCustomizations
+namespace MgmtCustomizations.Pets
 {
     public partial class PetStoreResource : IJsonModel<PetStoreData>
     {

--- a/test/TestProjects/MgmtCustomizations/src/Generated/PetStoreResource.cs
+++ b/test/TestProjects/MgmtCustomizations/src/Generated/PetStoreResource.cs
@@ -15,7 +15,7 @@ using Azure.Core.Pipeline;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 
-namespace MgmtCustomizations
+namespace MgmtCustomizations.Pets
 {
     /// <summary>
     /// A Class representing a PetStore along with the instance operations that can be performed on it.
@@ -61,7 +61,7 @@ namespace MgmtCustomizations
         /// <param name="id"> The identifier of the resource that is the target of operations. </param>
         internal PetStoreResource(ArmClient client, ResourceIdentifier id) : base(client, id)
         {
-            _petStoreClientDiagnostics = new ClientDiagnostics("MgmtCustomizations", ResourceType.Namespace, Diagnostics);
+            _petStoreClientDiagnostics = new ClientDiagnostics("MgmtCustomizations.Pets", ResourceType.Namespace, Diagnostics);
             TryGetApiVersion(ResourceType, out string petStoreApiVersion);
             _petStoreRestClient = new PetStoresRestOperations(Pipeline, Diagnostics.ApplicationId, Endpoint, petStoreApiVersion);
 #if DEBUG


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/51738

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first