### PR TITLE
Switch to using GitHubApp

### DIFF
--- a/eng/common/pipelines/templates/steps/login-to-github.yml
+++ b/eng/common/pipelines/templates/steps/login-to-github.yml
@@ -1,0 +1,29 @@
+# Will output a variable named GH_TOKEN_<Owner> for each owner in TokenOwners if there is only one owner it will just output GH_TOKEN
+
+parameters:
+- name: TokenOwners
+  type: object
+  default: 
+    - Azure
+- name: VariableNamePrefix
+  type: string 
+  default: GH_TOKEN
+- name: ExportAsOutputVariable
+  type: boolean 
+  default: false
+- name: ScriptDirectory
+  default: eng/common/scripts
+
+steps:
+- task: AzureCLI@2
+  name: GenerateGitHubToken
+  displayName: "Login to GitHub"
+  inputs:
+    azureSubscription: 'AzureSDKEngKeyVault Secrets'
+    scriptType: pscore
+    scriptLocation: scriptPath
+    scriptPath: ${{ parameters.ScriptDirectory }}/login-to-github.ps1
+    arguments: >
+     -InstallationTokenOwners '${{ join(''',''', parameters.TokenOwners) }}'
+     -VariableNamePrefix '${{ parameters.VariableNamePrefix }}'
+     -ExportAsOutputVariable:$${{ parameters.ExportAsOutputVariable }}

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -95,12 +95,16 @@ extends:
                   command: custom
                   customCommand: run build
                   workingDir: $(Build.SourcesDirectory)/autorest.csharp/src/TypeSpec.Extension/Emitter.Csharp
+              - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+                parameters:
+                  TokenOwners:
+                    - Azure
               - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
                 - pwsh: >
                     ./eng/PublishRelease.ps1
                     -AutorestArtifactDirectory ./artifacts/bin/AutoRest.CSharp/Release/net9.0/
                     -TypeSpecEmitterDirectory ./src/TypeSpec.Extension/Emitter.Csharp
-                    -GitHubToken $(azuresdk-github-pat)
+                    -GitHubToken $(GH_TOKEN)
                     -NpmToken $(azure-sdk-npm-token)
                     -BuildNumber $(Build.BuildNumber)
                     -Sha $(Build.SourceVersion)
@@ -249,6 +253,10 @@ extends:
                     Write-Host "Setting variable PrTitle to '$prTitle'"
                     Write-Host "##vso[task.setvariable variable=PrTitle]$prTitle"
                   displayName: 'Build PR Title'
+                - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+                  parameters:
+                    TokenOwners:
+                      - Azure
                 - task: PowerShell@2
                   displayName: Create pull request
                   inputs:
@@ -260,6 +268,6 @@ extends:
                       -BaseBranch "main"
                       -PROwner "azure-sdk"
                       -PRBranch $(BranchName)
-                      -AuthToken "$(azuresdk-github-pat)"
+                      -AuthToken "$(GH_TOKEN)"
                       -PRTitle "$(PrTitle)"
                       -PRBody "Update AutoRest C# version to $(AutorestCSharpVersion)"

--- a/eng/pipelines/sdk-update.yml
+++ b/eng/pipelines/sdk-update.yml
@@ -214,6 +214,7 @@ extends:
                   Write-Host "Setting variable PrTitle to '$prTitle'"
                   Write-Host "##vso[task.setvariable variable=PrTitle]$prTitle"
                 displayName: 'Build PR Title'
+              - template: /eng/common/pipelines/templates/steps/login-to-github.yml
               - task: PowerShell@2
                 displayName: Create pull request
                 inputs:
@@ -225,7 +226,7 @@ extends:
                     -BaseBranch "main"
                     -PROwner "azure-sdk"
                     -PRBranch "$(BranchName)"
-                    -AuthToken "$(azuresdk-github-pat)"
+                    -AuthToken "$(GH_TOKEN)"
                     -PRTitle "$(PrTitle)"
                     -PRBody "Triggered from $(PRUrl.PRUrl)"
                     -OpenAsDraft $true


### PR DESCRIPTION
This pull request updates the `eng/pipelines/build.yml` pipeline to improve GitHub authentication and token management during build and release steps. The main changes involve switching to a more standardized and secure approach for logging into GitHub and updating token usage in scripts.

**Pipeline authentication improvements:**

* Added the `/eng/common/pipelines/templates/steps/login-to-github.yml` template at key stages to standardize GitHub login, specifying `TokenOwners` as `Azure`. [[1]](diffhunk://#diff-bea2798fbc59869a31fcc226196bc6eb49784b4ab5a8d3793dd17dcd3baa9a04R98-R107) [[2]](diffhunk://#diff-bea2798fbc59869a31fcc226196bc6eb49784b4ab5a8d3793dd17dcd3baa9a04R256-R259)

**Token usage updates:**

* Replaced usage of the `azuresdk-github-pat` variable with the `GH_TOKEN` variable for GitHub authentication in both the `PublishRelease.ps1` and pull request creation scripts to ensure consistency and leverage the new login mechanism. [[1]](diffhunk://#diff-bea2798fbc59869a31fcc226196bc6eb49784b4ab5a8d3793dd17dcd3baa9a04R98-R107) [[2]](diffhunk://#diff-bea2798fbc59869a31fcc226196bc6eb49784b4ab5a8d3793dd17dcd3baa9a04L263-R271)

Part of resolving https://github.com/Azure/azure-sdk-tools/issues/9842